### PR TITLE
Fixed date formatter instead of locale dependant

### DIFF
--- a/swift-paperless/Views/DocumentScannerView.swift
+++ b/swift-paperless/Views/DocumentScannerView.swift
@@ -62,7 +62,11 @@ struct DocumentScannerView: UIViewControllerRepresentable {
                 }
             }
 
-            let date = Date().formatted(date: .numeric, time: .standard)
+            let date = Date().formatted(.verbatim(
+                "\(year: .extended())-\(month: .twoDigits)-\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .oneBased)).\(minute: .twoDigits).\(second: .twoDigits)",
+                timeZone: TimeZone.current,
+                calendar: .current
+            ))
 
             let url = FileManager.default.temporaryDirectory
                 .appending(component: "Scan \(date)")


### PR DESCRIPTION
Fix for #59

At least on my phone the error was caused by my locale using "/" as the date seperator and that is for obvious reasons not a good character to have in a filename.

I have changed the formatter to use a fixed format so it is no longer locale dependant.

this will produce a file name like "Scan 2024-03-19 20.43.00.pdf"