### PR TITLE
feat: add hint for autologin setting when a 403 is received

### DIFF
--- a/swift-paperless/Localization/Login.xcstrings
+++ b/swift-paperless/Localization/Login.xcstrings
@@ -96,6 +96,17 @@
         }
       }
     },
+    "autologinHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In case you have *autologin* using `PAPERLESS_AUTO_LOGIN_USERNAME` enabled, try logging in without credentials."
+          }
+        }
+      }
+    },
     "buttonLabel" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/swift-paperless/Views/Login/LoginError.swift
+++ b/swift-paperless/Views/Login/LoginError.swift
@@ -130,6 +130,10 @@ extension LoginError {
                     .italic()
             }
 
+            if code == 403 {
+                Text(.login(.autologinHint))
+            }
+
         case .badRequest:
             VStack(alignment: .leading) {
                 Text(.login(.errorInvalidResponse(400)))

--- a/swift-paperless/Views/Login/LoginViewModel.swift
+++ b/swift-paperless/Views/Login/LoginViewModel.swift
@@ -141,9 +141,17 @@ class LoginViewModel {
 
     func decodeDetails(_ body: Data) -> String? {
         struct Response: Decodable {
-            var details: String
+            var detail: String
         }
-        return try? JSONDecoder().decode(Response.self, from: body).details
+        if let detail = try? JSONDecoder().decode(Response.self, from: body).detail {
+            return detail
+        }
+
+        if let detail = String(data: body, encoding: .utf8) {
+            return detail
+        }
+
+        return nil
     }
 
     func checkUrl(string value: String) async {
@@ -297,8 +305,7 @@ class LoginViewModel {
                 if statusCode == 400 {
                     throw LoginError.invalidLogin
                 }
-                let body = String(data: data, encoding: .utf8) ?? "[NO BODY]"
-                throw LoginError.invalidResponse(statusCode: statusCode, details: body)
+                throw LoginError.invalidResponse(statusCode: statusCode, details: decodeDetails(data))
             }
 
             struct TokenResponse: Decodable {

--- a/swift-paperless/Views/Login/LoginViewV2.swift
+++ b/swift-paperless/Views/Login/LoginViewV2.swift
@@ -317,7 +317,6 @@ private struct CredentialsStageView: View {
                 onSuccess(stored)
             } catch {
                 Logger.shared.error("Got error validating credentials: \(error)")
-                errorController.push(error: error)
             }
         }
     }


### PR DESCRIPTION
Also: 
- disables errors being pushed to the error controller in the login environment
- fixes details parsing for login errors

See https://github.com/paulgessinger/swift-paperless/issues/157