### PR TITLE
feat: Add github issue creation button

### DIFF
--- a/swift-paperless/AppSettings.swift
+++ b/swift-paperless/AppSettings.swift
@@ -97,6 +97,7 @@ class AppSettings: ObservableObject {
     @PublishedUserDefaultsBacked(.loginScreenV2)
     var loginScreenV2: Bool = true
 
+    // @TODO: Refactor this with the new Common.Version
     struct Version: CustomStringConvertible, Codable, Equatable {
         private let releaseStored: [UInt]
 

--- a/swift-paperless/Localization/Settings.xcstrings
+++ b/swift-paperless/Localization/Settings.xcstrings
@@ -1980,6 +1980,17 @@
         }
       }
     },
+    "reportBug" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report a bug"
+          }
+        }
+      }
+    },
     "resetAppVersionDescription" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
Adds a button that launches the GitHub issue creation screen with the bug report template and prefilled version numbers.