### PR TITLE
feat: Allow taps on webview, while allowing link navigation

### DIFF
--- a/swift-paperless/Localization/Localizable.xcstrings
+++ b/swift-paperless/Localization/Localizable.xcstrings
@@ -6888,6 +6888,17 @@
         }
       }
     },
+    "showDocumentPropertiesLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show document properties"
+          }
+        }
+      }
+    },
     "sortBy" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
@@ -190,12 +190,7 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
     @State private var editDetent: PresentationDetent = .medium
 
     private var defaultEditDetent: PresentationDetent {
-        switch horizontalSizeClass {
-        case .compact:
-            .medium
-        default:
-            .large
-        }
+        .large
     }
 
     private var editDetentOptions: Set<PresentationDetent> {

--- a/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
@@ -393,6 +393,29 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
             .safeAreaInset(edge: .bottom) { documentPropertyBar }
 
             .ignoresSafeArea(edges: [.bottom])
+
+            .overlay(alignment: .bottomLeading) {
+                VStack {
+                    if !showPropertyBar {
+                        Button {
+                            showPropertyBar = true
+                        } label: {
+                            Label(localized: .localizable(.showDocumentPropertiesLabel),
+                                  systemImage: "chevron.up.circle.fill")
+                                .labelStyle(.iconOnly)
+                                .font(.largeTitle)
+                                .fontWeight(.bold)
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.primary, .tertiary)
+                        }
+                        .padding(.horizontal)
+                        .padding(.bottom, 10)
+                        .tint(.primary)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+                }
+                .animation(.spring(duration: 0.2), value: showPropertyBar)
+            }
         }
 
         .task {


### PR DESCRIPTION
This allows:

- Tapping on the document preview or drag down on the bottom bar to hide the bottom bar
- Add a button you can tap to bring it back (aside from tapping the document)
- Allow following links in documents (opens Safari)
- Open the edit modal in full size on dragging up + pressing the edit button.

Closes #144
Closes #140