### PR TITLE
refactor: Loading screen rework

### DIFF
--- a/swift-paperless/Localization/Localizable.xcstrings
+++ b/swift-paperless/Localization/Localizable.xcstrings
@@ -3750,31 +3750,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "It seems like the app is not able to connect to %@. You can try logging out and back in again:"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "It seems like the app is not able to connect to %@. You can try logging out and back in again:"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "It seems like the app is not able to connect to %@. You can try logging out and back in again:"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "It seems like the app is not able to connect to %@. You can try logging out and back in again:"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "It seems like the app is not able to connect to %@. You can try logging out and back in again:"
+            "value" : "It seems like the app is not able to connect to %@. You can try switching servers or logging out and back in again:"
           }
         }
       }

--- a/swift-paperless/Networking/ConnectionManager.swift
+++ b/swift-paperless/Networking/ConnectionManager.swift
@@ -6,6 +6,7 @@
 //
 
 import AuthenticationServices
+import Combine
 import Common
 import CryptoKit
 import DataModel
@@ -185,6 +186,13 @@ class ConnectionManager: ObservableObject {
         }
     }
 
+    enum Event {
+        case connectionChange(animated: Bool)
+    }
+
+    var eventPublisher =
+        PassthroughSubject<Event, Never>()
+
     let previewMode: Bool
 
     init(previewMode: Bool? = nil) {
@@ -221,10 +229,15 @@ class ConnectionManager: ObservableObject {
     }
 
     @UserDefaultsBacked("ActiveConnectionId", storage: .group)
-    var activeConnectionId: UUID? = nil {
+    private(set) var activeConnectionId: UUID? = nil {
         willSet {
             objectWillChange.send()
         }
+    }
+
+    func setActiveConnection(id: UUID, animated: Bool = true) {
+        activeConnectionId = id
+        eventPublisher.send(.connectionChange(animated: animated))
     }
 
     func isServerUnique(_ url: URL) -> Bool {
@@ -338,7 +351,7 @@ class ConnectionManager: ObservableObject {
     func login(_ connection: StoredConnection) {
         Logger.api.info("Performing login for connection with ID \(connection.id, privacy: .private(mask: .hash))")
         connections[connection.id] = connection
-        activeConnectionId = connection.id
+        setActiveConnection(id: connection.id, animated: false)
     }
 
     func setExtraHeaders(_ headers: [HeaderValue]) {
@@ -377,7 +390,7 @@ class ConnectionManager: ObservableObject {
             Logger.api.info("Have \(count)")
             if let newConn = connections.first?.value {
                 Logger.api.info("Setting connection to \(newConn.id)")
-                self.activeConnectionId = newConn.id
+                setActiveConnection(id: newConn.id, animated: true)
             } else {
                 Logger.api.info("Setting active connection to nil")
                 self.activeConnectionId = nil

--- a/swift-paperless/Views/Import/CreateDocumentView.swift
+++ b/swift-paperless/Views/Import/CreateDocumentView.swift
@@ -200,25 +200,10 @@ struct CreateDocumentView: View {
                 Spacer()
 
                 Form {
-                    if share, let stored = connectionManager.storedConnection {
+                    if share, connectionManager.storedConnection != nil {
                         Section(String(localized: .settings(.activeServer))) {
-                            Menu {
-                                ConnectionSelectionMenu(connectionManager: connectionManager)
-                            } label: {
-                                HStack {
-                                    let label = connectionManager.isServerUnique(stored.url) ? stored.shortLabel : stored.label
-                                    Text(label)
-                                        .font(.body)
-                                        .foregroundStyle(.gray)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .multilineTextAlignment(.leading)
-                                    Label(String(localized: .settings(.chooseServerAccessibilityLabel)),
-                                          systemImage: "chevron.up.chevron.down")
-                                        .labelStyle(.iconOnly)
-                                        .foregroundStyle(.gray)
-                                }
-                                .frame(maxWidth: .infinity)
-                            }
+                            ConnectionSelectionMenu(connectionManager: connectionManager,
+                                                    animated: false)
                         }
                     }
 

--- a/swift-paperless/Views/MainLoadingView.swift
+++ b/swift-paperless/Views/MainLoadingView.swift
@@ -1,0 +1,107 @@
+//
+//  MainLoadingView.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 26.12.24.
+//
+
+import DataModel
+import SwiftUI
+
+struct MainLoadingView: View {
+    let url: String?
+    let manager: ConnectionManager
+
+    let progressDelay: Duration
+    let failSafeDelay: Duration
+
+    init(url: String?, manager: ConnectionManager, progressDelay: Duration = .seconds(2), failSafeDelay: Duration = .seconds(15)) {
+        self.url = url
+        self.manager = manager
+        self.progressDelay = progressDelay
+        self.failSafeDelay = failSafeDelay
+    }
+
+    @State private var showProgress = false
+    @State private var showFailSafe = false
+
+    @ViewBuilder
+    private var failSafeView: some View {
+        VStack {
+            Text(.localizable(.loginFailSafe(url ?? "???")))
+                .padding(.horizontal)
+                .padding(.top, 50)
+
+            ConnectionSelectionMenu(connectionManager: manager,
+                                    animated: false)
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 15, style: .continuous)
+                        .stroke(lineWidth: 0.33)
+                )
+                .padding()
+
+            Button {
+                showFailSafe = false
+                manager.logout()
+            } label: {
+                Label(String(localized: .localizable(.logout)), systemImage: "rectangle.portrait.and.arrow.right")
+            }
+            .foregroundColor(Color.red)
+            .bold()
+            .padding(.top)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    var body: some View {
+        VStack {
+            LogoView()
+
+            if showProgress, !showFailSafe {
+                ProgressView()
+                    .controlSize(.large)
+            }
+
+            VStack {
+                if showFailSafe {
+                    ViewThatFits(in: .vertical) {
+                        failSafeView
+
+                        ScrollView(.vertical) {
+                            failSafeView
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                    }
+                }
+            }
+        }
+
+        .animation(.spring, value: showProgress)
+        .animation(.spring, value: showFailSafe)
+
+        .task {
+            try? await Task.sleep(for: progressDelay)
+            showProgress = true
+            try? await Task.sleep(for: failSafeDelay)
+            showFailSafe = true
+        }
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var manager = ConnectionManager()
+
+    MainLoadingView(url: manager.connection?.url.absoluteString,
+                    manager: manager,
+                    progressDelay: .seconds(0.5),
+                    failSafeDelay: .seconds(2))
+
+        .frame(maxHeight: .infinity)
+
+        .overlay(alignment: .bottom) {
+            Button("Add login") {
+                manager.login(StoredConnection(url: URL(string: "https://example.com")!, extraHeaders: [], user: User(id: 1, isSuperUser: false, username: "preview")))
+            }
+        }
+}

--- a/swift-paperless/Views/Settings/ConnectionsView.swift
+++ b/swift-paperless/Views/Settings/ConnectionsView.swift
@@ -9,19 +9,47 @@ import Common
 import os
 import SwiftUI
 
-struct ConnectionSelectionMenu: View {
+private struct ConnectionSelectionViews: View {
     @ObservedObject var connectionManager: ConnectionManager
+    let animated: Bool
 
     var body: some View {
         ForEach(connectionManager.connections.values.sorted(by: { $0.url.absoluteString < $1.url.absoluteString })) { conn in
             Button {
-                connectionManager.activeConnectionId = conn.id
+                connectionManager.setActiveConnection(id: conn.id,
+                                                      animated: animated)
             } label: {
                 // Bit of a hack to have by-character line breaks
                 let label = connectionManager.isServerUnique(conn.url) ? conn.shortLabel : conn.label
                 Text(label.map { String($0) }.joined(separator: "\u{200B}"))
             }
             .disabled(conn.id == connectionManager.activeConnectionId)
+        }
+    }
+}
+
+struct ConnectionSelectionMenu: View {
+    @ObservedObject var connectionManager: ConnectionManager
+    let animated: Bool
+
+    var body: some View {
+        if let stored = connectionManager.storedConnection {
+            Menu {
+                ConnectionSelectionViews(connectionManager: connectionManager, animated: animated)
+            } label: {
+                HStack {
+                    let label = connectionManager.isServerUnique(stored.url) ? stored.shortLabel : stored.label
+                    Text(label)
+                        .font(.body)
+                        .foregroundStyle(.gray)
+                        .multilineTextAlignment(.leading)
+                    Label(String(localized: .settings(.chooseServerAccessibilityLabel)),
+                          systemImage: "chevron.up.chevron.down")
+                        .labelStyle(.iconOnly)
+                        .foregroundStyle(.gray)
+                }
+//            .frame(maxWidth: .infinity)
+            }
         }
     }
 }
@@ -50,7 +78,8 @@ struct ConnectionsView: View {
                 HStack {
                     Text(.settings(.activeServerUrl))
                     Menu {
-                        ConnectionSelectionMenu(connectionManager: connectionManager)
+                        ConnectionSelectionViews(connectionManager: connectionManager,
+                                                 animated: false)
                     } label: {
                         Text(stored.url.absoluteString)
                             .font(.body)
@@ -138,7 +167,7 @@ struct ConnectionQuickChangeMenu: View {
     var body: some View {
         if connectionManager.connections.count > 1 {
             Menu {
-                ConnectionSelectionMenu(connectionManager: connectionManager)
+                ConnectionSelectionViews(connectionManager: connectionManager, animated: true)
             } label: {
                 Text(.settings(.activeServer))
             }


### PR DESCRIPTION
Adjusted the delays and reworked the way the connection manager communicates with the loading view (now explicitly via combine publishers. This now hides most of the loading states when switching servers in the quick menu, and does not show the loading view at all anymore inside the settings change menu.

Closes #184

CHANGELOG: Added the ability to change servers when the currently active server is not responding.