### PR TITLE
feat: Re-introduce search text debounce

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,3 +40,4 @@ in certain cases
 - Improved layout of the document detail screen for larger dynamic text sizes
 - Fix for storage path not being added to newly created documents
 - Fix ASN not being saved when uploading documents with restricted user accounts
+- Reintroduce delay when typing search text


### PR DESCRIPTION
This was removed when I changed the way the search works, but is needed to order searches in time.

See https://github.com/paulgessinger/swift-paperless/issues/202