### PR TITLE
feat: Remove inbox tags on save if configured in backend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,3 +41,4 @@ in certain cases
 - Fix for storage path not being added to newly created documents
 - Fix ASN not being saved when uploading documents with restricted user accounts
 - Reintroduce delay when typing search text
+- If configured, remove inbox tags from documents automatically when saving

--- a/swift-paperless/Document/DocumentStore.swift
+++ b/swift-paperless/Document/DocumentStore.swift
@@ -30,6 +30,7 @@ final class DocumentStore: ObservableObject, Sendable {
     @Published private(set) var tasks: [PaperlessTask] = []
 
     private(set) var permissions: UserPermissions = .empty
+    private(set) var settings = UISettingsSettings()
 
     var activeTasks: [PaperlessTask] {
         tasks.filter(\.isActive)
@@ -238,11 +239,13 @@ final class DocumentStore: ObservableObject, Sendable {
             // Older versions of the backend return an ok response here even if the perms aren't valid
             let uiSettings = try await repository.uiSettings()
             permissions = uiSettings.permissions
+            settings = uiSettings.settings
         } catch {
             // If we don't get permissions here, log a warning and assume full permissions.
             Logger.shared.error("Error getting UI settings: \(error)")
             Logger.shared.error("Assuming full permissions to proceed")
             permissions = UserPermissions.full
+            settings = UISettingsSettings()
         }
 
         let permissions = permissions

--- a/swift-paperless/Document/DocumentStore.swift
+++ b/swift-paperless/Document/DocumentStore.swift
@@ -119,6 +119,7 @@ final class DocumentStore: ObservableObject, Sendable {
         currentUser = nil
         tasks = []
         permissions = .empty
+        settings = UISettingsSettings()
     }
 
     func set(repository: some Repository) {

--- a/swift-paperless/Networking/NullRepository.swift
+++ b/swift-paperless/Networking/NullRepository.swift
@@ -23,6 +23,9 @@ actor NullRepository: Repository {
     func delete(tag _: Tag) async throws { throw NotImplemented() }
 
     func tags() async -> [Tag] { [] }
+    func uiSettings() async throws -> UISettings {
+        UISettings(user: User(id: 0, isSuperUser: false, username: "nobody"), permissions: .empty)
+    }
 
     func correspondent(id _: UInt) async -> Correspondent? { nil }
     func create(correspondent _: ProtoCorrespondent) async throws -> Correspondent { throw NotImplemented() }

--- a/swift-paperless/Networking/Repository.swift
+++ b/swift-paperless/Networking/Repository.swift
@@ -143,6 +143,7 @@ protocol Repository: Sendable, Actor {
     func currentUser() async throws -> User
     func users() async throws -> [User]
     func groups() async throws -> [UserGroup]
+    func uiSettings() async throws -> UISettings
 
     func task(id: UInt) async throws -> PaperlessTask?
     func tasks() async throws -> [PaperlessTask]

--- a/swift-paperless/ViewModel/PreviewRepository.swift
+++ b/swift-paperless/ViewModel/PreviewRepository.swift
@@ -363,4 +363,12 @@ actor PreviewRepository: Repository {
 
     nonisolated
     var delegate: (any URLSessionDelegate)? { nil }
+
+    func uiSettings() async -> UISettings {
+        UISettings(
+            user: User(id: 1, isSuperUser: true, username: "user"),
+            settings: UISettingsSettings(),
+            permissions: UserPermissions.full
+        )
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `DocumentStore` class and related repository classes in the `swift-paperless` project. The changes focus on adding support for user permissions and UI settings, as well as improving the handling of document updates and repository interactions.

### Enhancements to `DocumentStore`:

* Added `permissions` and `settings` properties to the `DocumentStore` class to manage user permissions and UI settings.
* Updated the `updateDocument` method to remove inbox tags from a document if specified in the settings.
* Modified the `fetchAll` method to retrieve and handle UI settings and permissions from the repository, with error handling for permission issues.

### Repository Interface Updates:

* Added a new `uiSettings` method to the `Repository` protocol to fetch UI settings and permissions.
* Implemented the `uiSettings` method in `NullRepository` and `PreviewRepository` to return default settings and permissions. [[1]](diffhunk://#diff-dfd427f788c3bd332ccf9a64dd69349ffac7d1a2249f6d307254e2a62d964388R26-R28) [[2]](diffhunk://#diff-8533077b1c53fda785e67748047015f8b1d00600e5b667c369caea572f3221ceR366-R373)

These changes enhance the functionality of the `DocumentStore` by integrating user permissions and settings, ensuring better control over document updates and repository interactions.