### PR TITLE
fix: Issue with lost token after upgrading from pre-multi-server to current version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,3 +42,6 @@ in certain cases
 - Fix ASN not being saved when uploading documents with restricted user accounts
 - Reintroduce delay when typing search text
 - If configured, remove inbox tags from documents automatically when saving
+- Fix a bug during migration from single-server (v1.1.1 and before) to
+  multi-server: the login token was not correctly persisted. This led to a
+  connection error the next time the app was launched.

--- a/swift-paperless/Networking/Api/ApiRepository.swift
+++ b/swift-paperless/Networking/Api/ApiRepository.swift
@@ -66,7 +66,11 @@ actor ApiRepository {
     init(connection: Connection) async {
         self.connection = connection
         let sanitizedUrl = Self.sanitizeUrlForLog(connection.url)
-        let tokenStr = connection.token != nil ? "<token len: \(connection.token?.count ?? 0)>" : "nil"
+        #if DEBUG
+            let tokenStr = connection.token ?? "nil"
+        #else
+            let tokenStr = connection.token != nil ? "<token len: \(connection.token?.count ?? 0)>" : "nil"
+        #endif
         Logger.api.notice("Initializing ApiRepository with connection \(sanitizedUrl, privacy: .public) and token \(tokenStr, privacy: .public)")
 
         let delegate = PaperlessURLSessionDelegate(identityName: connection.identity)

--- a/swift-paperless/Networking/ConnectionManager.swift
+++ b/swift-paperless/Networking/ConnectionManager.swift
@@ -49,6 +49,7 @@ struct StoredConnection: Equatable, Codable, Identifiable {
 
     var token: String? {
         get throws {
+            Logger.api.debug("Loading token from keychain for \(user.username) \(url.absoluteString)")
             guard let data = try Keychain.read(service: url.absoluteString,
                                                account: user.username)
             else {
@@ -66,6 +67,7 @@ struct StoredConnection: Equatable, Codable, Identifiable {
     }
 
     func setToken(_ token: String) throws(Keychain.KeychainError) {
+        Logger.api.debug("Saving token \(token) to keychain for \(user.username) \(url.absoluteString)")
         try Keychain.saveOrUpdate(service: url.absoluteString,
                                   account: user.username,
                                   value: token.data(using: .utf8)!)

--- a/swift-paperless/Networking/ConnectionManager.swift
+++ b/swift-paperless/Networking/ConnectionManager.swift
@@ -271,6 +271,11 @@ class ConnectionManager: ObservableObject {
                     let newConnection = StoredConnection(url: connection.url, extraHeaders: connection.extraHeaders, user: currentUser)
                     Logger.migration.info("Connection to store is: \(String(describing: newConnection))")
 
+                    if let token = connection.token, token != "" {
+                        Logger.migration.debug("Saving token into keychain under new lookup parameters")
+                        try newConnection.setToken(token)
+                    }
+
                     connections[newConnection.id] = newConnection
                     activeConnectionId = newConnection.id
                 } catch {

--- a/swift-paperless/Networking/Error/RequestError.swift
+++ b/swift-paperless/Networking/Error/RequestError.swift
@@ -55,7 +55,7 @@ extension RequestError: DisplayableError {
             if let details {
                 if !Self.isMTLSError(code: code, message: details) {
                     // We're not sure this is an SSL error, show details just in case
-                    msg += " " + .localizable(.requestErrorDetailLabel) + ": \n\n"
+                    msg += " " + .localizable(.requestErrorDetailLabel) + ": "
                         + details
                 }
                 msg += " " + .localizable(.requestErrorMTLS)
@@ -65,14 +65,14 @@ extension RequestError: DisplayableError {
         case let .forbidden(detail):
             var s = String(localized: .localizable(.requestErrorForbidden))
             if let detail {
-                s += "\n\n" + label
+                s += " " + label
                     + detail
             }
             raw = s
 
         case let .unauthorized(detail):
             var s = String(localized: .localizable(.requestErrorUnauthorized))
-            s += "\n\n" + label + detail
+            s += " " + label + detail
             raw = s
 
         case .unsupportedVersion:
@@ -82,7 +82,7 @@ extension RequestError: DisplayableError {
             raw = String(localized: .localizable(.requestErrorLocalNetworkDenied))
 
         case let .certificate(detail):
-            raw = String(localized: .localizable(.requestErrorCertificate)) + "\n\n" + detail
+            raw = String(localized: .localizable(.requestErrorCertificate)) + " " + detail
         }
 
         // Single source strings that might contain markdown markup: use AttributedString to remove them


### PR DESCRIPTION
Fix a bug during migration from single-server (v1.1.1 and before) to multi-server: the login token was not correctly persisted. This led to a connection error the next time the app was launched.

Fixes #208 