### PR TITLE
refactor: Adapt to updated `/api` endpoint

### DIFF
--- a/swift-paperless/Networking/Api/ApiRepository.swift
+++ b/swift-paperless/Networking/Api/ApiRepository.swift
@@ -55,7 +55,7 @@ actor ApiRepository {
     private var apiVersion: UInt?
     static let minimumApiVersion: UInt = 3
     static let minimumVersion = Version(1, 14, 1)
-    static let maximumApiVersion: UInt = 5
+    static let maximumApiVersion: UInt = 7
     private(set) var backendVersion: Version?
 
     var effectiveApiVersion: UInt {
@@ -703,7 +703,8 @@ extension ApiRepository: Repository {
     private func loadBackendVersions() async {
         Logger.api.info("Getting backend versions")
         do {
-            let request = try request(.root())
+            // @TODO: Maybe switch to `/api/remote_version`
+            let request = try request(.uiSettings())
 
             let (_, res) = try await fetchData(for: request)
 


### PR DESCRIPTION
https://github.com/paperless-ngx/paperless-ngx/pull/8948 changes the `/api` endpoint to redirect to a new OpenAPI display. This breaks the login flow and version determination. Therefore:

- I'm switching the URL check over to `/api/token`, which will return on `GET` a 406 if the version is invalid and a `405` (method not allowed) otherwise.
- The backend version is now retrieved from the `ui_settings` endpoint, instead of the root endpoint.