### PR TITLE
fix: Adjust to new document notes payload format

### DIFF
--- a/DataModel/Sources/DataModel/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/DocumentModel.swift
@@ -17,6 +17,21 @@ public protocol DocumentProtocol: Codable {
     var storagePath: UInt? { get set }
 }
 
+public struct NotesPayload: Decodable, Equatable, Sendable, Hashable {
+    public var count: Int = 0
+
+    public init() {}
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let notes = try? container.decode([Document.Note].self) {
+            count = notes.count
+        } else {
+            count = try (container.decode([UInt].self)).count
+        }
+    }
+}
+
 @Codable
 @CodingKeys(.snake_case)
 @MemberInit
@@ -62,7 +77,7 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
     }
 
     @IgnoreEncoding
-    public var notes: [Note]
+    public internal(set) var notes: NotesPayload = .init()
 
     // Presense of this depends on the endpoint
     // If we didn't get a value, we likely just modified

--- a/DataModel/Tests/DataModelTests/Data/Document/full_new_notes.json
+++ b/DataModel/Tests/DataModelTests/Data/Document/full_new_notes.json
@@ -1,0 +1,23 @@
+{
+    "id": 2724,
+    "correspondent": 123,
+    "document_type": 5,
+    "storage_path": 1,
+    "title": "Quittung",
+    "content": "bla bla bla",
+    "tags": [1, 2, 3],
+    "created": "2024-12-21T00:00:00+01:00",
+    "created_date": "2024-12-21",
+    "modified": "2024-12-21T21:41:49.907469+01:00",
+    "added": "2024-12-21T21:26:36.217383+01:00",
+    "deleted_at": null,
+    "archive_serial_number": 666,
+    "original_file_name": "original.pdf",
+    "archived_file_name": "archived.pdf",
+    "owner": 2,
+    "user_can_change": true,
+    "is_shared_by_requester": true,
+    "notes": [40],
+    "custom_fields": [],
+    "page_count": 1
+}

--- a/DataModel/Tests/DataModelTests/DocumentModelTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentModelTest.swift
@@ -34,10 +34,32 @@ struct DocumentModelTest {
         #expect(document.owner == 2)
         #expect(document.notes.count == 1)
 
-        let note = try #require(document.notes.first)
-        #expect(note.id == 40)
-        #expect(note.note == "hallo")
-        #expect(dateApprox(note.created, datetime(year: 2025, month: 1, day: 2, hour: 16, minute: 3, second: 36, tz: tz)))
+        #expect(document.userCanChange == true)
+
+        // No permissions by default
+        #expect(document.permissions == nil)
+    }
+
+    @Test("Tests that new notes are correctly decoded")
+    // After bundled notes payload changed: https://github.com/paperless-ngx/paperless-ngx/pull/8948
+    func testNewNotesDecode() throws {
+        let data = try #require(testData("Data/Document/full_new_notes.json"))
+        let document = try decoder.decode(Document.self, from: data)
+
+        #expect(document.id == 2724)
+        #expect(document.correspondent == 123)
+        #expect(document.documentType == 5)
+        #expect(document.storagePath == 1)
+        #expect(document.title == "Quittung")
+        #expect(document.tags == [1, 2, 3])
+
+        #expect(dateApprox(document.created, datetime(year: 2024, month: 12, day: 21, hour: 0, minute: 0, second: 0, tz: tz)))
+        #expect(try dateApprox(#require(document.modified), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 41, second: 49, tz: tz)))
+        #expect(try dateApprox(#require(document.added), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 26, second: 36, tz: tz)))
+
+        #expect(document.asn == 666)
+        #expect(document.owner == 2)
+        #expect(document.notes.count == 1)
 
         #expect(document.userCanChange == true)
 
@@ -54,7 +76,7 @@ struct DocumentModelTest {
 
     @Test
     func testSetPermissionsKey() throws {
-        var document = Document(id: 123, title: "hallo", created: .now, tags: [], notes: [])
+        var document = Document(id: 123, title: "hallo", created: .now, tags: [])
         document.added = .now
         document.modified = .now
         document.permissions = Permissions(view: Permissions.Set(users: [1], groups: [2]), change: Permissions.Set(users: [3], groups: [4]))

--- a/swift-paperless/Document/DocumentStore.swift
+++ b/swift-paperless/Document/DocumentStore.swift
@@ -157,25 +157,21 @@ final class DocumentStore: ObservableObject, Sendable {
 
     func deleteNote(from document: Document, id: UInt) async throws {
         eventPublisher.send(.changed(document: document))
-        let notes = try await repository.deleteNote(id: id, documentId: document.id)
+        _ = try await repository.deleteNote(id: id, documentId: document.id)
 
-        var document = document
-        document.notes = notes
-
-        documents[document.id] = document
         eventPublisher.send(.changeReceived(document: document))
     }
 
     func addNote(to document: Document, note: ProtoDocument.Note) async throws {
         eventPublisher.send(.changed(document: document))
 
-        let notes = try await repository.createNote(documentId: document.id, note: note)
+        _ = try await repository.createNote(documentId: document.id, note: note)
 
-        var document = document
-        document.notes = notes
-
-        documents[document.id] = document
         eventPublisher.send(.changeReceived(document: document))
+    }
+
+    func notes(for document: Document) async throws -> [Document.Note] {
+        try await repository.notes(documentId: document.id)
     }
 
     func fetchTasks() async {

--- a/swift-paperless/Networking/Api/ApiRepository.swift
+++ b/swift-paperless/Networking/Api/ApiRepository.swift
@@ -490,6 +490,16 @@ extension ApiRepository: Repository {
         }
     }
 
+    func notes(documentId: UInt) async throws -> [Document.Note] {
+        let request = try request(.notes(documentId: documentId))
+        do {
+            return try await fetchData(for: request, as: [Document.Note].self, code: .ok)
+        } catch {
+            Logger.shared.error("Error fetching notes for document \(documentId): \(error)")
+            throw error
+        }
+    }
+
     func createNote(documentId: UInt, note: ProtoDocument.Note) async throws -> [Document.Note] {
         var request = try request(.notes(documentId: documentId))
         let body = try JSONEncoder().encode(note)

--- a/swift-paperless/Networking/NullRepository.swift
+++ b/swift-paperless/Networking/NullRepository.swift
@@ -45,6 +45,7 @@ actor NullRepository: Repository {
 
     func metadata(documentId _: UInt) async throws -> Metadata { throw NotImplemented() }
 
+    func notes(documentId _: UInt) async -> [Document.Note] { [] }
     func createNote(documentId _: UInt, note _: ProtoDocument.Note) async throws -> [Document.Note] { [] }
     func deleteNote(id _: UInt, documentId _: UInt) async throws -> [Document.Note] { [] }
 

--- a/swift-paperless/Networking/Repository.swift
+++ b/swift-paperless/Networking/Repository.swift
@@ -110,6 +110,7 @@ protocol Repository: Sendable, Actor {
 
     func metadata(documentId: UInt) async throws -> Metadata
 
+    func notes(documentId: UInt) async throws -> [Document.Note]
     func createNote(documentId: UInt, note: ProtoDocument.Note) async throws -> [Document.Note]
     func deleteNote(id: UInt, documentId: UInt) async throws -> [Document.Note]
 

--- a/swift-paperlessTests/TransientRepositoryTest.swift
+++ b/swift-paperlessTests/TransientRepositoryTest.swift
@@ -176,6 +176,12 @@ import Testing
         #expect(notes.count == 1)
         #expect(notes.first?.note == "Test Note")
 
+        // Get notes
+        let notes2 = try await repository.notes(documentId: 1)
+        #expect(notes2.count == 1)
+        #expect(notes2.first?.note == "Test Note")
+        #expect(notes2.first?.id == 1)
+
         // Delete the note
         let notesAfterDelete = try await repository.deleteNote(id: notes[0].id, documentId: 1)
         #expect(notesAfterDelete.isEmpty)


### PR DESCRIPTION
This changed in https://github.com/paperless-ngx/paperless-ngx/pull/8948

it was previously giving the full notes content inline with the document response like this:

```json
[
    {
        "id": 44,
        "note": "What?",
        "created": "2025-03-08T16:50:30.277365Z",
        "user": {
            "id": 2,
            "username": "user",
            "first_name": "",
            "last_name": ""
        }
    },
    {
        "id": 41,
        "note": "Note",
        "created": "2025-03-08T16:46:04.081142Z",
        "user": {
            "id": 2,
            "username": "user",
            "first_name": "",
            "last_name": ""
        }
    }
```

while now it only returns an array of the note IDs like this:

```json
[44, 45]
```