### PR TITLE
feat: Load consume file tasks only after change to API

### DIFF
--- a/DataModel/Sources/DataModel/TaskModel.swift
+++ b/DataModel/Sources/DataModel/TaskModel.swift
@@ -17,6 +17,15 @@ public enum TaskStatus: String, Codable, Sendable {
     case REVOKED
 }
 
+// See https://github.com/paperless-ngx/paperless-ngx/blob/4c6fdbb21fdcd3ecf81b9a0dd87487f146066e01/src/documents/models.py#L542C9-L545C65
+public enum TaskName: String, Sendable {
+    // There might be more added but this is not (currently) used for deserialization
+    case consumeFile = "consume_file"
+    case trainClassifier = "train_classifier"
+    case checkSanity = "check_sanity"
+    case indexOptimize = "index_optimize"
+}
+
 @Codable
 @CodingKeys(.snake_case)
 @MemberInit

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -721,7 +721,7 @@ extension ApiRepository: Repository {
     }
 
     public func tasks() async throws -> [PaperlessTask] {
-        let request = try request(.tasks())
+        let request = try request(.tasks(name: .consumeFile))
 
         do {
             return try await fetchData(for: request, as: [PaperlessTask].self)

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -187,8 +187,12 @@ public extension Endpoint {
         Endpoint(path: "/api/ui_settings")
     }
 
-    static func tasks() -> Endpoint {
-        Endpoint(path: "/api/tasks")
+    static func tasks(name: TaskName? = nil) -> Endpoint {
+        var queryItems: [URLQueryItem] = []
+        if let name {
+            queryItems.append(URLQueryItem(name: "task_name", value: name.rawValue))
+        }
+        return Endpoint(path: "/api/tasks", queryItems: queryItems)
     }
 
     static func task(id: UInt) -> Endpoint {


### PR DESCRIPTION
The backend API now also stores tasks that are not document consumption ones. The frontend started adding `?task_name=consume_file` to the API request in https://github.com/paperless-ngx/paperless-ngx/pull/9106.

This is backwards compatible with older versions in my testing.