### PR TITLE
fix: DateOnlyCoder uses regex to strip time + timezone

### DIFF
--- a/Common/Package.swift
+++ b/Common/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "Common",
     platforms: [
         .iOS(.v17),
-        .macOS(.v12),
+        .macOS(.v13),
     ],
     products: [
         .library(

--- a/Common/Tests/CommonTests/DateOnlyCoderTest.swift
+++ b/Common/Tests/CommonTests/DateOnlyCoderTest.swift
@@ -36,23 +36,41 @@ func testDateOnlyCoderDecode() throws {
     let decoder = JSONDecoder()
 
     var decoded = try decoder.decode(TestStruct.self, from: dateOnly)
+    print(decoded)
 
     let exp = try #require(Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 4, hour: 0, minute: 0, second: 0)))
     #expect(decoded.created == exp)
 
-    let tz = TimeZone(secondsFromGMT: 60 * 60)!
     let dateTime = try #require(#"{"created":"2023-12-04T09:10:24+01:00"}"#.data(using: .utf8))
 
     decoded = try decoder.decode(TestStruct.self, from: dateTime)
 
-    var cal = Calendar.current
-    cal.timeZone = tz
+    let cal = Calendar.current
     let components = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: decoded.created)
 
     #expect(components.year == 2023)
     #expect(components.month == 12)
     #expect(components.day == 4)
-    #expect(components.hour == 9)
-    #expect(components.minute == 10)
-    #expect(components.second == 24)
+    #expect(components.hour == 0)
+    #expect(components.minute == 0)
+    #expect(components.second == 0)
+}
+
+@Test("Arbitrary timezones get stripped out", arguments: 1 ... 10)
+func testArbitraryTimezonesGetStrippedOut(offset: Int) throws {
+    let dateOnly = try #require("{\"created\":\"2028-11-02T00:00:00+0\(offset):00\"}".data(using: .utf8))
+
+    let decoder = JSONDecoder()
+
+    let decoded = try decoder.decode(TestStruct.self, from: dateOnly)
+
+    let cal = Calendar.current
+    let components = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: decoded.created)
+
+    #expect(components.year == 2028)
+    #expect(components.month == 11)
+    #expect(components.day == 2)
+    #expect(components.hour == 0)
+    #expect(components.minute == 0)
+    #expect(components.second == 0)
 }

--- a/DataModel/Tests/DataModelTests/DocumentModelTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentModelTest.swift
@@ -53,7 +53,7 @@ struct DocumentModelTest {
         #expect(document.title == "Quittung")
         #expect(document.tags == [1, 2, 3])
 
-        #expect(dateApprox(document.created, datetime(year: 2024, month: 12, day: 21, hour: 0, minute: 0, second: 0, tz: tz)))
+        #expect(dateApprox(document.created, datetime(year: 2024, month: 12, day: 21, hour: 0, minute: 0, second: 0)))
         #expect(try dateApprox(#require(document.modified), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 41, second: 49, tz: tz)))
         #expect(try dateApprox(#require(document.added), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 26, second: 36, tz: tz)))
 

--- a/DataModel/Tests/DataModelTests/DocumentModelTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentModelTest.swift
@@ -26,7 +26,7 @@ struct DocumentModelTest {
         #expect(document.title == "Quittung")
         #expect(document.tags == [1, 2, 3])
 
-        #expect(dateApprox(document.created, datetime(year: 2024, month: 12, day: 21, hour: 0, minute: 0, second: 0, tz: TimeZone(secondsFromGMT: 0)!)))
+        #expect(dateApprox(document.created, datetime(year: 2024, month: 12, day: 21, hour: 0, minute: 0, second: 0)))
         #expect(try dateApprox(#require(document.modified), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 41, second: 49, tz: tz)))
         #expect(try dateApprox(#require(document.added), datetime(year: 2024, month: 12, day: 21, hour: 21, minute: 26, second: 36, tz: tz)))
 

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Fix timezone conversion in document created date: on versions below 2.16.0 of Paperless-ngx, the timezone was incorrectly set and resulted in the date shifting when saving.


### PR DESCRIPTION
For DateOnlyCoding, we assume the device local timezone when parsing. For this, we now strip out everything except for the date from the input string, and only then run the formatter. This produces a naive Date object in the local timezone. When we send it back to the backend, we only format the date component, so roundtripping should be safe in all cases. 🤞

See https://github.com/paulgessinger/swift-paperless/issues/286