### PR TITLE
fix: Use NFC UTF8 form for filenames

### DIFF
--- a/swift-paperless/Views/Import/CreateDocumentView.swift
+++ b/swift-paperless/Views/Import/CreateDocumentView.swift
@@ -184,16 +184,16 @@ struct CreateDocumentView: View {
   }
 
   private var filename: String {
-      let filename: String
-      
-      if useOriginalTitle {
-        filename = sourceUrl.lastPathComponent
-      } else {
-        let ext = sourceUrl.pathExtension
-        let stem = document.title.slugify()
-        filename = ext.isEmpty ? stem : "\(stem).\(ext)"
-      }
-      
+    let filename: String
+
+    if useOriginalTitle {
+      filename = sourceUrl.lastPathComponent
+    } else {
+      let ext = sourceUrl.pathExtension
+      let stem = document.title.slugify()
+      filename = ext.isEmpty ? stem : "\(stem).\(ext)"
+    }
+
     return filename.precomposedStringWithCanonicalMapping
   }
 


### PR DESCRIPTION
Ensure that the computed `filename` property in `CreateDocumentView.swift` always returns a string in precomposed canonical Unicode form by applying `.precomposedStringWithCanonicalMapping` before returning.

See #372