### PR TITLE
fix: Apply NFC normalization to document titles and temp filenames

### DIFF
--- a/swift-paperless/Views/Import/CreateDocumentView.swift
+++ b/swift-paperless/Views/Import/CreateDocumentView.swift
@@ -140,8 +140,10 @@ struct CreateDocumentView: View {
     title: String? = nil
   ) {
     sourceUrl = url
+    let initialTitle = url.deletingPathExtension().lastPathComponent
+      .precomposedStringWithCanonicalMapping
     _document = State(
-      initialValue: ProtoDocument(title: url.deletingPathExtension().lastPathComponent))
+      initialValue: ProtoDocument(title: initialTitle))
     self.callback = callback
     self.share = share
     self.title = title ?? String(localized: .localizable(.documentAdd))

--- a/swift-paperless/Views/Import/DocumentImportModel.swift
+++ b/swift-paperless/Views/Import/DocumentImportModel.swift
@@ -55,8 +55,10 @@ class DocumentImportModel: ObservableObject {
 
             let temporaryDirectoryURL = URL(
               fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            let normalizedFilename = selectedFile.lastPathComponent
+              .precomposedStringWithCanonicalMapping
             let temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(
-              selectedFile.lastPathComponent)
+              normalizedFilename)
 
             if FileManager.default.fileExists(atPath: temporaryFileURL.path) {
               try FileManager.default.removeItem(at: temporaryFileURL)


### PR DESCRIPTION
This pull request introduces Unicode normalization for filenames and document titles during the document import process to ensure consistent handling of special characters. The changes focus on normalizing strings using precomposed canonical mapping when extracting filenames, which helps avoid issues with Unicode representation inconsistencies.

**Unicode normalization improvements:**

- In `CreateDocumentView.swift`, the document title is now initialized using a precomposed, canonically normalized version of the filename (without extension), ensuring that titles are consistently formatted regardless of the original file's Unicode composition.
- In `DocumentImportModel.swift`, the filename used for temporary storage is normalized with precomposed canonical mapping before being appended to the temporary directory path, preventing potential mismatches or errors caused by different Unicode representations of the same characters.

See #372 