### PR TITLE
Normalize upload title and filename; add RFC 5987 filename* encoding

### DIFF
--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -415,7 +415,8 @@ extension ApiRepository: Repository {
     var request = try request(.createDocument())
 
     let mp = MultiPartFormDataRequest()
-    mp.add(name: "title", string: document.title)
+    let normalizedTitle = document.title.precomposedStringWithCanonicalMapping
+    mp.add(name: "title", string: normalizedTitle)
 
     if let corr = document.correspondent {
       mp.add(name: "correspondent", string: String(corr))


### PR DESCRIPTION
### Motivation
- Ensure uploaded document metadata preserves intended Unicode form by normalizing strings before sending.
- Prevent malformed or incompatible filenames in multipart uploads by percent-encoding per RFC 5987.
- Improve interoperability with servers that expect an RFC 5987 `filename*` parameter for Unicode filenames.

### Description
- Normalize the document title using `precomposedStringWithCanonicalMapping` before adding it to the multipart payload in `ApiRepository`.
- Add a `rfc5987AllowedCharacters` character set and normalize filenames with `precomposedStringWithCanonicalMapping` in `MultiPartFormDataRequest`.
- Percent-encode the filename with the allowed character set and include an RFC 5987 `filename*` parameter in the `Content-Disposition` header.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a833cdc048322a60d4594076941b5)