### PR TITLE
fix: Drop permissions not returned by the API

### DIFF
--- a/DataModel/Sources/DataModel/Model/UserModel.swift
+++ b/DataModel/Sources/DataModel/Model/UserModel.swift
@@ -137,9 +137,7 @@ public struct UserPermissions: Sendable {
     case storagePath = "storagepath"
     case savedView = "savedview"
     case paperlessTask = "paperlesstask"
-    case appConfig = "appconfig"
     case uiSettings = "uisettings"
-    case history
     case note
     case mailAccount = "mailaccount"
     case mailRule = "mailrule"

--- a/DataModel/Tests/DataModelTests/UISettingsTest.swift
+++ b/DataModel/Tests/DataModelTests/UISettingsTest.swift
@@ -27,7 +27,7 @@ struct UISettingsTest {
     #expect(permissions.test(.change, for: .document))
 
     // Test some negative cases
-    #expect(!permissions.test(.delete, for: .appConfig))
+    #expect(!permissions.test(.delete, for: .shareLink))
     #expect(!permissions.test(.add, for: .workflow))
 
     // Default permissions not present yet

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Dropped the unused `appConfig` and `history` permission resources from the app so the permissions UI only reflects values Paperless actually supplies (fixes #366).

--- a/swift-paperless/Model/Localization/UserPermissionsResource+localizedName.swift
+++ b/swift-paperless/Model/Localization/UserPermissionsResource+localizedName.swift
@@ -24,8 +24,6 @@ extension UserPermissions.Resource {
     case .group: UserGroup.localizedName
     case .mailAccount: String(localized: .permissions(.resourceMailAccount))
     case .mailRule: String(localized: .permissions(.resourceMailRule))
-    case .history: String(localized: .permissions(.resourceHistory))
-    case .appConfig: String(localized: .permissions(.resourceAppConfig))
     case .shareLink: String(localized: .permissions(.resourceShareLink))
     case .workflow: String(localized: .permissions(.resourceWorkflow))
     case .customField: String(localized: .permissions(.resourceCustomField))

--- a/swift-paperless/Views/Settings/PermissionsView.swift
+++ b/swift-paperless/Views/Settings/PermissionsView.swift
@@ -89,7 +89,7 @@ struct PermissionsView: View {
 #Preview("Permissions view") {
   let perms = UserPermissions.full.configure {
     $0.set(.view, to: false, for: .storagePath)
-    $0.set(.change, to: false, for: .history)
+    $0.set(.change, to: false, for: .savedView)
   }
 
   NavigationStack {


### PR DESCRIPTION
This pull request removes unused permission resources from the app, specifically `appConfig` and `history`, to ensure the permissions UI only displays resources that are actually supplied by Paperless. 

See #366.