### PR TITLE
refactor: Tune no-perms case for custom fields editing on document

### DIFF
--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -2,3 +2,4 @@
 - Improve legibility of document link UI
 - Prevent document from being linked to itself
 - Clarify interaction for linking a document in custom field
+- Tune no-permissions display on custom fields when editing documents

--- a/swift-paperless/Views/CustomFields/CustomFieldEditView.swift
+++ b/swift-paperless/Views/CustomFields/CustomFieldEditView.swift
@@ -108,7 +108,7 @@ private struct AddCustomFieldView: View {
           ContentUnavailableView(
             String(localized: .permissions(.noViewPermissionsDisplayTitle)),
             systemImage: "lock.fill",
-            description: Text(Tag.localizedNoViewPermissions))
+            description: Text(.permissions(.noViewPermissionsCustomFields)))
         } else if availableFields.isEmpty {
           if !searchText.isEmpty {
             ContentUnavailableView.search
@@ -226,19 +226,23 @@ struct CustomFieldsEditView: View {
         }
       }
 
-      if document.customFields.isEmpty {
-        let msg =
-          isEnabled
-          ? Text(.customFields(.noCustomFieldsInDocumentDescription))
-          : Text(.customFields(.noCustomFieldsInDocumentDescriptionNoPerms))
+      if !store.permissions.test(.view, for: .customField) {
         ContentUnavailableView(
-          .customFields(.noCustomFieldsInDocument),
-          systemImage: "plus.square.dashed",
-          description: msg)
+          .permissions(.noViewPermissionsDisplayTitle),
+          systemImage: "lock.fill",
+          description: Text(.permissions(.noViewPermissionsCustomFields))
+        )
       } else {
-        ForEach(0..<customFields.count, id: \.self) { index in
-          let field = $customFields[index]
-          try? fieldView(index: index, field: field)
+        if document.customFields.isEmpty {
+          ContentUnavailableView(
+            .customFields(.noCustomFieldsInDocument),
+            systemImage: "plus.square.dashed",
+            description: Text(.customFields(.noCustomFieldsInDocumentDescription)))
+        } else {
+          ForEach(0..<customFields.count, id: \.self) { index in
+            let field = $customFields[index]
+            try? fieldView(index: index, field: field)
+          }
         }
       }
 
@@ -277,6 +281,7 @@ struct CustomFieldsEditView: View {
           Image(systemName: "plus")
             .accessibilityLabel(.localizable(.add))
         }
+        .disabled(!store.permissions.test(.view, for: .customField))
         .accessibilityAddTraits(.isButton)
       }
     }


### PR DESCRIPTION
This pull request improves how the app handles and displays permission-related messages when editing custom fields on documents. The changes ensure that users without the necessary permissions see more accurate and relevant feedback, and the UI is better tuned for these scenarios.

**Permission handling improvements:**

* Added a specific "no view permissions" message for custom fields when users lack permission, both when adding and editing custom fields (`swift-paperless/Views/CustomFields/CustomFieldEditView.swift`). [[1]](diffhunk://#diff-6e92e1838af7ec46658665075daf54194e6dda6b65020e333f4de73df9fb7111L111-R111) [[2]](diffhunk://#diff-6e92e1838af7ec46658665075daf54194e6dda6b65020e333f4de73df9fb7111R229-R247)
* Disabled the "add custom field" button if the user does not have permission to view custom fields (`swift-paperless/Views/CustomFields/CustomFieldEditView.swift`).