### PR TITLE
feat: add dynamic date ranges to DateFilterView

### DIFF
--- a/swift-paperless/Views/Filter/DateFilterView.swift
+++ b/swift-paperless/Views/Filter/DateFilterView.swift
@@ -129,29 +129,28 @@ private struct DateFilterModeView: View {
         break
       }
     }
-    
+
     .task {
-      var rangeValues: [Range]
-      = [
-      .within(num: -1, interval: .week),
-      .within(num: -1, interval: .month),
-      .within(num: -3, interval: .month),
-      .within(num: -1, interval: .year),
-      .currentYear,
-      .currentMonth,
-      .today,
-      .yesterday,
-    ]
-      
+      var rangeValues: [Range] = [
+        .within(num: -1, interval: .week),
+        .within(num: -1, interval: .month),
+        .within(num: -3, interval: .month),
+        .within(num: -1, interval: .year),
+        .currentYear,
+        .currentMonth,
+        .today,
+        .yesterday,
+      ]
+
       if store.repository.supports(feature: .dateFilterPreviousIntervals) {
         rangeValues += [
-        .previousWeek,
-        .previousMonth,
-        .previousQuarter,
-        .previousYear,
+          .previousWeek,
+          .previousMonth,
+          .previousQuarter,
+          .previousYear,
         ]
       }
-      
+
       self.rangeValues = rangeValues
     }
   }


### PR DESCRIPTION
This pull request updates the `DateFilterModeView` in `DateFilterView.swift` to make the available date filter range options dynamic based on repository feature support, rather than static. The list of range values is now initialized asynchronously and conditionally includes additional options if the repository supports the `.dateFilterPreviousIntervals` feature.

**Dynamic date filter range initialization:**

* Moved the `rangeValues` array from a static property to a state variable (`@State private var rangeValues: [Range] = []`) and populated it asynchronously in a `.task` modifier, allowing the options to depend on the repository's supported features. [[1]](diffhunk://#diff-9018f011083bdda02b680e621e37f9cf072c4d1e664af7240a68841ebea4960aR75-L95) [[2]](diffhunk://#diff-9018f011083bdda02b680e621e37f9cf072c4d1e664af7240a68841ebea4960aR132-R156)
* Conditionally includes previous interval options (`.previousWeek`, `.previousMonth`, `.previousQuarter`, `.previousYear`) in the filter range only if the repository supports the `.dateFilterPreviousIntervals` feature, using the `store.repository.supports(feature:)` check.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #400 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #399 
<!-- GitButler Footer Boundary Bottom -->

