### PR TITLE
feat: simplify searchable usage and clean up custom search bars

### DIFF
--- a/swift-paperless/Views/Filter/CommonPickerFilterView.swift
+++ b/swift-paperless/Views/Filter/CommonPickerFilterView.swift
@@ -86,10 +86,7 @@ struct CommonPickerFilterView: View {
 
   var body: some View {
     VStack {
-      SearchBarViewiOS18(text: $searchDebounce.text)
-        .transition(.opacity)
-        .padding(.horizontal)
-        .padding(.vertical, 2)
+
       Form {
         Section {
           Row(
@@ -153,12 +150,10 @@ struct CommonPickerFilterView: View {
             }())
         }
       }
-      .overlay(
-        Rectangle()
-          .fill(Color(.divider))
-          .frame(maxWidth: .infinity, maxHeight: 1),
-        alignment: .top
-      )
+
+      .animation(.spring, value: searchDebounce.debouncedText)
+
+      .searchable(text: $searchDebounce.text, placement: .navigationBarDrawer(displayMode: .always))
     }
 
     .navigationBarTitleDisplayMode(.inline)
@@ -417,7 +412,7 @@ where
     .animation(.spring, value: permissions)
     .animation(.spring, value: document)
 
-    .searchable(text: $searchDebounce.text)
+    .searchable(text: $searchDebounce.text, placement: .navigationBarDrawer(displayMode: .always))
 
     .refreshable {
       await Task {

--- a/swift-paperless/Views/Filter/FilterBar.swift
+++ b/swift-paperless/Views/Filter/FilterBar.swift
@@ -451,13 +451,10 @@ struct FilterBar: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
           ToolbarItem(placement: .navigationBarTrailing) {
-            Button {
+            SaveButton {
               dismiss()
               filterModel.filterState = filterState
               onDismiss()
-            } label: {
-              Text(.localizable(.done))
-                .accessibilityIdentifier("dismissButton")
             }
           }
         }

--- a/swift-paperless/Views/Filter/TagFilterView.swift
+++ b/swift-paperless/Views/Filter/TagFilterView.swift
@@ -125,13 +125,6 @@ struct TagFilterView: View {
 
   var body: some View {
     VStack {
-      VStack {
-        SearchBarViewiOS18(text: $searchDebounce.text)
-      }
-      .transition(.opacity)
-      .padding(.horizontal)
-      .padding(.vertical, 2)
-
       Form {
         Section {
           row(
@@ -227,12 +220,8 @@ struct TagFilterView: View {
             }())
         }
       }
-      .overlay(
-        Rectangle()
-          .fill(Color(.divider))
-          .frame(maxWidth: .infinity, maxHeight: 1),
-        alignment: .top
-      )
+
+      .searchable(text: $searchDebounce.text, placement: .navigationBarDrawer(displayMode: .always))
     }
 
     .onChange(of: mode) { _, value in
@@ -268,6 +257,14 @@ struct TagFilterView: View {
 
   @Previewable @State var filterState = FilterState.default
 
-  TagFilterView(selectedTags: $filterState.tags)
-    .environmentObject(store)
+  NavigationStack {
+    TagFilterView(selectedTags: $filterState.tags)
+      .environmentObject(store)
+
+      .toolbar {
+        ToolbarItem {
+          SaveButton {}
+        }
+      }
+  }
 }

--- a/swift-paperless/Views/Tags/TagSelectionView.swift
+++ b/swift-paperless/Views/Tags/TagSelectionView.swift
@@ -143,7 +143,7 @@ struct DocumentTagEditView<D>: View where D: DocumentProtocol {
         }
       }
     }
-    .searchable(text: $searchText)
+    .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
 
     .animation(.spring, value: displayTags)
     .animation(.spring, value: store.permissions[.tag])


### PR DESCRIPTION
Replace legacy SearchBarViewiOS18 components with SwiftUI’s
`.searchable` modifier, setting the placement to
`navigationBarDrawer(displayMode: .always)` across all filter
views. Remove manual overlay dividers and transition logic,
reducing visual clutter and improving consistency. Add a
`SaveButton` toolbar item to the `TagFilterView` preview for
better navigation context. This streamlines search UI, reduces
code duplication, and aligns with iOS 18+ design guidelines.