### PR TITLE
refactor: Move out ClearableDatePickerView into own file

### DIFF
--- a/swift-paperless/Localization/Localizable.xcstrings
+++ b/swift-paperless/Localization/Localizable.xcstrings
@@ -1792,6 +1792,30 @@
         }
       }
     },
+    "dateAdd" : {
+      "comment" : "Used in date picker where “no date” is a valid value. This button sets the value to today",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set"
+          }
+        }
+      }
+    },
+    "dateClear" : {
+      "comment" : "Used in date picker where “no date” is a valid value. This button unsets the value",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear date"
+          }
+        }
+      }
+    },
     "dateFilterAdded" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1843,28 +1867,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This year"
-          }
-        }
-      }
-    },
-    "dateFilterDateAdd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set"
-          }
-        }
-      }
-    },
-    "dateFilterDateClear" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear date"
           }
         }
       }

--- a/swift-paperless/Views/Filter/ClearableDatePickerView.swift
+++ b/swift-paperless/Views/Filter/ClearableDatePickerView.swift
@@ -1,0 +1,39 @@
+//
+//  ClearableDatePickerView.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 03.01.26.
+//
+
+import SwiftUI
+
+struct ClearableDatePickerView: View {
+  @Binding var value: Date?
+
+  var body: some View {
+    HStack {
+      if let unwrapped = Binding(unwrapping: $value) {
+        DatePicker(selection: unwrapped, displayedComponents: .date) {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundColor(.secondary)
+            .accessibilityLabel(String(localized: .localizable(.dateClear)))
+            .contentShape(Rectangle())
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .onTapGesture {
+              value = nil
+            }
+        }
+      } else {
+        HStack {
+          Image(systemName: "plus.circle.fill")
+          Text(.localizable(.dateAdd))
+        }
+        .foregroundColor(.accentColor)
+        .onTapGesture {
+          value = .now
+        }
+      }
+    }
+    .animation(.spring, value: value)
+  }
+}

--- a/swift-paperless/Views/Filter/DateFilterView.swift
+++ b/swift-paperless/Views/Filter/DateFilterView.swift
@@ -30,41 +30,6 @@ extension FilterState.DateFilter.Range {
   }
 }
 
-private struct ClearableDatePickerView: View {
-  @Binding private var value: Date?
-
-  init(value: Binding<Date?>) {
-    _value = value
-  }
-
-  var body: some View {
-    HStack {
-      if let unwrapped = Binding(unwrapping: $value) {
-        DatePicker(selection: unwrapped, displayedComponents: .date) {
-          Image(systemName: "xmark.circle.fill")
-            .foregroundColor(.secondary)
-            .accessibilityLabel(String(localized: .localizable(.dateFilterDateClear)))
-            .contentShape(Rectangle())
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .onTapGesture {
-              value = nil
-            }
-        }
-      } else {
-        HStack {
-          Image(systemName: "plus.circle.fill")
-          Text(.localizable(.dateFilterDateAdd))
-        }
-        .foregroundColor(.accentColor)
-        .onTapGesture {
-          value = .now
-        }
-      }
-    }
-    .animation(.spring, value: value)
-  }
-}
-
 private struct DateFilterModeView: View {
   typealias Argument = FilterState.DateFilter.Argument
   typealias Range = FilterState.DateFilter.Range


### PR DESCRIPTION
This pull request refactors and improves the date picker localization and component structure. It introduces a new reusable `ClearableDatePickerView`, updates localization keys for clarity, and removes the old inline implementation from `DateFilterView.swift`.

**Component Refactoring:**
* Introduced a new `ClearableDatePickerView` in its own file, making the clearable date picker logic reusable and easier to maintain.
* Removed the previous inline implementation of `ClearableDatePickerView` from `DateFilterView.swift`, cleaning up the view code.

**Localization Improvements:**
* Updated and renamed localization keys in `Localizable.xcstrings` for date picker actions (e.g., "Set", "Clear date"), improving clarity and consistency across the UI.