### PR TITLE
feat: Model for share links

### DIFF
--- a/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
+++ b/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
@@ -5,7 +5,7 @@ import MetaCodable
 @Codable
 @CodingKeys(.snake_case)
 @MemberInit
-public struct ShareLink : Sendable {
+public struct ShareLink: Sendable, Equatable {
   public enum FileVersion: String, Codable, Sendable {
     case original
     case archive
@@ -19,13 +19,17 @@ public struct ShareLink : Sendable {
   public var fileVersion: FileVersion
 }
 
-extension ShareLink : Model {}
+extension ShareLink: Model {}
 
 @Codable
 @CodingKeys(.snake_case)
 @MemberInit
 public struct ProtoShareLink: Sendable {
-  public var expiration: Date?
   public var document: UInt
+
+  @Default(ifMissing: nil as Date?)
+  public var expiration: Date?
+
+  @Default(ifMissing: ShareLink.FileVersion.original)
   public var fileVersion: ShareLink.FileVersion
 }

--- a/DataModel/Tests/DataModelTests/ShareLinkModelTest.swift
+++ b/DataModel/Tests/DataModelTests/ShareLinkModelTest.swift
@@ -173,8 +173,8 @@ struct ShareLinkModelTest {
 
   @Test func testProtoShareLinkEncoding() throws {
     let proto = ProtoShareLink(
-      expiration: datetime(year: 2026, month: 2, day: 15, hour: 10, minute: 30, second: 0, tz: tz),
       document: 25,
+      expiration: datetime(year: 2026, month: 2, day: 15, hour: 10, minute: 30, second: 0, tz: tz),
       fileVersion: .original)
 
     let encoder = JSONEncoder()
@@ -190,8 +190,8 @@ struct ShareLinkModelTest {
 
   @Test func testProtoShareLinkEncodingWithNullExpiration() throws {
     let proto = ProtoShareLink(
-      expiration: nil,
       document: 30,
+      expiration: nil,
       fileVersion: .archive)
 
     let encoder = JSONEncoder()
@@ -208,8 +208,8 @@ struct ShareLinkModelTest {
 
   @Test func testProtoShareLinkRoundTrip() throws {
     let original = ProtoShareLink(
-      expiration: datetime(year: 2026, month: 4, day: 1, hour: 0, minute: 0, second: 0, tz: tz),
       document: 99,
+      expiration: datetime(year: 2026, month: 4, day: 1, hour: 0, minute: 0, second: 0, tz: tz),
       fileVersion: .archive)
 
     let encoder = JSONEncoder()


### PR DESCRIPTION
This pull request introduces a new `ShareLink` model and its related types for handling shareable document links, along with comprehensive tests to ensure correct encoding, decoding, and round-trip integrity. The changes provide a robust foundation for managing share links in the data model, including support for optional expiration dates and different file versions.

**New model definitions:**

- Added a new `ShareLink` struct with fields for `id`, `created`, `expiration`, `slug`, `document`, and `fileVersion`, including an internal `FileVersion` enum and support for Codable, Equatable, and Sendable.
- Introduced a `ProtoShareLink` struct for creating or updating share links, supporting optional expiration and default file version handling.

**Testing:**

- Added `ShareLinkModelTest.swift` with extensive tests covering decoding, encoding, round-trip serialization, and edge cases (such as null expiration) for both `ShareLink` and `ProtoShareLink` models.

See #57 

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #412 
- <kbd>&nbsp;2&nbsp;</kbd> #411 
- <kbd>&nbsp;1&nbsp;</kbd> #410 👈 
<!-- GitButler Footer Boundary Bottom -->

