### PR TITLE
refactor: integrate SettingsView above DocumentView

### DIFF
--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -18,7 +18,6 @@ import os
 enum NavigationState: Equatable, Hashable, Identifiable {
   case root
   case detail(document: Document)
-  case settings
   case tasks
   case task(_: PaperlessTask)
 
@@ -26,7 +25,6 @@ enum NavigationState: Equatable, Hashable, Identifiable {
     switch self {
     case .root: 1
     case .detail: 2
-    case .settings: 3
     case .tasks: 4
     case .task: 5
     }
@@ -79,7 +77,11 @@ struct DocumentView: View {
 
   @State private var showDataScanner = false
   @State private var taskViewNavState: NavigationState? = nil
-  @State private var showSettings = false
+  @Binding private var showSettings: Bool
+
+  init(showSettings: Binding<Bool>) {
+    _showSettings = showSettings
+  }
 
   private func createCallback() {
     importModel.pop()
@@ -94,8 +96,6 @@ struct DocumentView: View {
     switch nav {
     case .detail(let doc):
       DocumentDetailView(store: store, document: doc, navPath: $navPath)
-    case .settings:
-      SettingsView()
     default:
       fatalError()
     }
@@ -142,6 +142,9 @@ struct DocumentView: View {
           await clear()
           navPath.append(NavigationState.detail(document: document))
         }
+      case .setFilter:
+        // @TODO: Implement set filter
+        break
       }
     }
   }
@@ -428,10 +431,6 @@ struct DocumentView: View {
         Button(String(localized: .localizable(.cancel)), role: .cancel) {}
       }
 
-      .sheet(isPresented: $showSettings) {
-        SettingsView()
-      }
-
       .onChange(of: routeManager.pendingRoute, initial: true, handlePendingRoute)
 
       .task {
@@ -475,8 +474,9 @@ struct DocumentView: View {
   @Previewable @StateObject var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @StateObject var connectionManager = ConnectionManager()
+  @Previewable @State var showSettings = false
 
-  DocumentView()
+  DocumentView(showSettings: $showSettings)
     .environmentObject(store)
     .environmentObject(errorController)
     .environmentObject(connectionManager)

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -17,6 +17,7 @@ struct MainView: View {
   @State private var showLoadingScreen = false
   @State private var store: DocumentStore?
   @State private var initialDisplay = true
+  @State private var showSettings = false
 
   @StateObject private var manager = ConnectionManager()
 
@@ -180,7 +181,7 @@ struct MainView: View {
     VStack {
       ZStack {
         if manager.connection != nil, storeReady {
-          DocumentView()
+          DocumentView(showSettings: $showSettings)
             .errorOverlay(errorController: errorController)
             .environmentObject(store!)
             .environmentObject(manager)
@@ -222,6 +223,15 @@ struct MainView: View {
 
     .fullScreenCover(isPresented: $releaseNotesModel.showReleaseNotes) {
       ReleaseNotesCoverView(releaseNotesModel: $releaseNotesModel)
+    }
+
+    .sheet(isPresented: $showSettings) {
+      if let store {
+        SettingsView()
+          .environmentObject(manager)
+          .environmentObject(store)
+          .environmentObject(errorController)
+      }
     }
 
     .task {


### PR DESCRIPTION
Add a `showSettings` state to the app root and pass it into
`DocumentView`.  Convert the former `NavigationState.settings` case to a
binding so that the sheet can be presented directly from the root view.
Remove the now‑unused `NavigationState.settings` case and related
navigation logic.  Update previews to use the new binding.  This simplifies
settings presentation, eliminates redundant navigation state handling,
and keeps the UI flow consistent across the app.