### PR TITLE
feat: add customizable port to docs-serve command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
-docs-serve:
-    uv run --with-requirements docs/requirements.txt mkdocs serve -o -a localhost:8001
+default_port := '8000'
+docs-serve port=default_port:
+    uv run --with-requirements docs/requirements.txt mkdocs serve -o -a localhost:{{port}}
 
 docs:
     uv run --with-requirements docs/requirements.txt mkdocs build


### PR DESCRIPTION
Add a `default_port` variable and expose a `port`
argument for the `docs-serve` rule. The command now
runs MkDocs on the specified port instead of a hard‑coded
value, allowing developers to serve documentation on any
desired port without editing the Justfile.