### PR TITLE
feat(ReleaseNotesView): ignore newer releases

### DIFF
--- a/swift-paperless/Views/ReleaseNotesView.swift
+++ b/swift-paperless/Views/ReleaseNotesView.swift
@@ -226,6 +226,11 @@ class ReleaseNotesViewModel {
             Logger.shared.warning("Invalid tag format: \(release.tag_name)")
             return nil
           }
+          guard buildNumber <= version.build else {
+            Logger.shared.debug(
+              "Skipping release \(release.tag_name) newer than current build \(version.build)")
+            return nil
+          }
           return (release, buildNumber)
         }
         .sorted { $0.1 > $1.1 }  // Sort by build number descending


### PR DESCRIPTION
Add guard to skip releases whose build number is greater than
the current app build. Log a debug message for skipped releases
and return nil so they are omitted from the list.
This prevents displaying unreleased or future versions in
ReleaseNotesView.