### PR TITLE
fix: prevent crash in PreferencesView by adding biometric env object

### DIFF
--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Fix crash on settings > preferences view

--- a/swift-paperless/Views/Settings/PreferencesView.swift
+++ b/swift-paperless/Views/Settings/PreferencesView.swift
@@ -6,7 +6,6 @@ import os
 struct PreferencesView: View {
   @ObservedObject private var appSettings = AppSettings.shared
 
-  @EnvironmentObject private var errorController: ErrorController
   @EnvironmentObject private var biometricLockManager: BiometricLockManager
   @EnvironmentObject private var store: DocumentStore
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -234,6 +234,7 @@ struct MainView: View {
           .environmentObject(manager)
           .environmentObject(store)
           .environmentObject(errorController)
+          .environmentObject(biometricLockManager)
       }
     }
 


### PR DESCRIPTION
Add biometricLockManager to the app environment so it is available
throughout the view hierarchy, which eliminates a nil
reference that caused the crash when navigating to Settings > Preferences.