### PR TITLE
add scanner options

### DIFF
--- a/swift-paperless/Localization/Settings.xcstrings
+++ b/swift-paperless/Localization/Settings.xcstrings
@@ -2402,6 +2402,39 @@
         }
       }
     },
+    "scannerAutoscanLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic Scanning"
+          }
+        }
+      }
+    },
+    "scannerFlashLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flash"
+          }
+        }
+      }
+    },
+    "scannerSectionHeader" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner"
+          }
+        }
+      }
+    },
     "showDocumentDetailPropertyBar" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/swift-paperless/Utilities/AppSettings.swift
+++ b/swift-paperless/Utilities/AppSettings.swift
@@ -21,6 +21,9 @@ enum SettingsKeys: String {
   case editingUserInterfaceExperiment
 
   case showDocumentDetailPropertyBar
+
+  case scannerFlashEnabled
+  case scannerAutoscanEnabled
 }
 
 extension PublishedUserDefaultsBacked {
@@ -108,6 +111,12 @@ class AppSettings: ObservableObject {
 
   @PublishedUserDefaultsBacked(.showDocumentDetailPropertyBar)
   var showDocumentDetailPropertyBar: Bool = true
+
+  @PublishedUserDefaultsBacked(.scannerFlashEnabled)
+  var scannerFlashEnabled = false
+
+  @PublishedUserDefaultsBacked(.scannerAutoscanEnabled)
+  var scannerAutoscanEnabled = true
 
   var lastAppVersion: AppVersion?
   @UserDefaultsBacked(appVersionKey)

--- a/swift-paperless/Utilities/ScannerSettingsConfiguration.swift
+++ b/swift-paperless/Utilities/ScannerSettingsConfiguration.swift
@@ -1,0 +1,109 @@
+import UIKit
+
+struct ScannerButtonPattern {
+    let accessibilityLabels: [String]
+    let buttonTitles: [String]
+    let controlType: ControlType
+    let activationMethod: ActivationMethod
+
+    enum ControlType: CustomStringConvertible {
+        case button
+        case labelledButtonWithInnerButton
+        case menuButton
+
+        var description: String {
+            switch self {
+            case .button: "button"
+            case .labelledButtonWithInnerButton: "labelledButtonWithInnerButton"
+            case .menuButton: "menuButton"
+            }
+        }
+    }
+
+    enum ActivationMethod: CustomStringConvertible {
+        case sendActions
+        case tapInnerButton
+        case openMenuThenTap(menuItemTitle: String)
+
+        var description: String {
+            switch self {
+            case .sendActions: "sendActions"
+            case .tapInnerButton: "tapInnerButton"
+            case let .openMenuThenTap(title): "openMenuThenTap(\(title))"
+            }
+        }
+    }
+}
+
+/// When a user reports scanner settings don't work on a new iOS version:
+/// 1. Ask them to share logs from Settings -> Logs
+/// 2. Logs show all buttons found with their accessibility labels
+/// 3. Add a new configuration for the iOS version
+struct ScannerSettingsConfiguration {
+    let flashPattern: ScannerButtonPattern
+    let autoscanEnabledPattern: ScannerButtonPattern
+    let autoscanDisabledPattern: ScannerButtonPattern
+    let initialDelay: Duration
+    let menuDelay: Duration
+
+    let isSupported: Bool
+
+    static func forCurrentOS() -> ScannerSettingsConfiguration {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+
+        switch (version.majorVersion, version.minorVersion) {
+        case (18, _):
+            return .iOS18Configuration
+        default:
+            return .fallbackConfiguration
+        }
+    }
+
+    static let iOS18Configuration = ScannerSettingsConfiguration(
+        flashPattern: ScannerButtonPattern(
+            accessibilityLabels: ["flash settings", "Show flash settings"],
+            buttonTitles: [],
+            controlType: .menuButton,
+            activationMethod: .openMenuThenTap(menuItemTitle: "On")
+        ),
+        autoscanEnabledPattern: ScannerButtonPattern(
+            accessibilityLabels: ["Automatic document capture enabled"],
+            buttonTitles: [],
+            controlType: .labelledButtonWithInnerButton,
+            activationMethod: .tapInnerButton
+        ),
+        autoscanDisabledPattern: ScannerButtonPattern(
+            accessibilityLabels: ["Automatic document capture disabled"],
+            buttonTitles: [],
+            controlType: .labelledButtonWithInnerButton,
+            activationMethod: .tapInnerButton
+        ),
+        initialDelay: .milliseconds(500),
+        menuDelay: .milliseconds(300),
+        isSupported: true
+    )
+
+    static let fallbackConfiguration = ScannerSettingsConfiguration(
+        flashPattern: ScannerButtonPattern(
+            accessibilityLabels: ["flash settings", "Show flash settings"],
+            buttonTitles: [],
+            controlType: .menuButton,
+            activationMethod: .openMenuThenTap(menuItemTitle: "On")
+        ),
+        autoscanEnabledPattern: ScannerButtonPattern(
+            accessibilityLabels: ["Automatic document capture enabled"],
+            buttonTitles: [],
+            controlType: .labelledButtonWithInnerButton,
+            activationMethod: .tapInnerButton
+        ),
+        autoscanDisabledPattern: ScannerButtonPattern(
+            accessibilityLabels: ["Automatic document capture disabled"],
+            buttonTitles: [],
+            controlType: .labelledButtonWithInnerButton,
+            activationMethod: .tapInnerButton
+        ),
+        initialDelay: .milliseconds(500),
+        menuDelay: .milliseconds(300),
+        isSupported: false
+    )
+}

--- a/swift-paperless/Views/Import/DocumentScannerView.swift
+++ b/swift-paperless/Views/Import/DocumentScannerView.swift
@@ -26,12 +26,259 @@ struct DocumentScannerView: UIViewControllerRepresentable {
     @Binding var isPresented: Bool
     let completionHandler: @Sendable (_ result: Result<[URL], any Error>) -> Void
 
+    private var hasConfigured = false
+
     init(
       isPresented: Binding<Bool>,
       onCompletion: @Sendable @escaping (_ result: Result<[URL], any Error>) -> Void
     ) {
       _isPresented = isPresented
       completionHandler = onCompletion
+    }
+
+    func configureScanner(_ vc: VNDocumentCameraViewController) {
+      guard !hasConfigured else { return }
+      hasConfigured = true
+
+      let flashEnabled = AppSettings.value(for: .scannerFlashEnabled, or: false)
+      let autoscanEnabled = AppSettings.value(for: .scannerAutoscanEnabled, or: true)
+
+      let view = vc.view!
+      Task { @MainActor in
+        try? await Task.sleep(for: .milliseconds(500))
+        Coordinator.applySettings(in: view, flash: flashEnabled, autoscan: autoscanEnabled)
+      }
+    }
+
+    // MARK: - Scanner Settings
+
+    enum SettingResult: CustomStringConvertible {
+        case success
+        case controlNotFound(searched: [String])
+        case activationFailed(reason: String)
+        case skipped(reason: String)
+
+        var description: String {
+            switch self {
+            case .success:
+                "success"
+            case let .controlNotFound(searched):
+                "controlNotFound(searched: \(searched))"
+            case let .activationFailed(reason):
+                "activationFailed(\(reason))"
+            case let .skipped(reason):
+                "skipped(\(reason))"
+            }
+        }
+    }
+
+    @MainActor
+    private static func applySettings(in view: UIView, flash: Bool, autoscan: Bool) {
+        let config = ScannerSettingsConfiguration.forCurrentOS()
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+
+        Logger.shared.info(
+            """
+            Scanner settings applying - iOS \(osVersion.majorVersion).\(osVersion.minorVersion), \
+            flash: \(flash), autoscan: \(autoscan), supported: \(config.isSupported)
+            """
+        )
+
+        let diagnostics = captureViewHierarchyDiagnostics(in: view)
+        Logger.shared.notice("Scanner view hierarchy: \(diagnostics)")
+
+        if flash {
+            let result = applyFlashSetting(in: view, config: config)
+            Logger.shared.info("Flash setting result: \(result)")
+        }
+
+        if !autoscan {
+            let result = disableAutoscan(in: view, config: config)
+            Logger.shared.info("Autoscan setting result: \(result)")
+        }
+    }
+
+    @MainActor
+    private static func captureViewHierarchyDiagnostics(in view: UIView) -> String {
+        var controls: [(label: String?, title: String?, type: String)] = []
+
+        func traverse(_ v: UIView) {
+            if let control = v as? UIControl {
+                controls.append((
+                    label: control.accessibilityLabel,
+                    title: (control as? UIButton)?.currentTitle,
+                    type: String(describing: type(of: control))
+                ))
+            }
+            v.subviews.forEach(traverse)
+        }
+
+        traverse(view)
+
+        if controls.isEmpty {
+            return "No controls found"
+        }
+
+        return controls.map { "[\($0.type): '\($0.label ?? "")' / '\($0.title ?? "")']" }
+            .joined(separator: ", ")
+    }
+
+    @MainActor
+    private static func applyFlashSetting(
+        in view: UIView,
+        config: ScannerSettingsConfiguration
+    ) -> SettingResult {
+        let pattern = config.flashPattern
+
+        guard let flashButton = findButton(in: view, matching: pattern) else {
+            Logger.shared.warning("Scanner: Flash settings button not found")
+            return .controlNotFound(searched: pattern.accessibilityLabels + pattern.buttonTitles)
+        }
+
+        switch pattern.activationMethod {
+        case .sendActions:
+            flashButton.sendActions(for: .touchUpInside)
+            return .success
+
+        case .tapInnerButton:
+            if let innerButton = flashButton.subviews.first(where: { $0 is UIButton }) as? UIButton {
+                innerButton.sendActions(for: .touchUpInside)
+                return .success
+            }
+            return .activationFailed(reason: "No inner button found")
+
+        case let .openMenuThenTap(menuItemTitle):
+            flashButton.sendActions(for: .touchUpInside)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: config.menuDelay)
+                if let menuItem = findButton(in: view, titleEquals: menuItemTitle) {
+                    menuItem.sendActions(for: .touchUpInside)
+                    Logger.shared.info("Flash menu item '\(menuItemTitle)' tapped")
+                } else {
+                    Logger.shared.warning("Scanner: Flash menu item '\(menuItemTitle)' not found")
+                }
+            }
+            return .success
+        }
+    }
+
+    @MainActor
+    private static func disableAutoscan(
+        in view: UIView,
+        config: ScannerSettingsConfiguration
+    ) -> SettingResult {
+        let enabledPattern = config.autoscanEnabledPattern
+        let disabledPattern = config.autoscanDisabledPattern
+
+        if findControl(in: view, matching: disabledPattern) != nil {
+            return .skipped(reason: "Already disabled")
+        }
+
+        guard let autoControl = findControl(in: view, matching: enabledPattern) else {
+            Logger.shared.warning("Scanner: Autoscan control not found")
+            return .controlNotFound(searched: enabledPattern.accessibilityLabels)
+        }
+
+        switch enabledPattern.activationMethod {
+        case .sendActions:
+            autoControl.sendActions(for: .touchUpInside)
+            return .success
+
+        case .tapInnerButton:
+            if let innerButton = autoControl.subviews.first(where: { $0 is UIButton }) as? UIButton {
+                innerButton.sendActions(for: .touchUpInside)
+                return .success
+            }
+            return .activationFailed(reason: "No inner button found")
+
+        case let .openMenuThenTap(menuItemTitle):
+            autoControl.sendActions(for: .touchUpInside)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: config.menuDelay)
+                if let menuItem = findButton(in: view, titleEquals: menuItemTitle) {
+                    menuItem.sendActions(for: .touchUpInside)
+                } else {
+                    Logger.shared.warning("Scanner: Autoscan menu item '\(menuItemTitle)' not found")
+                }
+            }
+            return .success
+        }
+    }
+
+    @MainActor
+    private static func findButton(in view: UIView, matching pattern: ScannerButtonPattern) -> UIButton? {
+        for label in pattern.accessibilityLabels {
+            if let button = findButton(in: view, accessibilityLabelContains: label) {
+                return button
+            }
+        }
+
+        for title in pattern.buttonTitles {
+            if let button = findButton(in: view, titleEquals: title) {
+                return button
+            }
+        }
+
+        return nil
+    }
+
+    @MainActor
+    private static func findControl(in view: UIView, matching pattern: ScannerButtonPattern) -> UIControl? {
+        for label in pattern.accessibilityLabels {
+            if let control = findControl(in: view, accessibilityLabelContains: label) {
+                return control
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func findButton(in view: UIView, accessibilityLabelContains search: String) -> UIButton? {
+        if let button = view as? UIButton,
+           let label = button.accessibilityLabel,
+           label.localizedCaseInsensitiveContains(search)
+        {
+            return button
+        }
+        for subview in view.subviews {
+            if let found = findButton(in: subview, accessibilityLabelContains: search) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func findButton(in view: UIView, titleEquals title: String) -> UIButton? {
+        if let button = view as? UIButton,
+           button.currentTitle == title
+        {
+            return button
+        }
+        for subview in view.subviews {
+            if let found = findButton(in: subview, titleEquals: title) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func findControl(in view: UIView, accessibilityLabelContains search: String) -> UIControl? {
+        if let control = view as? UIControl,
+           let label = control.accessibilityLabel,
+           label.localizedCaseInsensitiveContains(search)
+        {
+            return control
+        }
+        for subview in view.subviews {
+            if let found = findControl(in: subview, accessibilityLabelContains: search) {
+                return found
+            }
+        }
+        return nil
     }
 
     func documentCameraViewController(
@@ -84,5 +331,9 @@ struct DocumentScannerView: UIViewControllerRepresentable {
     return vc
   }
 
-  func updateUIViewController(_: UIViewControllerType, context _: Context) {}
+  func updateUIViewController(_ vc: UIViewControllerType, context: Context) {
+    if let documentVC = vc as? VNDocumentCameraViewController {
+      context.coordinator.configureScanner(documentVC)
+    }
+  }
 }

--- a/swift-paperless/Views/Settings/PreferencesView.swift
+++ b/swift-paperless/Views/Settings/PreferencesView.swift
@@ -27,6 +27,19 @@ struct PreferencesView: View {
         Text(.settings(.showDocumentDetailPropertyBarDescription))
       }
 
+      Section {
+        Toggle(
+          String(localized: .settings(.scannerFlashLabel)),
+          isOn: $appSettings.scannerFlashEnabled
+        )
+        Toggle(
+          String(localized: .settings(.scannerAutoscanLabel)),
+          isOn: $appSettings.scannerAutoscanEnabled
+        )
+      } header: {
+        Text(.settings(.scannerSectionHeader))
+      }
+
       if let biometricName = BiometricLockManager.biometricName {
         Section {
           Toggle(


### PR DESCRIPTION
**Summary**
  - Extracted scanner button patterns into ScannerSettingsConfiguration for centralized,
  version specific configuration
  - Added diagnostic logging that captures the full view hierarchy when scanner settings are
  applied

**Notes**
  - Scanner control matching currently uses English accessibility labels. On non-English iOS
  locales, the controls won't be found and settings will silently not apply. Diagnostic logs
  capture the localized labels, so adding support for other locales is straightforward as users
  report them.
  - The fallback configuration for unknown iOS versions reuses iOS 18 patterns. If they don't
  match, the scanner still works normally just without the custom settings.

**Test plan - verified on my device - iPhone 17 - iOS 26.2.1**
  - Verify flash and autoscan toggles still work on iOS 18 (English)
  - Verify scanner opens and functions normally when controls aren't found (e.g. non-English locale
   or unsupported iOS)
  - Check Console.app logs show view hierarchy diagnostics and setting results