### PR TITLE
feat: make document created date optional and add clearable picker

### DIFF
--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -167,14 +167,14 @@ public struct ProtoDocument: DocumentProtocol, Equatable, Sendable {
   public var documentType: UInt?
   public var correspondent: UInt?
   public var tags: [UInt]
-  public var created: Date
+  public var created: Date?
   public var storagePath: UInt?
 
   public var customFields = CustomFieldRawEntryList()
 
   public init(
     title: String = "", asn: UInt? = nil, documentType: UInt? = nil, correspondent: UInt? = nil,
-    tags: [UInt] = [], created: Date = .now, storagePath: UInt? = nil
+    tags: [UInt] = [], created: Date? = .now, storagePath: UInt? = nil
   ) {
     self.title = title
     self.asn = asn

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -448,10 +448,12 @@ extension ApiRepository: Repository {
       mp.add(name: "correspondent", string: String(corr))
     }
 
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd"
-    let createdStr = formatter.string(from: document.created)
-    mp.add(name: "created", string: createdStr)
+    if let created = document.created {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "yyyy-MM-dd"
+      let createdStr = formatter.string(from: created)
+      mp.add(name: "created", string: createdStr)
+    }
 
     if let dt = document.documentType {
       mp.add(name: "document_type", string: String(dt))

--- a/Networking/Sources/Networking/Api/TransientRepository.swift
+++ b/Networking/Sources/Networking/Api/TransientRepository.swift
@@ -166,7 +166,7 @@ extension TransientRepository: Repository {
       asn: document.asn,
       documentType: document.documentType,
       correspondent: document.correspondent,
-      created: document.created,
+      created: document.created ?? .now,
       tags: document.tags,
       added: .now,
       modified: .now,

--- a/swift-paperless/Views/Filter/ClearableDatePickerView.swift
+++ b/swift-paperless/Views/Filter/ClearableDatePickerView.swift
@@ -9,20 +9,26 @@ import SwiftUI
 
 struct ClearableDatePickerView: View {
   @Binding var value: Date?
+  let title: LocalizedStringResource?
+
+  init(value: Binding<Date?>, title: LocalizedStringResource? = nil) {
+    self._value = value
+    self.title = title
+  }
 
   var body: some View {
     HStack {
+      Text(title ?? "")
+        .frame(maxWidth: .infinity, alignment: .leading)
       if let unwrapped = Binding(unwrapping: $value) {
-        DatePicker(selection: unwrapped, displayedComponents: .date) {
-          Image(systemName: "xmark.circle.fill")
-            .foregroundColor(.secondary)
-            .accessibilityLabel(String(localized: .localizable(.dateClear)))
-            .contentShape(Rectangle())
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .onTapGesture {
-              value = nil
-            }
-        }
+        Image(systemName: "xmark.circle.fill")
+          .foregroundColor(.secondary)
+          .accessibilityLabel(String(localized: .localizable(.dateClear)))
+          .contentShape(Rectangle())
+          .onTapGesture {
+            value = nil
+          }
+        DatePicker(selection: unwrapped, displayedComponents: .date) {}
       } else {
         HStack {
           Image(systemName: "plus.circle.fill")
@@ -36,4 +42,38 @@ struct ClearableDatePickerView: View {
     }
     .animation(.spring, value: value)
   }
+}
+
+private struct ClearableDatePickerPreview: View {
+  @State private var emptyValue: Date?
+  @State private var setValue: Date?
+  @State private var noTitleValue: Date?
+
+  init() {
+    _emptyValue = State(initialValue: nil)
+    _setValue = State(initialValue: Date(timeIntervalSince1970: 0))
+    _noTitleValue = State(initialValue: nil)
+  }
+
+  var body: some View {
+    Form {
+      Section("With Title") {
+        ClearableDatePickerView(
+          value: $emptyValue,
+          title: "No Date Set"
+        )
+        ClearableDatePickerView(
+          value: $setValue,
+          title: "Date Set"
+        )
+      }
+      Section("No Title") {
+        ClearableDatePickerView(value: $noTitleValue)
+      }
+    }
+  }
+}
+
+#Preview("ClearableDatePickerView") {
+  ClearableDatePickerPreview()
 }


### PR DESCRIPTION
Make the `created` field nullable in `DocumentModel`. Update initializers and
state handling to default to `nil` when the user chooses not to include a date.
Add a new `ClearableDatePickerView` that shows an optional date picker with
a clear button and optional title. Replace the old date picker in
`CreateDocumentView` with this component, keeping logic to remember whether a
date was set. Adjust networking code to skip the created field when it is
nil, and update API serialization accordingly. Add preview for the new view.
This removes mandatory date entry, improves UX with a clearable picker,
and keeps data consistency across the app.

Closes https://github.com/paulgessinger/swift-paperless/issues/469