### PR TITLE
feat: Replace element save buttons with SaveButton and enforce permissions

### DIFF
--- a/swift-paperless/Views/DocumentTypeEditView.swift
+++ b/swift-paperless/Views/DocumentTypeEditView.swift
@@ -42,7 +42,7 @@ struct DocumentTypeEditView<Element>: View where Element: DocumentTypeProtocol {
     }
     .toolbar {
       ToolbarItem(placement: .navigationBarTrailing) {
-        Button(saveLabel) {
+        SaveButton(saveLabel) {
           do {
             try onSave?(element)
           } catch {

--- a/swift-paperless/Views/Settings/ManageView.swift
+++ b/swift-paperless/Views/Settings/ManageView.swift
@@ -93,6 +93,7 @@ struct ManageView<Manager>: View where Manager: ManagerProtocol {
 
     var body: some View {
       Manager.EditView(element: element, onSave: onSaveInternal)
+        .disabled(!model.permissions.test(.change))
     }
   }
 
@@ -194,6 +195,9 @@ struct ManageView<Manager>: View where Manager: ManagerProtocol {
               NavigationLink {
                 Edit(model: model, element: element) { element in
                   guard model.permissions.test(.change) else {
+                    Logger.shared.info(
+                      "Silently not saving from edit view: this likely indicates a button is active that shouldn't be"
+                    )
                     return
                   }
 

--- a/swift-paperless/Views/StoragePathEditView.swift
+++ b/swift-paperless/Views/StoragePathEditView.swift
@@ -50,7 +50,8 @@ struct StoragePathEditView<Element>: View where Element: StoragePathProtocol {
 
     .toolbar {
       ToolbarItem(placement: .navigationBarTrailing) {
-        Button(saveLabel) {
+
+        SaveButton(saveLabel) {
           do {
             try onSave?(storagePath)
           } catch {
@@ -71,15 +72,10 @@ extension StoragePathEditView where Element == ProtoStoragePath {
   }
 }
 
-struct EditStoragePath_Previews: PreviewProvider {
-  struct Container: View {
-    @State var path = ProtoStoragePath()
-    var body: some View {
-      StoragePathEditView(element: path, onSave: { _ in })
-    }
-  }
-
-  static var previews: some View {
-    Container()
+#Preview {
+  NavigationStack {
+    StoragePathEditView<ProtoStoragePath>(onSave: { _ in })
+      .navigationBarTitleDisplayMode(.inline)
+      .navigationTitle(Text(.localizable(.storagePathCreateTitle)))
   }
 }


### PR DESCRIPTION
Replace explicit `Button` calls with the reusable `SaveButton` component in
`StoragePathEditView` and `DocumentTypeEditView`. This centralizes the save
logic, improves consistency, and reduces duplication.

Add `.disabled(!model.permissions.test(.change))` to the manager edit view
to prevent UI interaction when the user lacks change permissions.

Include a preview wrapper that uses `NavigationStack` and sets
`navigationTitle`, improving preview ergonomics.

Log an informational message when a disabled edit action is attempted,
helping developers identify unintended UI states.

Fixes https://github.com/paulgessinger/swift-paperless/issues/466