### PR TITLE
refactor: Improve API version detection and support

### DIFF
--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -65,7 +65,7 @@ public class ApiRepository {
     public let backendVersion: Version?
 
   public var effectiveApiVersion: UInt {
-    min(Self.maximumApiVersion, max(Self.minimumApiVersion, apiVersion ?? Self.minimumApiVersion))
+    min(Self.maximumApiVersion, apiVersion ?? Self.maximumApiVersion)
   }
 
   public init(connection: Connection, mode: Mode) async {

--- a/swift-paperless/Localization/Localizable.xcstrings
+++ b/swift-paperless/Localization/Localizable.xcstrings
@@ -8942,49 +8942,49 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Backend'en understøtter ikke den mindste API-version `%u`, som denne version af appen kræver."
+            "value" : "Backend'en understøtter ikke det krævede API-versioninterval `%u`-`%u` som denne version af appen kræver."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Das Backend unterstützt nicht die minimale API-Version `%u`, die diese Version der App benötigt."
+            "value" : "Das Backend unterstützt nicht die erforderliche API-Version `%u`-`%u`, die diese Version der App benötigt."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The backend does not support the minimum API version `%u` that this version of the app requires."
+            "value" : "The backend does not support the required API version range `%u`-`%u`."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le serveur ne supporte pas la version minimale de l'API `%u` que cette version de l'application requiert."
+            "value" : "Le serveur ne supporte pas la plage de versions de l'API requise `%u`-`%u`."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il backend non supporta la versione minima dell'API `%u` richiesta da questa versione dell'applicazione."
+            "value" : "Il backend non supporta l'intervallo di versioni dell'API richiesto `%u`-`%u`."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De backend ondersteunt de minimale API versie `%u` niet die deze versie van de app vereist."
+            "value" : "De backend ondersteunt de vereiste API-versie range `%u`-`%u` niet."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Serwer nie obsługuje wersji API `%u`, której wymaga ta wersja aplikacji."
+            "value" : "Serwer nie obsługuje wymaganego zakresu wersji API `%u`-`%u`."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Arka yüz, uygulamanın bu sürümünün gerektirdiği minimum API sürümünü (`%u`) desteklemiyor."
+            "value" : "Arka yüz, uygulamanın bu sürümünün gerektirdiği API sürüm aralığını (`%u`-`%u`) desteklemiyor."
           }
         }
       }

--- a/swift-paperless/Networking/Error/RequestError+DisplayableError.swift
+++ b/swift-paperless/Networking/Error/RequestError+DisplayableError.swift
@@ -56,7 +56,8 @@ extension RequestError: DisplayableError {
     case .unsupportedVersion:
       raw = String(
         localized: .localizable(
-          .requestErrorUnsupportedVersion(ApiRepository.minimumApiVersion, ApiRepository.maximumApiVersion)))
+          .requestErrorUnsupportedVersion(
+            ApiRepository.minimumApiVersion, ApiRepository.maximumApiVersion)))
 
     case .localNetworkDenied:
       raw = String(localized: .localizable(.requestErrorLocalNetworkDenied))

--- a/swift-paperless/Networking/Error/RequestError+DisplayableError.swift
+++ b/swift-paperless/Networking/Error/RequestError+DisplayableError.swift
@@ -55,7 +55,8 @@ extension RequestError: DisplayableError {
 
     case .unsupportedVersion:
       raw = String(
-        localized: .localizable(.requestErrorUnsupportedVersion(ApiRepository.minimumApiVersion)))
+        localized: .localizable(
+          .requestErrorUnsupportedVersion(ApiRepository.minimumApiVersion, ApiRepository.maximumApiVersion)))
 
     case .localNetworkDenied:
       raw = String(localized: .localizable(.requestErrorLocalNetworkDenied))

--- a/swift-paperless/Networking/Error/RequestError+PresentableError.swift
+++ b/swift-paperless/Networking/Error/RequestError+PresentableError.swift
@@ -14,8 +14,12 @@ extension RequestError: PresentableError {
   var presentation: some View {
     switch self {
     case .unsupportedVersion:
-      Text(.localizable(.requestErrorUnsupportedVersion(ApiRepository.minimumApiVersion)))
-        .bold()
+      Text(
+        .localizable(
+          .requestErrorUnsupportedVersion(
+            ApiRepository.minimumApiVersion, ApiRepository.maximumApiVersion))
+      )
+      .bold()
 
     case .unexpectedStatusCode(let code, let details):
       Text(.localizable(.requestErrorUnexpectedStatusCode(code.description)))

--- a/swift-paperless/Views/Login/LoginViewModel.swift
+++ b/swift-paperless/Views/Login/LoginViewModel.swift
@@ -192,6 +192,59 @@ class LoginViewModel {
     }
   }
 
+  private enum ApiVersionProbeResult {
+    case accepted(UInt)
+    case unsupportedVersion(detail: String?)
+    case unexpectedStatusCode(status: HTTPStatusCode, detail: String?)
+    case invalidResponse
+  }
+
+  private func probeAcceptedApiVersion(
+    using session: URLSession,
+    requestBase: URLRequest
+  ) async throws -> ApiVersionProbeResult {
+    var lastUnsupportedDetail: String?
+
+    for apiVersionInt in stride(
+      from: Int(ApiRepository.maximumApiVersion),
+      through: Int(ApiRepository.minimumApiVersion),
+      by: -1
+    ) {
+      var request = requestBase
+      let apiVersion = UInt(apiVersionInt)
+      request.setValue(
+        "application/json; version=\(apiVersion)", forHTTPHeaderField: "Accept")
+      Logger.api.info("Checking API with version=\(apiVersion, privacy: .public)")
+      Logger.api.debug("Headers for check request: \(request.allHTTPHeaderFields ?? [:])")
+
+      let (data, response) = try await session.getData(for: request)
+
+      guard
+        let httpResponse = response as? HTTPURLResponse,
+        let status = httpResponse.status
+      else {
+        return .invalidResponse
+      }
+
+      // As per https://github.com/paperless-ngx/paperless-ngx/pull/8948#issuecomment-2661515625,
+      // a 405 indicates the version is ok, but the method is not allowed.
+      if status == .methodNotAllowed {
+        return .accepted(apiVersion)
+      }
+
+      let detail = decodeDetails(data)
+
+      switch status {
+      case .notAcceptable:
+        lastUnsupportedDetail = detail
+      default:
+        return .unexpectedStatusCode(status: status, detail: detail)
+      }
+    }
+
+    return .unsupportedVersion(detail: lastUnsupportedDetail)
+  }
+
   func checkUrl(string value: String) async {
     Logger.shared.notice("Checking backend URL \(value)")
     guard !value.isEmpty else {
@@ -214,10 +267,6 @@ class LoginViewModel {
     var request = URLRequest(url: tokenUrl)
     extraHeaders.apply(toRequest: &request)
     request.timeoutInterval = 15
-    request.setValue(
-      "application/json; version=\(ApiRepository.minimumApiVersion)", forHTTPHeaderField: "Accept")
-
-    Logger.api.info("Headers for check request: \(request.allHTTPHeaderFields ?? [:])")
 
     do {
       Logger.shared.info("Checking valid-looking URL \(apiUrl)")
@@ -229,36 +278,33 @@ class LoginViewModel {
         configuration: .default,
         delegate: PaperlessURLSessionDelegate(identity: selectedIdentity),
         delegateQueue: nil)
+      let probeResult = try await probeAcceptedApiVersion(using: session, requestBase: request)
 
-      let (data, response) = try await session.getData(for: request)
+      switch probeResult {
+      case .accepted(let apiVersion):
+        Logger.api.info("Detected backend API version: \(apiVersion)")
+        loginState = .valid
+        await makeOIDCClient()
 
-      guard let httpResponse = response as? HTTPURLResponse, let status = httpResponse.status else {
-        loginState = .error(.request(.invalidResponse))
-        return
-      }
+      case .unsupportedVersion(let lastUnsupportedDetail):
+        Logger.shared.warning(
+          "Backend did not accept any API version in [\(ApiRepository.minimumApiVersion), \(ApiRepository.maximumApiVersion)]\(lastUnsupportedDetail.map { ", last detail: \($0)" } ?? "")"
+        )
+        loginState = .error(.request(.unsupportedVersion))
 
-      // As per https://github.com/paperless-ngx/paperless-ngx/pull/8948#issuecomment-2661515625, a 405 indicates the version is ok, but the method is not allowed
-      guard status == .methodNotAllowed else {
-        let detail = decodeDetails(data)
+      case .unexpectedStatusCode(let status, let detail):
         Logger.shared.warning(
           "Checking API status was not 200 but \(status.rawValue, privacy: .public), detail: \(detail ?? "no detail", privacy: .public)"
         )
-        switch status {
-        case .notAcceptable:
-          loginState = .error(.request(.unsupportedVersion))
-        default:
-          loginState = .error(
-            .request(
-              .unexpectedStatusCode(
-                code: status,
-                detail: detail)))
-        }
-        return
+        loginState = .error(
+          .request(
+            .unexpectedStatusCode(
+              code: status,
+              detail: detail)))
+
+      case .invalidResponse:
+        loginState = .error(.request(.invalidResponse))
       }
-
-      loginState = .valid
-
-      await makeOIDCClient()
     } catch let error where error.isCancellationError {
       // do nothing
       return


### PR DESCRIPTION
This switches to checking version one by one from highest supported to lowest supported. This should help with the now upcoming removal of older API versions in Pngx.