### PR TITLE
fix: include leaf certificate in URLCredential for mTLS

### DIFF
--- a/Networking/Sources/Networking/Api/PaperlessURLSessionDelegate.swift
+++ b/Networking/Sources/Networking/Api/PaperlessURLSessionDelegate.swift
@@ -18,7 +18,7 @@ public final class PaperlessURLSessionDelegate: NSObject, URLSessionTaskDelegate
     {
       Logger.networking.info(
         "URLSessionDelegate initializing with identity: \(pName, privacy: .public)")
-      credential = URLCredential(identity: identity, certificates: nil, persistence: .none)
+      credential = Self.makeCredential(identity: identity)
     } else {
       Logger.networking.info("URLSessionDelegate initializing without identity")
       credential = nil
@@ -27,10 +27,25 @@ public final class PaperlessURLSessionDelegate: NSObject, URLSessionTaskDelegate
 
   public init(identity: TLSIdentity?) {
     if let identity {
-      credential = URLCredential(identity: identity.identity, certificates: nil, persistence: .none)
+      credential = Self.makeCredential(identity: identity.identity)
     } else {
       credential = nil
     }
+  }
+
+  private static func makeCredential(identity: SecIdentity) -> URLCredential {
+    var leafCertificate: SecCertificate?
+    let status = SecIdentityCopyCertificate(identity, &leafCertificate)
+
+    if status == errSecSuccess, let cert = leafCertificate {
+      // Include the leaf certificate so TLS client-auth always sends a non-empty certificate list.
+      return URLCredential(identity: identity, certificates: [cert], persistence: .none)
+    }
+
+    Logger.networking.warning(
+      "Failed to extract leaf certificate from identity (\(status, privacy: .public)); using identity without certificates"
+    )
+    return URLCredential(identity: identity, certificates: nil, persistence: .none)
   }
 
   public func urlSession(_: URLSession, didReceive challenge: URLAuthenticationChallenge) async -> (


### PR DESCRIPTION
Extract the leaf certificate from the SecIdentity and include it in the URLCredential's certificates array. Without this, URLSession may send an empty certificate list in the ClientHello during TLS client-auth, which some servers and proxies (e.g. Pomerium) may not handle gracefully.

I'm trying to protect Paperless-ngx and Home Assistant with mTLS because both apps support it. It works flawlessly for HA, but my identity-aware proxy (Pomerium) rejects SwiftPaperless because it can't find a certificate matching a given SAN. This is the only meaningful difference I could find between the two code bases and it looks plausible that if the matcher fails because of the empty certificate list.