### PR TITLE
refactor: Split task model and prepare for v10 shape

### DIFF
--- a/DataModel/Sources/DataModel/Model/TaskModel.swift
+++ b/DataModel/Sources/DataModel/Model/TaskModel.swift
@@ -38,6 +38,7 @@ public struct PaperlessTask: Model, Identifiable, Hashable, Sendable {
   public var result: String?
   public var acknowledged: Bool
   public var relatedDocument: String?
+  public var duplicateDocumentId: UInt?
 
   public init(
     id: UInt,
@@ -50,7 +51,8 @@ public struct PaperlessTask: Model, Identifiable, Hashable, Sendable {
     status: TaskStatus,
     result: String? = nil,
     acknowledged: Bool,
-    relatedDocument: String? = nil
+    relatedDocument: String? = nil,
+    duplicateDocumentId: UInt? = nil
   ) {
     self.id = id
     self.taskId = taskId
@@ -63,6 +65,7 @@ public struct PaperlessTask: Model, Identifiable, Hashable, Sendable {
     self.result = result
     self.acknowledged = acknowledged
     self.relatedDocument = relatedDocument
+    self.duplicateDocumentId = duplicateDocumentId
   }
 
   public var isActive: Bool {

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -820,7 +820,7 @@ extension ApiRepository: Repository {
       through: taskShape
     ) { data in
       Attempt(TaskShape.v10) {
-        try decoder.decode([ApiTaskV10].self, from: data).map(\.domain)
+        try decoder.decode(ListResponse<ApiTaskV10>.self, from: data).results.map(\.domain)
       }
       Attempt(TaskShape.v9) {
         try decoder.decode([ApiTaskV9].self, from: data).map(\.domain)

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -53,8 +53,6 @@ public class ApiRepository {
   private let urlSession: URLSession
   private let urlSessionDelegate: PaperlessURLSessionDelegate
 
-  private let taskShape = FallbackLatch<TaskShape>()
-
   nonisolated
     private let apiVersion: UInt?
   nonisolated
@@ -815,24 +813,25 @@ extension ApiRepository: Repository {
   }
 
   public func tasks() async throws -> [PaperlessTask] {
-    try await send(
-      endpoint: .tasks(name: .consumeFile, acknowledged: false),
-      through: taskShape
-    ) { data in
-      Attempt(TaskShape.v10) {
-        try decoder.decode(ListResponse<ApiTaskV10>.self, from: data).results.map(\.domain)
-      }
-      Attempt(TaskShape.v9) {
-        try decoder.decode([ApiTaskV9].self, from: data).map(\.domain)
-      }
+    if supports(feature: .taskListEnvelope) {
+      try await send(
+        endpoint: .tasks(name: .consumeFile, acknowledged: false),
+        returns: ListResponse<ApiTaskV10>.self
+      ).results.map(\.domain)
+    } else {
+      try await send(
+        endpoint: .tasks(name: .consumeFile, acknowledged: false),
+        returns: [ApiTaskV9].self
+      ).map(\.domain)
     }
   }
 
   public func task(id: UInt) async throws -> PaperlessTask? {
     do {
-      return try await send(endpoint: .task(id: id), through: taskShape) { data in
-        Attempt(TaskShape.v10) { try decoder.decode(ApiTaskV10.self, from: data).domain }
-        Attempt(TaskShape.v9) { try decoder.decode(ApiTaskV9.self, from: data).domain }
+      if supports(feature: .taskListEnvelope) {
+        return try await send(endpoint: .task(id: id), returns: ApiTaskV10.self).domain
+      } else {
+        return try await send(endpoint: .task(id: id), returns: ApiTaskV9.self).domain
       }
     } catch RequestError.unexpectedStatusCode(code: .notFound, _) {
       return nil

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -53,6 +53,8 @@ public class ApiRepository {
   private let urlSession: URLSession
   private let urlSessionDelegate: PaperlessURLSessionDelegate
 
+  private let taskShape = FallbackLatch<TaskShape>()
+
   nonisolated
     private let apiVersion: UInt?
   nonisolated
@@ -813,18 +815,28 @@ extension ApiRepository: Repository {
   }
 
   public func tasks() async throws -> [PaperlessTask] {
-    let request = try request(.tasks(name: .consumeFile, acknowledged: false))
-
-    do {
-      return try await fetchData(for: request, as: [ApiTask].self).map(\.domain)
-    } catch {
-      Logger.networking.error("Unable to load tasks: \(error)")
-      throw error
+    try await send(
+      endpoint: .tasks(name: .consumeFile, acknowledged: false),
+      through: taskShape
+    ) { data in
+      Attempt(TaskShape.v10) {
+        try decoder.decode([ApiTaskV10].self, from: data).map(\.domain)
+      }
+      Attempt(TaskShape.v9) {
+        try decoder.decode([ApiTaskV9].self, from: data).map(\.domain)
+      }
     }
   }
 
   public func task(id: UInt) async throws -> PaperlessTask? {
-    try await get(ApiTask.self, endpoint: .task(id: id))?.domain
+    do {
+      return try await send(endpoint: .task(id: id), through: taskShape) { data in
+        Attempt(TaskShape.v10) { try decoder.decode(ApiTaskV10.self, from: data).domain }
+        Attempt(TaskShape.v9) { try decoder.decode(ApiTaskV9.self, from: data).domain }
+      }
+    } catch RequestError.unexpectedStatusCode(code: .notFound, _) {
+      return nil
+    }
   }
 
   public func acknowledge(tasks ids: [UInt]) async throws {

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -812,17 +812,27 @@ extension ApiRepository: Repository {
     try await send(.post, endpoint: .uiSettings(), body: UISettingsPayload(settings: settings))
   }
 
-  public func tasks() async throws -> [PaperlessTask] {
+  public func tasks(limit: UInt) async throws -> [PaperlessTask] {
     if supports(feature: .taskListEnvelope) {
-      try await send(
-        endpoint: .tasks(name: .consumeFile, acknowledged: false),
+      return try await send(
+        endpoint: .tasks(name: .consumeFile, acknowledged: false, pageSize: limit),
         returns: ListResponse<ApiTaskV10>.self
       ).results.map(\.domain)
     } else {
-      try await send(
+      // V9 backends do not paginate the tasks endpoint; the limit is ignored.
+      return try await send(
         endpoint: .tasks(name: .consumeFile, acknowledged: false),
         returns: [ApiTaskV9].self
       ).map(\.domain)
+    }
+  }
+
+  public func tasks() throws -> any TaskSource {
+    if supports(feature: .taskListEnvelope) {
+      let initial = try url(.tasks(name: .consumeFile, acknowledged: false, pageSize: 100))
+      return ApiTaskSourceV10(repository: self, initialUrl: initial)
+    } else {
+      return ApiTaskSourceV9(repository: self)
     }
   }
 

--- a/Networking/Sources/Networking/Api/ApiTaskSource.swift
+++ b/Networking/Sources/Networking/Api/ApiTaskSource.swift
@@ -1,0 +1,65 @@
+//
+//  ApiTaskSource.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 03.05.26.
+//
+
+import DataModel
+import Foundation
+
+// V10 backends paginate via the standard ListResponse envelope; we drive the
+// fetch through ApiSequence and map each wire item to its domain type.
+public actor ApiTaskSourceV10: TaskSource {
+  private let sequence: ApiSequence<ApiTaskV10>
+
+  init(repository: ApiRepository, initialUrl: URL) {
+    sequence = ApiSequence<ApiTaskV10>(repository: repository, url: initialUrl)
+  }
+
+  public func fetch(limit: UInt) async throws -> [PaperlessTask] {
+    var batch: [PaperlessTask] = []
+    while UInt(batch.count) < limit {
+      guard let item = try await sequence.next() else { break }
+      batch.append(item.domain)
+    }
+    return batch
+  }
+
+  public func hasMore() async -> Bool {
+    await sequence.hasMore
+  }
+}
+
+// V9 backends serve the full unpaginated array, so we cache the first fetch
+// and serve client-side chunks to keep the UI responsive.
+public actor ApiTaskSourceV9: TaskSource {
+  private let repository: ApiRepository
+
+  private var loaded: [PaperlessTask] = []
+  private var cursor: Int = 0
+  private var fetched: Bool = false
+
+  init(repository: ApiRepository) {
+    self.repository = repository
+  }
+
+  public func fetch(limit: UInt) async throws -> [PaperlessTask] {
+    if !fetched {
+      let request = try await repository.request(
+        .tasks(name: .consumeFile, acknowledged: false))
+      let decoded = try await repository.fetchData(for: request, as: [ApiTaskV9].self)
+      loaded = decoded.map(\.domain)
+      fetched = true
+    }
+    let remaining = loaded.count - cursor
+    let take = Int(min(UInt(remaining), limit))
+    let result = Array(loaded[cursor..<cursor + take])
+    cursor += take
+    return result
+  }
+
+  public func hasMore() async -> Bool {
+    !fetched || cursor < loaded.count
+  }
+}

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -314,7 +314,12 @@ extension Endpoint {
   public static func tasks(name: TaskName? = nil, acknowledged: Bool = false) -> Endpoint {
     var queryItems: [URLQueryItem] = []
     if let name {
+      // https://github.com/paperless-ngx/paperless-ngx/pull/12584 renamed `task_name`
+      // to `task_type`. Send both: pre-#12584 servers read `task_name` and ignore
+      // `task_type`; #12584 servers do the opposite. Values are identical so neither
+      // server can observe a conflict.
       queryItems.append(URLQueryItem(name: "task_name", value: name.rawValue))
+      queryItems.append(URLQueryItem(name: "task_type", value: name.rawValue))
     }
     queryItems.append(URLQueryItem(name: "acknowledged", value: acknowledged ? "true" : "false"))
     return Endpoint(path: "/api/tasks", queryItems: queryItems)

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -311,7 +311,9 @@ extension Endpoint {
 
 // MARK: - Task related endpoints
 extension Endpoint {
-  public static func tasks(name: TaskName? = nil, acknowledged: Bool = false) -> Endpoint {
+  public static func tasks(
+    name: TaskName? = nil, acknowledged: Bool = false, pageSize: UInt = 100_000
+  ) -> Endpoint {
     var queryItems: [URLQueryItem] = []
     if let name {
       // https://github.com/paperless-ngx/paperless-ngx/pull/12584 renamed `task_name`
@@ -322,6 +324,7 @@ extension Endpoint {
       queryItems.append(URLQueryItem(name: "task_type", value: name.rawValue))
     }
     queryItems.append(URLQueryItem(name: "acknowledged", value: acknowledged ? "true" : "false"))
+    queryItems.append(URLQueryItem(name: "page_size", value: String(pageSize)))
     return Endpoint(path: "/api/tasks", queryItems: queryItems)
   }
 

--- a/Networking/Sources/Networking/Api/PreviewRepository.swift
+++ b/Networking/Sources/Networking/Api/PreviewRepository.swift
@@ -50,7 +50,7 @@ public class PreviewRepository: Repository {
   private let documentTypes: [UInt: DocumentType]
   private let correspondents: [UInt: Correspondent]
   private let storagePaths: [UInt: StoragePath]
-  private let tasks: [PaperlessTask]
+  private let storedTasks: [PaperlessTask]
   private let users: [User]
   private let groups: [UserGroup]
   private var notesByDocument: [UInt: [Document.Note]]
@@ -219,7 +219,7 @@ public class PreviewRepository: Repository {
     self.users = users
     self.groups = groups
 
-    tasks = [
+    storedTasks = [
       PaperlessTask(
         id: 2748,
         taskId: UUID(uuidString: "ef16d8fb-c495-4850-92b8-73a64109674e")!,
@@ -442,10 +442,14 @@ public class PreviewRepository: Repository {
   public func users() async -> [User] { users }
   public func groups() async throws -> [UserGroup] { groups }
 
-  public func tasks() async -> [PaperlessTask] { tasks }
+  public func tasks(limit: UInt) async -> [PaperlessTask] {
+    Array(storedTasks.prefix(Int(limit)))
+  }
+
+  public func tasks() throws -> any TaskSource { InMemoryTaskSource(storedTasks) }
   public func task(id _: UInt) async throws -> PaperlessTask? { nil }
 
-  public func task(id: UInt) throws -> PaperlessTask? { tasks.first { $0.id == id } }
+  public func task(id: UInt) throws -> PaperlessTask? { storedTasks.first { $0.id == id } }
 
   public func acknowledge(tasks _: [UInt]) async throws {}
 

--- a/Networking/Sources/Networking/Api/TransientRepository.swift
+++ b/Networking/Sources/Networking/Api/TransientRepository.swift
@@ -12,7 +12,7 @@ public class TransientRepository {
   private var documentTypes: [UInt: DocumentType]
   private var correspondents: [UInt: Correspondent]
   private var storagePaths: [UInt: StoragePath]
-  private var tasks: [PaperlessTask]
+  private var storedTasks: [PaperlessTask]
   private var users: [User]
   private var groups: [UserGroup]
   private var savedViews: [UInt: SavedView]
@@ -40,7 +40,7 @@ public class TransientRepository {
     documentTypes = [:]
     correspondents = [:]
     storagePaths = [:]
-    tasks = []
+    storedTasks = []
     users = []
     groups = []
     savedViews = [:]
@@ -394,20 +394,24 @@ extension TransientRepository: Repository {
 
   // MARK: - Tasks
 
-  public func tasks() async throws -> [PaperlessTask] {
-    tasks
+  public func tasks(limit: UInt) async throws -> [PaperlessTask] {
+    Array(storedTasks.prefix(Int(limit)))
+  }
+
+  public func tasks() throws -> any TaskSource {
+    InMemoryTaskSource(storedTasks)
   }
 
   public func task(id: UInt) async throws -> PaperlessTask? {
-    tasks.first { $0.id == id }
+    storedTasks.first { $0.id == id }
   }
 
   public func acknowledge(tasks ids: [UInt]) async throws {
     for id in ids {
-      if let index = tasks.firstIndex(where: { $0.id == id }) {
-        var task = tasks[index]
+      if let index = storedTasks.firstIndex(where: { $0.id == id }) {
+        var task = storedTasks[index]
         task.acknowledged = true
-        tasks[index] = task
+        storedTasks[index] = task
       }
     }
   }

--- a/Networking/Sources/Networking/Api/Wire/ApiTask.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiTask.swift
@@ -1,6 +1,17 @@
 import DataModel
 import Foundation
 
+// Matches Paperless-ngx duplicate failure messages of the form:
+//   "<file>: Not consuming <file>: It is a duplicate of <other> (#<id>)"
+// A trailing period after the closing paren has been observed in the wild.
+func parseDuplicateDocumentId(from result: String?) -> UInt? {
+  let pattern = /(.*): Not consuming (.*): It is a duplicate of (.*) \(#(\d+)\)\.?/
+  guard let result, let match = try? pattern.wholeMatch(in: result) else {
+    return nil
+  }
+  return UInt(match.4)
+}
+
 struct ApiTaskV9: Codable, Sendable {
   var id: UInt
   var task_id: UUID
@@ -28,7 +39,8 @@ extension ApiTaskV9 {
       status: TaskStatus(rawValue: status) ?? .UNKNOWN,
       result: result,
       acknowledged: acknowledged,
-      relatedDocument: related_document
+      relatedDocument: related_document,
+      duplicateDocumentId: parseDuplicateDocumentId(from: result)
     )
   }
 }
@@ -66,7 +78,8 @@ extension ApiTaskV10 {
       status: normalizedStatus,
       result: result_message,
       acknowledged: acknowledged,
-      relatedDocument: related_document_ids.first.map(String.init)
+      relatedDocument: related_document_ids.first.map(String.init),
+      duplicateDocumentId: parseDuplicateDocumentId(from: result_message)
     )
   }
 }

--- a/Networking/Sources/Networking/Api/Wire/ApiTask.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiTask.swift
@@ -1,7 +1,7 @@
 import DataModel
 import Foundation
 
-struct ApiTask: Codable, Sendable {
+struct ApiTaskV9: Codable, Sendable {
   var id: UInt
   var task_id: UUID
   var task_file_name: String?
@@ -15,7 +15,7 @@ struct ApiTask: Codable, Sendable {
   var related_document: String?
 }
 
-extension ApiTask {
+extension ApiTaskV9 {
   var domain: PaperlessTask {
     PaperlessTask(
       id: id,
@@ -29,6 +29,44 @@ extension ApiTask {
       result: result,
       acknowledged: acknowledged,
       relatedDocument: related_document
+    )
+  }
+}
+
+struct ApiTaskV10: Codable, Sendable {
+  struct InputData: Codable, Sendable {
+    var filename: String?
+  }
+
+  var id: UInt
+  var task_id: UUID
+  var task_type: String
+  var trigger_source: String
+  var status: String
+  var date_created: Date?
+  var date_done: Date?
+  var result_message: String?
+  var input_data: InputData?
+  var related_document_ids: [UInt]
+  var acknowledged: Bool
+}
+
+extension ApiTaskV10 {
+  var domain: PaperlessTask {
+    // v10 sends lowercase status strings; TaskStatus raw values are uppercase.
+    let normalizedStatus = TaskStatus(rawValue: status.uppercased()) ?? .UNKNOWN
+    return PaperlessTask(
+      id: id,
+      taskId: task_id,
+      taskFileName: input_data?.filename,
+      taskName: task_type,
+      dateCreated: date_created,
+      dateDone: date_done,
+      type: trigger_source,
+      status: normalizedStatus,
+      result: result_message,
+      acknowledged: acknowledged,
+      relatedDocument: related_document_ids.first.map(String.init)
     )
   }
 }

--- a/Networking/Sources/Networking/BackendFeature.swift
+++ b/Networking/Sources/Networking/BackendFeature.swift
@@ -46,5 +46,6 @@ public enum BackendFeature {
 // https://github.com/paperless-ngx/paperless-ngx/pull/12584 / API v10, likely v3.0.0
 // Task list / detail endpoint wire shape. Resolved at runtime via FallbackLatch
 // because v2.x backends on the dev branch serve the new shape under API v10
-// while released v2.x backends keep the old one.
+// while released v2.x backends keep the old one. v10 list responses are wrapped
+// in the standard ListResponse envelope; v9 list responses are a top-level array.
 public enum TaskShape: Sendable, Equatable { case v10, v9 }

--- a/Networking/Sources/Networking/BackendFeature.swift
+++ b/Networking/Sources/Networking/BackendFeature.swift
@@ -27,6 +27,11 @@ public enum BackendFeature {
   // https://github.com/paperless-ngx/paperless-ngx/pull/12142 / API v10, likely v3.0.0
   case savedViewPermissions
 
+  // https://github.com/paperless-ngx/paperless-ngx/pull/12584 / API v10, likely v3.0.0
+  // Task list / detail endpoint wire shape: v10 wraps list responses in the
+  // standard ListResponse envelope; older backends return a top-level array.
+  case taskListEnvelope
+
   func isSupported(on backendVersion: Version, api apiVersion: UInt) -> Bool {
     switch self {
     case .nextAsnEndpoint:
@@ -37,15 +42,8 @@ public enum BackendFeature {
       backendVersion >= Version(2, 19, 0)
     case .dateFilterModified, .dateFilterPreviousIntervals:
       backendVersion >= Version(2, 20, 0)
-    case .savedViewNewVisibility, .savedViewPermissions:
+    case .savedViewNewVisibility, .savedViewPermissions, .taskListEnvelope:
       apiVersion >= 10 || backendVersion >= Version(3, 0, 0)
     }
   }
 }
-
-// https://github.com/paperless-ngx/paperless-ngx/pull/12584 / API v10, likely v3.0.0
-// Task list / detail endpoint wire shape. Resolved at runtime via FallbackLatch
-// because v2.x backends on the dev branch serve the new shape under API v10
-// while released v2.x backends keep the old one. v10 list responses are wrapped
-// in the standard ListResponse envelope; v9 list responses are a top-level array.
-public enum TaskShape: Sendable, Equatable { case v10, v9 }

--- a/Networking/Sources/Networking/BackendFeature.swift
+++ b/Networking/Sources/Networking/BackendFeature.swift
@@ -42,3 +42,9 @@ public enum BackendFeature {
     }
   }
 }
+
+// https://github.com/paperless-ngx/paperless-ngx/pull/12584 / API v10, likely v3.0.0
+// Task list / detail endpoint wire shape. Resolved at runtime via FallbackLatch
+// because v2.x backends on the dev branch serve the new shape under API v10
+// while released v2.x backends keep the old one.
+public enum TaskShape: Sendable, Equatable { case v10, v9 }

--- a/Networking/Sources/Networking/NullRepository.swift
+++ b/Networking/Sources/Networking/NullRepository.swift
@@ -120,7 +120,8 @@ public class NullRepository: Repository {
   public func groups() async throws -> [UserGroup] { [] }
 
   public func task(id _: UInt) async throws -> PaperlessTask? { nil }
-  public func tasks() async -> [PaperlessTask] { [] }
+  public func tasks(limit _: UInt) async -> [PaperlessTask] { [] }
+  public func tasks() throws -> any TaskSource { InMemoryTaskSource([]) }
 
   public func acknowledge(tasks _: [UInt]) async throws {}
 

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -161,7 +161,12 @@ public protocol Repository: Sendable {
   func update(settings: UISettingsSettings) async throws
 
   func task(id: UInt) async throws -> PaperlessTask?
-  func tasks() async throws -> [PaperlessTask]
+
+  // Cap to bound decode cost on installations with many unacknowledged tasks.
+  // V10 backends honor the cap server-side; V9 backends serve the full array.
+  func tasks(limit: UInt) async throws -> [PaperlessTask]
+
+  func tasks() throws -> any TaskSource
 
   func acknowledge(tasks: [UInt]) async throws
 
@@ -199,4 +204,27 @@ extension Repository {
 public protocol DocumentSource: Actor {
   func fetch(limit: UInt) async throws -> [Document]
   func hasMore() async -> Bool
+}
+
+// - MARK: TaskSource
+public protocol TaskSource: Actor {
+  func fetch(limit: UInt) async throws -> [PaperlessTask]
+  func hasMore() async -> Bool
+}
+
+public actor InMemoryTaskSource: TaskSource {
+  private var remaining: [PaperlessTask]
+
+  public init(_ tasks: [PaperlessTask]) {
+    remaining = tasks
+  }
+
+  public func fetch(limit: UInt) async -> [PaperlessTask] {
+    let take = Int(min(UInt(remaining.count), limit))
+    let head = Array(remaining.prefix(take))
+    remaining.removeFirst(take)
+    return head
+  }
+
+  public func hasMore() async -> Bool { !remaining.isEmpty }
 }

--- a/Networking/Tests/NetworkingTests/ApiTaskTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiTaskTest.swift
@@ -12,7 +12,7 @@ private let decoder = makeDecoder(tz: tz)
 struct ApiTaskTest {
   @Test func testDecoding() throws {
     let data = try #require(testData("Data/tasks.json"))
-    let tasks = try decoder.decode([ApiTask].self, from: data).map(\.domain)
+    let tasks = try decoder.decode([ApiTaskV9].self, from: data).map(\.domain)
 
     #expect(tasks[0].id == 3438)
     #expect(tasks[0].taskId == UUID(uuidString: "373a38ca-5f44-46f5-9466-32e55e103533"))

--- a/Networking/Tests/NetworkingTests/ApiTaskTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiTaskTest.swift
@@ -51,6 +51,14 @@ struct ApiTaskTest {
     #expect(tasks[4].isActive == true)
   }
 
+  @Test func testDecodingV10Paginated() throws {
+    let data = try #require(testData("Data/tasks_v10_paginated.json"))
+    let tasks = try decoder.decode(ListResponse<ApiTaskV10>.self, from: data).results.map(\.domain)
+    #expect(tasks.count == 2)
+    #expect(tasks[0].id == 2)
+    #expect(tasks[1].id == 1)
+  }
+
   @Test func testDecodingV10() throws {
     let data = try #require(testData("Data/tasks_v10.json"))
     let tasks = try decoder.decode([ApiTaskV10].self, from: data).map(\.domain)

--- a/Networking/Tests/NetworkingTests/ApiTaskTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiTaskTest.swift
@@ -50,4 +50,63 @@ struct ApiTaskTest {
     #expect(tasks[4].result == "Retrying after temporary error")
     #expect(tasks[4].isActive == true)
   }
+
+  @Test func testDecodingV10() throws {
+    let data = try #require(testData("Data/tasks_v10.json"))
+    let tasks = try decoder.decode([ApiTaskV10].self, from: data).map(\.domain)
+
+    #expect(tasks[0].id == 2)
+    #expect(tasks[0].taskId == UUID(uuidString: "07dd974d-be9e-4a2d-9be2-0cbe183a2069"))
+    #expect(tasks[0].taskFileName == "slides-with-plans.pdf")
+    #expect(tasks[0].taskName == "consume_file")
+    #expect(tasks[0].type == "web_ui")
+    #expect(
+      try dateApprox(
+        #require(tasks[0].dateCreated),
+        datetime(year: 2026, month: 4, day: 18, hour: 8, minute: 46, second: 56.306241, tz: tz)))
+    #expect(
+      try dateApprox(
+        #require(tasks[0].dateDone),
+        datetime(year: 2026, month: 4, day: 18, hour: 8, minute: 46, second: 58.981436, tz: tz)))
+    #expect(tasks[0].status == TaskStatus.SUCCESS)
+    #expect(tasks[0].result == "Success. New document id 29 created")
+    #expect(tasks[0].acknowledged == false)
+    #expect(tasks[0].relatedDocument == "29")
+    #expect(tasks[0].isActive == false)
+
+    #expect(tasks[1].id == 1)
+    #expect(tasks[1].taskId == UUID(uuidString: "f15a52a7-5af2-4944-b8b7-5be1a5231096"))
+    #expect(tasks[1].taskFileName == "colliderml_overview.pdf")
+    #expect(tasks[1].status == TaskStatus.PENDING)
+    #expect(tasks[1].dateDone == nil)
+    #expect(tasks[1].result == nil)
+    #expect(tasks[1].relatedDocument == nil)
+    #expect(tasks[1].isActive == true)
+  }
+
+  @Test(arguments: [
+    // Historic form, no trailing period.
+    (
+      "2015-02-01 Form.pdf: Not consuming 2015-02-01 Form.pdf: It is a duplicate of 2015-02-01 Form.pdf (#28)",
+      UInt(28)
+    ),
+    // Observed on a live backend: trailing period after the id.
+    (
+      "2018-11-02 McMillan Quarterly Statement.pdf: Not consuming 2018-11-02 McMillan Quarterly Statement.pdf: It is a duplicate of Quarterly Statement (#1).",
+      UInt(1)
+    ),
+  ])
+  func testDuplicateParsing(result: String, expected: UInt) throws {
+    #expect(parseDuplicateDocumentId(from: result) == expected)
+  }
+
+  @Test(
+    arguments: [
+      nil,
+      "Success. New document id 29 created",
+      "Document processing failed: invalid file format",
+    ] as [String?])
+  func testDuplicateParsingNoMatch(result: String?) throws {
+    #expect(parseDuplicateDocumentId(from: result) == nil)
+  }
 }

--- a/Networking/Tests/NetworkingTests/Data/tasks_v10.json
+++ b/Networking/Tests/NetworkingTests/Data/tasks_v10.json
@@ -1,0 +1,64 @@
+[
+    {
+        "id": 2,
+        "task_id": "07dd974d-be9e-4a2d-9be2-0cbe183a2069",
+        "task_type": "consume_file",
+        "task_type_display": "Consume File",
+        "trigger_source": "web_ui",
+        "trigger_source_display": "Web UI",
+        "status": "success",
+        "status_display": "Success",
+        "date_created": "2026-04-18T07:46:56.306241Z",
+        "date_started": "2026-04-18T07:46:56.313031Z",
+        "date_done": "2026-04-18T07:46:58.981436Z",
+        "duration_seconds": 2.668405,
+        "wait_time_seconds": 0.00679,
+        "input_data": {
+            "filename": "slides-with-plans.pdf",
+            "mime_type": "application/pdf",
+            "overrides": {
+                "filename": "slides-with-plans.pdf",
+                "owner_id": 4,
+                "skip_asn_if_exists": false
+            }
+        },
+        "result_data": {
+            "document_id": 29
+        },
+        "result_message": "Success. New document id 29 created",
+        "related_document_ids": [
+            29
+        ],
+        "acknowledged": false,
+        "owner": 4
+    },
+    {
+        "id": 1,
+        "task_id": "f15a52a7-5af2-4944-b8b7-5be1a5231096",
+        "task_type": "consume_file",
+        "task_type_display": "Consume File",
+        "trigger_source": "web_ui",
+        "trigger_source_display": "Web UI",
+        "status": "pending",
+        "status_display": "Pending",
+        "date_created": "2026-04-18T07:46:17.804764Z",
+        "date_started": null,
+        "date_done": null,
+        "duration_seconds": null,
+        "wait_time_seconds": null,
+        "input_data": {
+            "filename": "colliderml_overview.pdf",
+            "mime_type": "application/pdf",
+            "overrides": {
+                "filename": "colliderml_overview.pdf",
+                "owner_id": 4,
+                "skip_asn_if_exists": false
+            }
+        },
+        "result_data": null,
+        "result_message": null,
+        "related_document_ids": [],
+        "acknowledged": false,
+        "owner": 4
+    }
+]

--- a/Networking/Tests/NetworkingTests/Data/tasks_v10_paginated.json
+++ b/Networking/Tests/NetworkingTests/Data/tasks_v10_paginated.json
@@ -1,0 +1,69 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 2,
+            "task_id": "07dd974d-be9e-4a2d-9be2-0cbe183a2069",
+            "task_type": "consume_file",
+            "task_type_display": "Consume File",
+            "trigger_source": "web_ui",
+            "trigger_source_display": "Web UI",
+            "status": "success",
+            "status_display": "Success",
+            "date_created": "2026-04-18T07:46:56.306241Z",
+            "date_started": "2026-04-18T07:46:56.313031Z",
+            "date_done": "2026-04-18T07:46:58.981436Z",
+            "duration_seconds": 2.668405,
+            "wait_time_seconds": 0.00679,
+            "input_data": {
+                "filename": "slides-with-plans.pdf",
+                "mime_type": "application/pdf",
+                "overrides": {
+                    "filename": "slides-with-plans.pdf",
+                    "owner_id": 4,
+                    "skip_asn_if_exists": false
+                }
+            },
+            "result_data": {
+                "document_id": 29
+            },
+            "result_message": "Success. New document id 29 created",
+            "related_document_ids": [
+                29
+            ],
+            "acknowledged": false,
+            "owner": 4
+        },
+        {
+            "id": 1,
+            "task_id": "f15a52a7-5af2-4944-b8b7-5be1a5231096",
+            "task_type": "consume_file",
+            "task_type_display": "Consume File",
+            "trigger_source": "web_ui",
+            "trigger_source_display": "Web UI",
+            "status": "pending",
+            "status_display": "Pending",
+            "date_created": "2026-04-18T07:46:17.804764Z",
+            "date_started": null,
+            "date_done": null,
+            "duration_seconds": null,
+            "wait_time_seconds": null,
+            "input_data": {
+                "filename": "colliderml_overview.pdf",
+                "mime_type": "application/pdf",
+                "overrides": {
+                    "filename": "colliderml_overview.pdf",
+                    "owner_id": 4,
+                    "skip_asn_if_exists": false
+                }
+            },
+            "result_data": null,
+            "result_message": null,
+            "related_document_ids": [],
+            "acknowledged": false,
+            "owner": 4
+        }
+    ]
+}

--- a/Networking/Tests/NetworkingTests/EndpointTest.swift
+++ b/Networking/Tests/NetworkingTests/EndpointTest.swift
@@ -248,13 +248,19 @@ import Testing
   @Test func testTasksDefault() {
     let endpoint = Endpoint.tasks()
     #expect(endpoint.path == "/api/tasks")
-    #expect(endpoint.queryItems.count == 1)
+    #expect(endpoint.queryItems.count == 2)
     #expect(endpoint.queryItems.contains { $0.name == "acknowledged" && $0.value == "false" })
+    #expect(endpoint.queryItems.contains { $0.name == "page_size" && $0.value == "100000" })
   }
 
   @Test func testTasksAcknowledged() {
     let endpoint = Endpoint.tasks(acknowledged: true)
     #expect(endpoint.queryItems.contains { $0.name == "acknowledged" && $0.value == "true" })
+  }
+
+  @Test func testTasksPageSize() {
+    let endpoint = Endpoint.tasks(pageSize: 250)
+    #expect(endpoint.queryItems.contains { $0.name == "page_size" && $0.value == "250" })
   }
 
   @Test func testTask() {

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,3 +1,4 @@
 - Move JSON decoding to a background branch to not block the UI
 - Fix filter rule count display not taking sorting into account
 - Add loading indicator to search bar when loading
+- Add support for the new task API endpoint coming in v3.0.0 / APIv10

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -2,3 +2,5 @@
 - Fix filter rule count display not taking sorting into account
 - Add loading indicator to search bar when loading
 - Add support for the new task API endpoint coming in v3.0.0 / APIv10
+- Add support for the new task API endpoint coming in v3.0.0 / APIv10
+- Fix freeze when polling tasks on installations with many unacknowledged tasks; the task list now scroll-loads additional pages on demand

--- a/swift-paperless/Document/DocumentStore.swift
+++ b/swift-paperless/Document/DocumentStore.swift
@@ -215,11 +215,17 @@ final class DocumentStore: ObservableObject, Sendable {
     return try await repository.notes(documentId: document.id)
   }
 
+  // Polling fetches a small leading page to bound decode cost when a server
+  // has many unacknowledged tasks. Active and recently-failed tasks are at
+  // the top of the list (sorted by creation date), so this window catches
+  // everything the poller actually consumes (badge count, error events).
+  static let taskPollLimit: UInt = 100
+
   func fetchTasks() async {
     guard (try? checkPermission(.view, for: .paperlessTask)) != nil else {
       return
     }
-    guard let tasks = try? await repository.tasks() else {
+    guard let tasks = try? await repository.tasks(limit: Self.taskPollLimit) else {
       return
     }
     self.tasks = tasks

--- a/swift-paperless/Localization/Tasks.xcstrings
+++ b/swift-paperless/Localization/Tasks.xcstrings
@@ -59,49 +59,49 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Afvis alle"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Alle verwerfen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dismiss all"
+            "value" : "Dismiss visible"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Tout ignorer"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Ignora tutti"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Alles negeren"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Odrzuć wszystkie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "stale",
             "value" : "Tümünü yoksay"
           }
         }

--- a/swift-paperless/Model/Localization/TaskModel+localizedResult.swift
+++ b/swift-paperless/Model/Localization/TaskModel+localizedResult.swift
@@ -13,12 +13,8 @@ extension PaperlessTask {
       return nil
     }
 
-    // @TODO: More sophisticated parsing of errors
-    let fileName = taskFileName ?? String(localized: .tasks(.unknownFileName))
-
-    let duplicatePattern = /(.*): Not consuming (.*): It is a duplicate of (.*) \(#(\d*)\)/
-
-    if (try? duplicatePattern.wholeMatch(in: result)) != nil {
+    if duplicateDocumentId != nil {
+      let fileName = taskFileName ?? String(localized: .tasks(.unknownFileName))
       return String(localized: .tasks(.errorDuplicate(fileName)))
     }
 

--- a/swift-paperless/Views/Tasks/TasksView.swift
+++ b/swift-paperless/Views/Tasks/TasksView.swift
@@ -239,6 +239,68 @@ struct TaskDetailView: View {
   }
 }
 
+@MainActor
+@Observable
+final class TaskListViewModel {
+  var tasks: [PaperlessTask] = []
+  var ready = false
+
+  private weak var store: DocumentStore?
+  private var source: (any TaskSource)?
+  private var exhausted = false
+
+  private let initialBatchSize: UInt = 100
+  private let batchSize: UInt = 100
+  private let fetchMargin = 10
+
+  init(store: DocumentStore) {
+    self.store = store
+  }
+
+  func load() async {
+    guard let store, tasks.isEmpty else { return }
+    do {
+      let source = try store.repository.tasks()
+      self.source = source
+      tasks = try await source.fetch(limit: initialBatchSize)
+      exhausted = await !source.hasMore()
+      ready = true
+    } catch {
+      Logger.shared.error("TaskList failed to load: \(error)")
+      ready = true
+    }
+  }
+
+  func refresh() async {
+    source = nil
+    exhausted = false
+    tasks = []
+    ready = false
+    await load()
+  }
+
+  func fetchMoreIfNeeded(currentIndex: Int) async {
+    guard !exhausted, let source else { return }
+    guard currentIndex >= tasks.count - fetchMargin else { return }
+
+    do {
+      let batch = try await source.fetch(limit: batchSize)
+      if batch.isEmpty {
+        exhausted = true
+        return
+      }
+      tasks.append(contentsOf: batch)
+      exhausted = await !source.hasMore()
+    } catch {
+      Logger.shared.error("TaskList failed to load more: \(error)")
+    }
+  }
+
+  func remove(ids: Set<UInt>) {
+    tasks.removeAll { ids.contains($0.id) }
+  }
+}
+
 struct TasksView: View {
   @State var navPath: [NavigationState]
 
@@ -250,7 +312,7 @@ struct TasksView: View {
 
   var body: some View {
     NavigationStack(path: $navPath) {
-      TaskList(tasks: store.tasks, navPath: $navPath)
+      TaskList(navPath: $navPath)
 
         .navigationTitle(String(localized: .tasks(.title)))
         .navigationBarTitleDisplayMode(.inline)
@@ -265,7 +327,6 @@ struct TasksView: View {
             Text("Empty")
           }
         }
-        .animation(.default, value: store.tasks)
     }
 
     .task {
@@ -275,11 +336,10 @@ struct TasksView: View {
 }
 
 private struct TaskList: View {
-  let tasks: [PaperlessTask]
-
   @Binding var navPath: [NavigationState]
 
   @State private var errorTask: PaperlessTask? = nil
+  @State private var viewModel: TaskListViewModel?
 
   @EnvironmentObject private var store: DocumentStore
   @EnvironmentObject private var errorController: ErrorController
@@ -295,42 +355,50 @@ private struct TaskList: View {
     return fmt
   }
 
-  private var mainList: some View {
-    List(tasks, selection: $selection) { task in
-      NavigationLink(value: NavigationState.task(task)) {
-        VStack(alignment: .leading) {
-          HStack {
-            Text(String(localized: .tasks(.task(String(task.id)))))
-            if let created = task.dateCreated {
-              Text("\(fmt.string(from: created))")
-                .frame(maxWidth: .infinity, alignment: .trailing)
-            }
-          }
-          .foregroundColor(.gray)
+  private func acknowledge(ids: [UInt]) async {
+    do {
+      try await store.acknowledge(tasks: ids)
+      viewModel?.remove(ids: Set(ids))
+    } catch {
+      Logger.shared.error("Error acknowledging \(ids.count) task(s): \(error)")
+      errorController.push(error: error)
+    }
+  }
 
-          let name = task.taskFileName ?? String(localized: .tasks(.unknownFileName))
-          HStack(alignment: .top) {
-            task.status.label
-              .labelStyle(.iconOnly)
-            Text("\(name)")
-          }
-          .bold()
-          .font(.body)
-        }
-
-        .swipeActions(edge: .trailing) {
-          Button {
-            Task {
-              do {
-                try await store.acknowledge(tasks: [task.id])
-              } catch {
-                Logger.shared.error("Error acknowledging task \(task.id): \(error)")
-                errorController.push(error: error)
+  private func mainList(viewModel: TaskListViewModel) -> some View {
+    List(selection: $selection) {
+      ForEach(Array(zip(viewModel.tasks.indices, viewModel.tasks)), id: \.1.id) { idx, task in
+        NavigationLink(value: NavigationState.task(task)) {
+          VStack(alignment: .leading) {
+            HStack {
+              Text(String(localized: .tasks(.task(String(task.id)))))
+              if let created = task.dateCreated {
+                Text("\(fmt.string(from: created))")
+                  .frame(maxWidth: .infinity, alignment: .trailing)
               }
             }
-          } label: {
-            Label(localized: .tasks(.acknowledge), systemImage: "checkmark")
+            .foregroundColor(.gray)
+
+            let name = task.taskFileName ?? String(localized: .tasks(.unknownFileName))
+            HStack(alignment: .top) {
+              task.status.label
+                .labelStyle(.iconOnly)
+              Text("\(name)")
+            }
+            .bold()
+            .font(.body)
           }
+
+          .swipeActions(edge: .trailing) {
+            Button {
+              Task { await acknowledge(ids: [task.id]) }
+            } label: {
+              Label(localized: .tasks(.acknowledge), systemImage: "checkmark")
+            }
+          }
+        }
+        .task {
+          await viewModel.fetchMoreIfNeeded(currentIndex: idx)
         }
       }
     }
@@ -360,8 +428,8 @@ private struct TaskList: View {
         Form {
           NoPermissionsView()
         }
-      } else if !tasks.isEmpty {
-        mainList
+      } else if let viewModel, !viewModel.tasks.isEmpty {
+        mainList(viewModel: viewModel)
       } else {
         Form {
           NoElementsView()
@@ -370,12 +438,20 @@ private struct TaskList: View {
       }
     }
 
+    .task {
+      if viewModel == nil {
+        viewModel = TaskListViewModel(store: store)
+      }
+      await viewModel?.load()
+    }
+
     .refreshable {
       store.startTaskPolling()
+      await viewModel?.refresh()
     }
 
     .animation(.default, value: editMode)
-    .animation(.default, value: store.tasks)
+    .animation(.default, value: viewModel?.tasks ?? [])
 
     .environment(\.editMode, $editMode)
 
@@ -391,29 +467,21 @@ private struct TaskList: View {
           CancelIconButton()
         } else {
           if selection.isEmpty {
+            // Acknowledges only the loaded subset; remaining unacknowledged
+            // tasks past the scroll-load horizon are left for a follow-up pass.
+            let loadedIds = viewModel?.tasks.map(\.id) ?? []
             Button(String(localized: .tasks(.acknowledgeAll)), role: .destructive) {
               Task {
-                do {
-                  try await store.acknowledge(tasks: store.tasks.map(\.id))
-                  editMode = .inactive
-                } catch {
-                  Logger.shared.error("Error dismissing \(store.tasks.count) tasks: \(error)")
-                  errorController.push(error: error)
-                }
+                await acknowledge(ids: loadedIds)
+                editMode = .inactive
               }
             }
+            .disabled(loadedIds.isEmpty)
           } else {
             Button(
               String(localized: .tasks(.acknowledgeN(UInt(selection.count)))), role: .destructive
             ) {
-              Task {
-                do {
-                  try await store.acknowledge(tasks: Array(selection))
-                } catch {
-                  Logger.shared.error("Error dismissing \(selection.count) tasks: \(error)")
-                  errorController.push(error: error)
-                }
-              }
+              Task { await acknowledge(ids: Array(selection)) }
             }
           }
         }
@@ -424,7 +492,7 @@ private struct TaskList: View {
           Button(String(localized: .localizable(.select))) {
             editMode = .active
           }
-          .disabled(tasks.isEmpty)
+          .disabled(viewModel?.tasks.isEmpty ?? true)
         } else {
           Button(String(localized: .localizable(.done))) {
             editMode = .inactive

--- a/swift-paperlessTests/ErrorParsingTest.swift
+++ b/swift-paperlessTests/ErrorParsingTest.swift
@@ -9,14 +9,15 @@ import DataModel
 import Testing
 
 @Test
-func testDuplicateParsing() throws {
+func testDuplicateLocalizedResult() throws {
   let task = PaperlessTask(
     id: 1, taskId: .init(),
     taskFileName: "2015-02-01 Car Garage Health Employee Data Collection Form.pdf", type: "file",
     status: .FAILURE,
     result:
       "2015-02-01 Car Garage Health Employee Data Collection Form.pdf: Not consuming 2015-02-01 Car Garage Health Employee Data Collection Form.pdf: It is a duplicate of 2015-02-01 Car Garage Health Employee Data Collection Form.pdf (#28)",
-    acknowledged: false)
+    acknowledged: false,
+    duplicateDocumentId: 28)
 
   #expect(task.localizedResult == String(localized: .tasks(.errorDuplicate(task.taskFileName!))))
 }


### PR DESCRIPTION
This pull request adds support for the new Paperless-ngx task API endpoint introduced in v3.0.0 (API v10), while maintaining compatibility with the previous v9 API. The networking layer now dynamically determines the correct wire format to use at runtime, and the data model and tests have been updated accordingly. Additionally, duplicate document detection has been improved and is now surfaced in the domain model.

**API Compatibility and Model Updates:**

* Added support for both v9 and v10 task API wire formats by introducing `ApiTaskV9`, `ApiTaskV10`, and the `TaskShape` enum, with runtime fallback logic in `ApiRepository` for fetching tasks and task details. [[1]](diffhunk://#diff-f0918b1347afcd63fa90f692953627c496a8187f2a76e55a8f662ecd2c9465f5L809-R832) [[2]](diffhunk://#diff-59e64a9ab985b2ea407785d9f116b26e9ed295d3e60f4afee4986a0540a248a9L4-R15) [[3]](diffhunk://#diff-59e64a9ab985b2ea407785d9f116b26e9ed295d3e60f4afee4986a0540a248a9L18-R29) [[4]](diffhunk://#diff-59e64a9ab985b2ea407785d9f116b26e9ed295d3e60f4afee4986a0540a248a9L31-R82) [[5]](diffhunk://#diff-74299fda7f4b3e2fd4de486ab47b7e801de5b5758de6e6a68f8821c73c00bd20R45-R51)
* Updated the `PaperlessTask` model to include a new `duplicateDocumentId` property, which is parsed from result messages for both API versions. [[1]](diffhunk://#diff-0d49d45e286538801740d2062fc03cce8944f9f9e5ab99629628133b58ebd967R41) [[2]](diffhunk://#diff-0d49d45e286538801740d2062fc03cce8944f9f9e5ab99629628133b58ebd967L53-R55) [[3]](diffhunk://#diff-0d49d45e286538801740d2062fc03cce8944f9f9e5ab99629628133b58ebd967R68)

**Endpoint and Query Improvements:**

* Modified the `Endpoint.tasks` factory to send both `task_name` and `task_type` parameters for compatibility, and to include a `page_size` parameter (defaulting to 100,000).
* Updated endpoint tests to check for the new query parameters and added tests for custom page sizes.

**Error Handling and Localization:**

* Improved duplicate document error detection in `PaperlessTask.localizedResult` by using the new `duplicateDocumentId` field, resulting in more accurate and maintainable error messages. [[1]](diffhunk://#diff-415f0af9e7979ccee0f3da95c114e16670ca6d6943bcfb69d2353372b39b2dc3L16-L21) [[2]](diffhunk://#diff-659fede737a1da49a8f799348e7920e073df8914b7a1bf568d47e93ac946ed4eL12-R20)

**Tests and Fixtures:**

* Added comprehensive tests and fixture data for both v9 and v10 API responses, including paginated v10 responses and duplicate document parsing. [[1]](diffhunk://#diff-55a944ba0fea1bd992a7fae280e2538e37481978982cbc00b16768d1fe5a418aL15-R15) [[2]](diffhunk://#diff-55a944ba0fea1bd992a7fae280e2538e37481978982cbc00b16768d1fe5a418aR53-R119) [[3]](diffhunk://#diff-8ecfddc996778ce88a2ff43aca1923b1e54919a5aaaf46e5f77296c6014191c4R1-R64) [[4]](diffhunk://#diff-a4fb6d642129ece06d562adc663952e8f45826e2864b28d3817dc05da97437c0R1-R69)

**Changelog:**

* Updated the changelog to note support for the new task API endpoint.


<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #518 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #519 
- <kbd>&nbsp;2&nbsp;</kbd> #524 
- <kbd>&nbsp;1&nbsp;</kbd> #511 
<!-- GitButler Footer Boundary Bottom -->