### PR TITLE
fix: remove primaryAction from DocumentView

### DIFF
--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,3 +1,4 @@
 - Fix task view showing "no elements" while loading
 - Tune visuals for document preview thumbnail fade-in and page indicator
 - Deep links can now open a specific document field for editing, e.g. x-paperless://v1/document/123?edit=tags
+- Drop primary action for the "add document" button in the document list: this didn't work properly

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -295,8 +295,6 @@ struct DocumentView: View {
 
       } label: {
         Label(String(localized: .localizable(.add)), systemImage: "plus")
-      } primaryAction: {
-        showDocumentScanner = true
       }
       .tint(.accent)
     }


### PR DESCRIPTION
This didn’t work with the menu.