### PR TITLE
feat: On-disk document cache

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Common
 import DataModel
 import Foundation
 import Networking
@@ -154,7 +155,27 @@ public final class DocumentStore: ObservableObject, Sendable {
     if let delegate {
       dataLoader.delegate = delegate
     }
-    return ImagePipeline(configuration: .init(dataLoader: dataLoader))
+    var config = ImagePipeline.Configuration(dataLoader: dataLoader)
+    if let cacheURL = sharedThumbnailCacheURL(),
+      let dataCache = try? DataCache(path: cacheURL)
+    {
+      config.dataCache = dataCache
+    }
+    return ImagePipeline(configuration: config)
+  }
+
+  private static func sharedThumbnailCacheURL() -> URL? {
+    guard
+      let container = FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: ContentStore.appGroup)
+    else { return nil }
+    let url = container.appendingPathComponent("Caches/Nuke", isDirectory: true)
+    try? FileManager.default.createDirectory(
+      at: url, withIntermediateDirectories: true)
+    try? FileManager.default.setAttributes(
+      [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+      ofItemAtPath: url.path)
+    return url
   }
 
   public func preloadThumbnail(for document: Document) {

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -84,7 +84,9 @@ public struct StoredConnection: Equatable, Codable, Identifiable, Sendable {
 
   public var connection: Connection {
     get throws {
-      try Connection(url: url, token: token, extraHeaders: extraHeaders, identityName: identity)
+      try Connection(
+        url: url, token: token, extraHeaders: extraHeaders,
+        identityName: identity, serverID: id)
     }
   }
 

--- a/AppShared/Sources/AppShared/Views/NamedShareLink.swift
+++ b/AppShared/Sources/AppShared/Views/NamedShareLink.swift
@@ -6,34 +6,34 @@
 import SwiftUI
 import UIKit
 
-/// Drop-in alternative to SwiftUI `ShareLink(item: URL)` for file URLs where
-/// the on-disk filename and the user-visible name differ. Internally presents
-/// `UIActivityViewController` with `NSItemProvider.suggestedName` set to
-/// `name`, so the share sheet (Save to Files, Mail, AirDrop, …) shows the
-/// human-friendly name without renaming or copying the underlying file.
-public struct NamedShareLink<Label: View>: View {
-  private let url: URL
-  private let name: String
-  private let label: () -> Label
+/// Identifies a file to be shared along with the display name the share
+/// sheet should show ("Save to Files" suggested filename, AirDrop label,
+/// etc.). Conforms to `Identifiable` so it can drive `.sheet(item:)`. A
+/// fresh `id` per construction means tapping the same file twice in a row
+/// re-presents the sheet.
+public struct NamedShareItem: Identifiable, Sendable {
+  public let id = UUID()
+  public let url: URL
+  public let name: String
 
-  @State private var isPresented = false
-
-  public init(
-    url: URL, name: String, @ViewBuilder label: @escaping () -> Label
-  ) {
+  public init(url: URL, name: String) {
     self.url = url
     self.name = name
-    self.label = label
   }
+}
 
-  public var body: some View {
-    Button {
-      isPresented = true
-    } label: {
-      label()
-    }
-    .sheet(isPresented: $isPresented) {
-      NamedShareSheet(url: url, name: name)
+extension View {
+  /// Presents the system share sheet when `item` becomes non-nil, using
+  /// `NSItemProvider.suggestedName` so the share sheet shows the
+  /// caller-supplied display name instead of the URL's last path component.
+  ///
+  /// Attach to a view *outside* any `Menu` — SwiftUI menus flatten their
+  /// content into UIKit menu items and discard `.sheet` modifiers attached
+  /// to those items. The trigger inside the menu is a plain `Button` that
+  /// assigns the item; this modifier is what actually drives the sheet.
+  public func namedShareSheet(item: Binding<NamedShareItem?>) -> some View {
+    sheet(item: item) { item in
+      NamedShareSheet(url: item.url, name: item.name)
     }
   }
 }
@@ -43,11 +43,41 @@ private struct NamedShareSheet: UIViewControllerRepresentable {
   let name: String
 
   func makeUIViewController(context _: Context) -> UIActivityViewController {
-    let provider = NSItemProvider(contentsOf: url) ?? NSItemProvider()
-    provider.suggestedName = name
+    let item = stageForShare(canonical: url, name: name) ?? url
     return UIActivityViewController(
-      activityItems: [provider], applicationActivities: nil)
+      activityItems: [item], applicationActivities: nil)
   }
 
   func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+
+  /// Stages a hardlink to `canonical` under a fresh UUID-d subdirectory of
+  /// `NSTemporaryDirectory()` whose filename matches `name`. The share sheet
+  /// then sees a URL whose `lastPathComponent` is the friendly name — which
+  /// "Save to Files", AirDrop, and friends all respect (unlike
+  /// `NSItemProvider.suggestedName`, which Files specifically ignores).
+  ///
+  /// Hardlink shares an inode with the canonical blob (no data copy); the
+  /// fresh subdirectory means no collision logic; the OS purges
+  /// `NSTemporaryDirectory()`, so no cleanup is needed.
+  private func stageForShare(canonical: URL, name: String) -> URL? {
+    do {
+      let subdir = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+          "Share-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(
+        at: subdir, withIntermediateDirectories: true)
+      let dest = subdir.appendingPathComponent(sanitize(name))
+      try FileManager.default.linkItem(at: canonical, to: dest)
+      return dest
+    } catch {
+      return nil
+    }
+  }
+
+  private func sanitize(_ name: String) -> String {
+    let invalid = CharacterSet(charactersIn: "/\0").union(.controlCharacters)
+    let scrubbed = name.components(separatedBy: invalid).joined()
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return scrubbed.isEmpty ? "document.pdf" : scrubbed
+  }
 }

--- a/AppShared/Sources/AppShared/Views/NamedShareLink.swift
+++ b/AppShared/Sources/AppShared/Views/NamedShareLink.swift
@@ -1,0 +1,53 @@
+//
+//  NamedShareLink.swift
+//  AppShared
+//
+
+import SwiftUI
+import UIKit
+
+/// Drop-in alternative to SwiftUI `ShareLink(item: URL)` for file URLs where
+/// the on-disk filename and the user-visible name differ. Internally presents
+/// `UIActivityViewController` with `NSItemProvider.suggestedName` set to
+/// `name`, so the share sheet (Save to Files, Mail, AirDrop, …) shows the
+/// human-friendly name without renaming or copying the underlying file.
+public struct NamedShareLink<Label: View>: View {
+  private let url: URL
+  private let name: String
+  private let label: () -> Label
+
+  @State private var isPresented = false
+
+  public init(
+    url: URL, name: String, @ViewBuilder label: @escaping () -> Label
+  ) {
+    self.url = url
+    self.name = name
+    self.label = label
+  }
+
+  public var body: some View {
+    Button {
+      isPresented = true
+    } label: {
+      label()
+    }
+    .sheet(isPresented: $isPresented) {
+      NamedShareSheet(url: url, name: name)
+    }
+  }
+}
+
+private struct NamedShareSheet: UIViewControllerRepresentable {
+  let url: URL
+  let name: String
+
+  func makeUIViewController(context _: Context) -> UIActivityViewController {
+    let provider = NSItemProvider(contentsOf: url) ?? NSItemProvider()
+    provider.suggestedName = name
+    return UIActivityViewController(
+      activityItems: [provider], applicationActivities: nil)
+  }
+
+  func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}

--- a/Common/Sources/Common/AppGroup.swift
+++ b/Common/Sources/Common/AppGroup.swift
@@ -1,0 +1,19 @@
+//
+//  AppGroup.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 26.05.26.
+//
+
+import Foundation
+
+/// The single source of truth for the shared app-group identifier used by the
+/// main app, the Share Extension, and any future extensions (e.g. File
+/// Provider) to reach shared containers and `UserDefaults`.
+///
+/// The `.entitlements` files must repeat this literal — Xcode reads them before
+/// any Swift runs — but every Swift call site should reference this constant
+/// rather than hard-coding the string.
+public enum AppGroup {
+  public static let identifier = "group.com.paulgessinger.swift-paperless"
+}

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -165,13 +165,12 @@ public struct ContentStore: Sendable {
     try writeSidecar(
       for: key, modified: modified, suggestedFilename: suggestedFilename)
 
-    let friendlyTarget = friendlyURL(
-      for: key, suggestedFilename: suggestedFilename)
-    if let oldCanonicalInode,
-      FileManager.default.fileExists(atPath: friendlyTarget.path),
-      inode(of: friendlyTarget) == oldCanonicalInode
-    {
-      try? FileManager.default.removeItem(at: friendlyTarget)
+    // Sweep any friendly link still pointing at the *previous* canonical
+    // inode — covers both (i) plain overwrite under the same name and
+    // (ii) a server-side rename where the old name's link would otherwise
+    // be orphaned forever.
+    if let oldCanonicalInode {
+      removeFriendlyLinks(matchingInode: oldCanonicalInode)
     }
 
     let friendly =
@@ -195,13 +194,31 @@ public struct ContentStore: Sendable {
 
   public func delete(_ key: Key) throws {
     let canonical = url(for: key)
-    if let sidecar = readSidecar(for: key) {
-      let friendly = friendlyURL(
-        for: key, suggestedFilename: sidecar.suggestedFilename)
-      try? FileManager.default.removeItem(at: friendly)
-    }
+    // Capture the inode before removing the blob so we can sweep every
+    // friendly link that points at it — including disambiguated names
+    // (`name (docID).ext`) that the sidecar's suggestedFilename alone
+    // cannot tell us about.
+    let canonicalInode = inode(of: canonical)
+
     try? FileManager.default.removeItem(at: canonical)
     try? FileManager.default.removeItem(at: sidecarURL(for: key))
+
+    if let canonicalInode {
+      removeFriendlyLinks(matchingInode: canonicalInode)
+    }
+  }
+
+  /// Removes every entry under `Friendly/` whose underlying inode equals
+  /// the given inode. Bounded by the size of `Friendly/`, which the OS
+  /// keeps small under storage pressure. Best-effort: failures are swallowed.
+  private func removeFriendlyLinks(matchingInode target: NSNumber) {
+    guard
+      let contents = try? FileManager.default.contentsOfDirectory(
+        at: friendlyRoot, includingPropertiesForKeys: nil)
+    else { return }
+    for entry in contents where inode(of: entry) == target {
+      try? FileManager.default.removeItem(at: entry)
+    }
   }
 
   // MARK: - Sidecar

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -1,0 +1,331 @@
+//
+//  ContentStore.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 26.05.26.
+//
+
+import Foundation
+import os
+
+private let log = Logger(
+  subsystem: "com.paulgessinger.swift-paperless", category: "ContentStore")
+
+/// On-disk blob cache keyed by `(serverID, documentRemoteID, versionID, kind)`.
+///
+/// Lives in the app-group container so the Share Extension (and a future
+/// File Provider extension) can read it on a locked device. Files are written
+/// with `.completeUntilFirstUserAuthentication` protection on iOS; on macOS
+/// (host tests) the protection class is a no-op.
+///
+/// `Hit.friendlyURL` is a hardlink under `Caches/ContentStore/Friendly/`
+/// named after the server-provided filename, so consumers like
+/// `UIActivityViewController` show a recognizable name.
+public struct ContentStore: Sendable {
+  public enum Kind: String, Sendable, CaseIterable {
+    case original
+    case archive
+    case thumbnail
+
+    public var fileExtension: String {
+      switch self {
+      case .original, .archive: "pdf"
+      case .thumbnail: "bin"
+      }
+    }
+  }
+
+  public struct Key: Hashable, Sendable {
+    public let serverID: UUID
+    public let documentRemoteID: UInt
+    public let versionID: String
+    public let kind: Kind
+
+    public static let currentVersion = "current"
+
+    public init(
+      serverID: UUID, documentRemoteID: UInt,
+      versionID: String = Key.currentVersion, kind: Kind
+    ) {
+      self.serverID = serverID
+      self.documentRemoteID = documentRemoteID
+      self.versionID = versionID
+      self.kind = kind
+    }
+  }
+
+  public struct Hit: Sendable {
+    public let canonicalURL: URL
+    public let friendlyURL: URL
+    public let suggestedFilename: String
+  }
+
+  public enum StoreError: Error {
+    case appGroupUnavailable(identifier: String)
+  }
+
+  public static let appGroup = AppGroup.identifier
+
+  private let root: URL
+
+  public init(appGroupIdentifier: String = ContentStore.appGroup) throws {
+    guard
+      let container = FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+    else {
+      throw StoreError.appGroupUnavailable(identifier: appGroupIdentifier)
+    }
+    try self.init(root: container)
+  }
+
+  // Test seam: cross-package consumers (e.g. NetworkingTests) construct a
+  // ContentStore rooted at a temp directory rather than an app-group container.
+  public init(root: URL) throws {
+    self.root = root
+    try createDirectory(canonicalRoot)
+    try createDirectory(friendlyRoot)
+  }
+
+  // MARK: - Paths
+
+  private var canonicalRoot: URL {
+    root.appendingPathComponent("Caches/ContentStore", isDirectory: true)
+  }
+
+  private var friendlyRoot: URL {
+    canonicalRoot.appendingPathComponent("Friendly", isDirectory: true)
+  }
+
+  private func directory(for key: Key) -> URL {
+    canonicalRoot
+      .appendingPathComponent(key.serverID.uuidString, isDirectory: true)
+      .appendingPathComponent(String(key.documentRemoteID), isDirectory: true)
+      .appendingPathComponent(key.versionID, isDirectory: true)
+  }
+
+  public func url(for key: Key) -> URL {
+    directory(for: key).appendingPathComponent(
+      "\(key.kind.rawValue).\(key.kind.fileExtension)")
+  }
+
+  private func sidecarURL(for key: Key) -> URL {
+    directory(for: key).appendingPathComponent("\(key.kind.rawValue).meta.json")
+  }
+
+  // MARK: - Operations
+
+  public func exists(_ key: Key) -> Bool {
+    FileManager.default.fileExists(atPath: url(for: key).path)
+  }
+
+  public func read(_ key: Key, freshAgainst modified: Date?) -> Hit? {
+    let canonical = url(for: key)
+    guard FileManager.default.fileExists(atPath: canonical.path) else {
+      return nil
+    }
+    guard let sidecar = readSidecar(for: key) else { return nil }
+    guard staleness(sidecar.modified, matches: modified) else { return nil }
+
+    let friendly =
+      (try? materializeFriendlyLink(
+        for: key,
+        suggestedFilename: sidecar.suggestedFilename,
+        canonical: canonical)) ?? canonical
+
+    return Hit(
+      canonicalURL: canonical,
+      friendlyURL: friendly,
+      suggestedFilename: sidecar.suggestedFilename)
+  }
+
+  @discardableResult
+  public func store(
+    _ key: Key,
+    movingFrom tempURL: URL,
+    modified: Date?,
+    suggestedFilename: String
+  ) throws -> Hit {
+    let directory = directory(for: key)
+    try createDirectory(directory)
+    let canonical = url(for: key)
+
+    // Capture old inode before overwriting so we can recognize stale friendly
+    // links that still point at our previous blob and remove them. A friendly
+    // link pointing at a *different* doc's blob is a collision (handled by
+    // materializeFriendlyLink via disambiguation), not ours to clear.
+    let oldCanonicalInode = inode(of: canonical)
+
+    if FileManager.default.fileExists(atPath: canonical.path) {
+      _ = try FileManager.default.replaceItemAt(canonical, withItemAt: tempURL)
+    } else {
+      try FileManager.default.moveItem(at: tempURL, to: canonical)
+    }
+    applyFileProtection(canonical)
+
+    try writeSidecar(
+      for: key, modified: modified, suggestedFilename: suggestedFilename)
+
+    let friendlyTarget = friendlyURL(
+      for: key, suggestedFilename: suggestedFilename)
+    if let oldCanonicalInode,
+      FileManager.default.fileExists(atPath: friendlyTarget.path),
+      inode(of: friendlyTarget) == oldCanonicalInode
+    {
+      try? FileManager.default.removeItem(at: friendlyTarget)
+    }
+
+    let friendly =
+      (try? materializeFriendlyLink(
+        for: key,
+        suggestedFilename: suggestedFilename,
+        canonical: canonical)) ?? canonical
+
+    return Hit(
+      canonicalURL: canonical,
+      friendlyURL: friendly,
+      suggestedFilename: suggestedFilename)
+  }
+
+  private func inode(of url: URL) -> NSNumber? {
+    guard
+      let attr = try? FileManager.default.attributesOfItem(atPath: url.path)
+    else { return nil }
+    return attr[.systemFileNumber] as? NSNumber
+  }
+
+  public func delete(_ key: Key) throws {
+    let canonical = url(for: key)
+    if let sidecar = readSidecar(for: key) {
+      let friendly = friendlyURL(
+        for: key, suggestedFilename: sidecar.suggestedFilename)
+      try? FileManager.default.removeItem(at: friendly)
+    }
+    try? FileManager.default.removeItem(at: canonical)
+    try? FileManager.default.removeItem(at: sidecarURL(for: key))
+  }
+
+  // MARK: - Sidecar
+
+  private struct Sidecar: Codable {
+    var modified: Date?
+    var suggestedFilename: String
+    var writtenAt: Date
+  }
+
+  private func writeSidecar(
+    for key: Key, modified: Date?, suggestedFilename: String
+  ) throws {
+    let sidecar = Sidecar(
+      modified: modified, suggestedFilename: suggestedFilename,
+      writtenAt: Date())
+    let encoder = JSONEncoder()
+    // Encode dates as numeric time intervals (JSONEncoder's default strategy),
+    // NOT ISO-8601: `.iso8601` truncates to whole seconds, but paperless
+    // `modified` timestamps carry sub-second precision. A truncated sidecar
+    // would never equal the live `document.modified`, so `read(_:freshAgainst:)`
+    // would miss on every lookup and the cache would never serve a hit. A
+    // numeric interval round-trips exactly.
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(sidecar)
+    let url = sidecarURL(for: key)
+    try data.write(to: url, options: .atomic)
+    applyFileProtection(url)
+  }
+
+  private func readSidecar(for key: Key) -> Sidecar? {
+    let url = sidecarURL(for: key)
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    // Matches writeSidecar's numeric date encoding (JSONDecoder's default).
+    return try? JSONDecoder().decode(Sidecar.self, from: data)
+  }
+
+  private func staleness(_ sidecar: Date?, matches arg: Date?) -> Bool {
+    switch (sidecar, arg) {
+    case (nil, nil): true
+    case (let l?, let r?): l == r
+    default: false
+    }
+  }
+
+  // MARK: - Friendly link
+
+  private func friendlyURL(for key: Key, suggestedFilename: String) -> URL {
+    let sanitized = sanitize(filename: suggestedFilename, kind: key.kind)
+    return friendlyRoot.appendingPathComponent(sanitized)
+  }
+
+  private func materializeFriendlyLink(
+    for key: Key, suggestedFilename: String, canonical: URL
+  ) throws -> URL {
+    var friendly = friendlyURL(
+      for: key, suggestedFilename: suggestedFilename)
+    let manager = FileManager.default
+
+    if manager.fileExists(atPath: friendly.path) {
+      if sameInode(friendly, canonical) {
+        return friendly
+      }
+      // Different inode at the friendly path means a *different* document
+      // hashed to the same filename. Disambiguate by appending the doc ID.
+      friendly = disambiguatedFriendlyURL(for: friendly, key: key)
+      if manager.fileExists(atPath: friendly.path) {
+        if sameInode(friendly, canonical) {
+          return friendly
+        }
+        try? manager.removeItem(at: friendly)
+      }
+    }
+
+    try manager.linkItem(at: canonical, to: friendly)
+    return friendly
+  }
+
+  private func sameInode(_ a: URL, _ b: URL) -> Bool {
+    guard let aI = inode(of: a), let bI = inode(of: b) else { return false }
+    return aI == bI
+  }
+
+  private func disambiguatedFriendlyURL(for url: URL, key: Key) -> URL {
+    let ext = url.pathExtension
+    let base = url.deletingPathExtension().lastPathComponent
+    let newName =
+      ext.isEmpty
+      ? "\(base) (\(key.documentRemoteID))"
+      : "\(base) (\(key.documentRemoteID)).\(ext)"
+    return url.deletingLastPathComponent().appendingPathComponent(newName)
+  }
+
+  private func sanitize(filename: String, kind: Kind) -> String {
+    let invalid = CharacterSet(charactersIn: "/\0").union(.controlCharacters)
+    let scrubbed =
+      filename
+      .components(separatedBy: invalid).joined()
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    if scrubbed.isEmpty {
+      return "\(kind.rawValue).\(kind.fileExtension)"
+    }
+    return scrubbed
+  }
+
+  // MARK: - Filesystem helpers
+
+  private func createDirectory(_ url: URL) throws {
+    try FileManager.default.createDirectory(
+      at: url, withIntermediateDirectories: true)
+    applyFileProtection(url)
+  }
+
+  private func applyFileProtection(_ url: URL) {
+    #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || targetEnvironment(macCatalyst)
+      do {
+        try FileManager.default.setAttributes(
+          [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+          ofItemAtPath: url.path)
+      } catch {
+        log.debug(
+          "Could not set file protection on \(url.path, privacy: .public): \(error)"
+        )
+      }
+    #endif
+  }
+}

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -18,9 +18,10 @@ private let log = Logger(
 /// with `.completeUntilFirstUserAuthentication` protection on iOS; on macOS
 /// (host tests) the protection class is a no-op.
 ///
-/// `Hit.friendlyURL` is a hardlink under `Caches/ContentStore/Friendly/`
-/// named after the server-provided filename, so consumers like
-/// `UIActivityViewController` show a recognizable name.
+/// Returns canonical paths only; consumers that need to show the user a
+/// recognizable filename (e.g. the share sheet) use a separate display name
+/// from `Document.archivedFileName` / `Document.originalFileName` and pass it
+/// to `UIActivityViewController` via `NSItemProvider.suggestedName`.
 public struct ContentStore: Sendable {
   public enum Kind: String, Sendable, CaseIterable {
     case original
@@ -54,12 +55,6 @@ public struct ContentStore: Sendable {
     }
   }
 
-  public struct Hit: Sendable {
-    public let canonicalURL: URL
-    public let friendlyURL: URL
-    public let suggestedFilename: String
-  }
-
   public enum StoreError: Error {
     case appGroupUnavailable(identifier: String)
   }
@@ -83,17 +78,12 @@ public struct ContentStore: Sendable {
   public init(root: URL) throws {
     self.root = root
     try createDirectory(canonicalRoot)
-    try createDirectory(friendlyRoot)
   }
 
   // MARK: - Paths
 
   private var canonicalRoot: URL {
     root.appendingPathComponent("Caches/ContentStore", isDirectory: true)
-  }
-
-  private var friendlyRoot: URL {
-    canonicalRoot.appendingPathComponent("Friendly", isDirectory: true)
   }
 
   private func directory(for key: Key) -> URL {
@@ -118,42 +108,24 @@ public struct ContentStore: Sendable {
     FileManager.default.fileExists(atPath: url(for: key).path)
   }
 
-  public func read(_ key: Key, freshAgainst modified: Date?) -> Hit? {
+  /// Returns the canonical URL if the blob exists and the sidecar's
+  /// `modified` matches the passed value. Both-nil counts as fresh.
+  public func read(_ key: Key, freshAgainst modified: Date?) -> URL? {
     let canonical = url(for: key)
-    guard FileManager.default.fileExists(atPath: canonical.path) else {
-      return nil
-    }
-    guard let sidecar = readSidecar(for: key) else { return nil }
-    guard staleness(sidecar.modified, matches: modified) else { return nil }
-
-    let friendly =
-      (try? materializeFriendlyLink(
-        for: key,
-        suggestedFilename: sidecar.suggestedFilename,
-        canonical: canonical)) ?? canonical
-
-    return Hit(
-      canonicalURL: canonical,
-      friendlyURL: friendly,
-      suggestedFilename: sidecar.suggestedFilename)
+    guard FileManager.default.fileExists(atPath: canonical.path),
+      let sidecar = readSidecar(for: key),
+      staleness(sidecar.modified, matches: modified)
+    else { return nil }
+    return canonical
   }
 
   @discardableResult
   public func store(
-    _ key: Key,
-    movingFrom tempURL: URL,
-    modified: Date?,
-    suggestedFilename: String
-  ) throws -> Hit {
+    _ key: Key, movingFrom tempURL: URL, modified: Date?
+  ) throws -> URL {
     let directory = directory(for: key)
     try createDirectory(directory)
     let canonical = url(for: key)
-
-    // Capture old inode before overwriting so we can recognize stale friendly
-    // links that still point at our previous blob and remove them. A friendly
-    // link pointing at a *different* doc's blob is a collision (handled by
-    // materializeFriendlyLink via disambiguation), not ours to clear.
-    let oldCanonicalInode = inode(of: canonical)
 
     if FileManager.default.fileExists(atPath: canonical.path) {
       _ = try FileManager.default.replaceItemAt(canonical, withItemAt: tempURL)
@@ -162,79 +134,24 @@ public struct ContentStore: Sendable {
     }
     applyFileProtection(canonical)
 
-    try writeSidecar(
-      for: key, modified: modified, suggestedFilename: suggestedFilename)
-
-    // Sweep any friendly link still pointing at the *previous* canonical
-    // inode — covers both (i) plain overwrite under the same name and
-    // (ii) a server-side rename where the old name's link would otherwise
-    // be orphaned forever.
-    if let oldCanonicalInode {
-      removeFriendlyLinks(matchingInode: oldCanonicalInode)
-    }
-
-    let friendly =
-      (try? materializeFriendlyLink(
-        for: key,
-        suggestedFilename: suggestedFilename,
-        canonical: canonical)) ?? canonical
-
-    return Hit(
-      canonicalURL: canonical,
-      friendlyURL: friendly,
-      suggestedFilename: suggestedFilename)
-  }
-
-  private func inode(of url: URL) -> NSNumber? {
-    guard
-      let attr = try? FileManager.default.attributesOfItem(atPath: url.path)
-    else { return nil }
-    return attr[.systemFileNumber] as? NSNumber
+    try writeSidecar(for: key, modified: modified)
+    return canonical
   }
 
   public func delete(_ key: Key) throws {
-    let canonical = url(for: key)
-    // Capture the inode before removing the blob so we can sweep every
-    // friendly link that points at it — including disambiguated names
-    // (`name (docID).ext`) that the sidecar's suggestedFilename alone
-    // cannot tell us about.
-    let canonicalInode = inode(of: canonical)
-
-    try? FileManager.default.removeItem(at: canonical)
+    try? FileManager.default.removeItem(at: url(for: key))
     try? FileManager.default.removeItem(at: sidecarURL(for: key))
-
-    if let canonicalInode {
-      removeFriendlyLinks(matchingInode: canonicalInode)
-    }
-  }
-
-  /// Removes every entry under `Friendly/` whose underlying inode equals
-  /// the given inode. Bounded by the size of `Friendly/`, which the OS
-  /// keeps small under storage pressure. Best-effort: failures are swallowed.
-  private func removeFriendlyLinks(matchingInode target: NSNumber) {
-    guard
-      let contents = try? FileManager.default.contentsOfDirectory(
-        at: friendlyRoot, includingPropertiesForKeys: nil)
-    else { return }
-    for entry in contents where inode(of: entry) == target {
-      try? FileManager.default.removeItem(at: entry)
-    }
   }
 
   // MARK: - Sidecar
 
   private struct Sidecar: Codable {
     var modified: Date?
-    var suggestedFilename: String
     var writtenAt: Date
   }
 
-  private func writeSidecar(
-    for key: Key, modified: Date?, suggestedFilename: String
-  ) throws {
-    let sidecar = Sidecar(
-      modified: modified, suggestedFilename: suggestedFilename,
-      writtenAt: Date())
+  private func writeSidecar(for key: Key, modified: Date?) throws {
+    let sidecar = Sidecar(modified: modified, writtenAt: Date())
     let encoder = JSONEncoder()
     // Encode dates as numeric time intervals (JSONEncoder's default strategy),
     // NOT ISO-8601: `.iso8601` truncates to whole seconds, but paperless
@@ -262,66 +179,6 @@ public struct ContentStore: Sendable {
     case (let l?, let r?): l == r
     default: false
     }
-  }
-
-  // MARK: - Friendly link
-
-  private func friendlyURL(for key: Key, suggestedFilename: String) -> URL {
-    let sanitized = sanitize(filename: suggestedFilename, kind: key.kind)
-    return friendlyRoot.appendingPathComponent(sanitized)
-  }
-
-  private func materializeFriendlyLink(
-    for key: Key, suggestedFilename: String, canonical: URL
-  ) throws -> URL {
-    var friendly = friendlyURL(
-      for: key, suggestedFilename: suggestedFilename)
-    let manager = FileManager.default
-
-    if manager.fileExists(atPath: friendly.path) {
-      if sameInode(friendly, canonical) {
-        return friendly
-      }
-      // Different inode at the friendly path means a *different* document
-      // hashed to the same filename. Disambiguate by appending the doc ID.
-      friendly = disambiguatedFriendlyURL(for: friendly, key: key)
-      if manager.fileExists(atPath: friendly.path) {
-        if sameInode(friendly, canonical) {
-          return friendly
-        }
-        try? manager.removeItem(at: friendly)
-      }
-    }
-
-    try manager.linkItem(at: canonical, to: friendly)
-    return friendly
-  }
-
-  private func sameInode(_ a: URL, _ b: URL) -> Bool {
-    guard let aI = inode(of: a), let bI = inode(of: b) else { return false }
-    return aI == bI
-  }
-
-  private func disambiguatedFriendlyURL(for url: URL, key: Key) -> URL {
-    let ext = url.pathExtension
-    let base = url.deletingPathExtension().lastPathComponent
-    let newName =
-      ext.isEmpty
-      ? "\(base) (\(key.documentRemoteID))"
-      : "\(base) (\(key.documentRemoteID)).\(ext)"
-    return url.deletingLastPathComponent().appendingPathComponent(newName)
-  }
-
-  private func sanitize(filename: String, kind: Kind) -> String {
-    let invalid = CharacterSet(charactersIn: "/\0").union(.controlCharacters)
-    let scrubbed =
-      filename
-      .components(separatedBy: invalid).joined()
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    if scrubbed.isEmpty {
-      return "\(kind.rawValue).\(kind.fileExtension)"
-    }
-    return scrubbed
   }
 
   // MARK: - Filesystem helpers

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -8,9 +8,6 @@
 import Foundation
 import os
 
-private let log = Logger(
-  subsystem: "com.paulgessinger.swift-paperless", category: "ContentStore")
-
 /// On-disk blob cache keyed by `(serverID, documentRemoteID, versionID, kind)`.
 ///
 /// Lives in the app-group container so the Share Extension (and a future
@@ -196,7 +193,7 @@ public struct ContentStore: Sendable {
           [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
           ofItemAtPath: url.path)
       } catch {
-        log.debug(
+        Logger.cache.debug(
           "Could not set file protection on \(url.path, privacy: .public): \(error)"
         )
       }

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -105,13 +105,19 @@ public struct ContentStore: Sendable {
     FileManager.default.fileExists(atPath: url(for: key).path)
   }
 
-  /// Returns the canonical URL if the blob exists and the sidecar's
-  /// `modified` matches the passed value. Both-nil counts as fresh.
+  /// Returns the canonical URL if the blob exists, the sidecar is present,
+  /// and the sidecar's `modified` equals the passed value.
+  ///
+  /// A nil `modified` (either side) is treated as "no staleness signal" and
+  /// returns nil — the cache will not serve a hit without a positive
+  /// validity check. Callers that genuinely have no timestamp should bypass
+  /// the cache entirely rather than calling `read` with nil.
   public func read(_ key: Key, freshAgainst modified: Date?) -> URL? {
+    guard let modified else { return nil }
     let canonical = url(for: key)
     guard FileManager.default.fileExists(atPath: canonical.path),
       let sidecar = readSidecar(for: key),
-      staleness(sidecar.modified, matches: modified)
+      sidecar.modified == modified
     else { return nil }
     return canonical
   }
@@ -168,14 +174,6 @@ public struct ContentStore: Sendable {
     guard let data = try? Data(contentsOf: url) else { return nil }
     // Matches writeSidecar's numeric date encoding (JSONDecoder's default).
     return try? JSONDecoder().decode(Sidecar.self, from: data)
-  }
-
-  private func staleness(_ sidecar: Date?, matches arg: Date?) -> Bool {
-    switch (sidecar, arg) {
-    case (nil, nil): true
-    case (let l?, let r?): l == r
-    default: false
-    }
   }
 
   // MARK: - Filesystem helpers

--- a/Common/Sources/Common/Logging.swift
+++ b/Common/Sources/Common/Logging.swift
@@ -2,4 +2,5 @@ import os
 
 extension Logger {
   static let common = Logger(subsystem: "com.paulgessinger.swift-paperless", category: "Common")
+  static let cache = Logger(subsystem: "com.paulgessinger.swift-paperless", category: "Cache")
 }

--- a/Common/Sources/Common/URLSession+download.swift
+++ b/Common/Sources/Common/URLSession+download.swift
@@ -1,0 +1,47 @@
+//
+//  URLSession+download.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 26.05.26.
+//
+
+import Foundation
+
+extension URLSession {
+  /// Streams the response of `request` to a temp file on disk and reports
+  /// progress via KVO on `URLSessionTask.progress`. Mirrors the shape of
+  /// `getData(for:progress:)` so callers can swap them with no API churn.
+  ///
+  /// The returned URL points into the system temp directory and is owned by
+  /// the caller — `URLSession` deletes it once the delegate method returns,
+  /// so the caller MUST move or replace it before this method returns.
+  /// Background `URLSession`s only support download/upload tasks (not `data`),
+  /// so this shape is also what a future background sync engine will need.
+  public nonisolated func getDownload(
+    for request: URLRequest, progress: (@Sendable (Double) -> Void)?
+  ) async throws -> (URL, URLResponse) {
+    final class Delegate: NSObject, URLSessionTaskDelegate {
+      let callback: (@Sendable (Double) -> Void)?
+
+      @MainActor
+      private var progressObservation: NSKeyValueObservation? = nil
+
+      init(_ callback: (@Sendable (Double) -> Void)? = nil) {
+        self.callback = callback
+      }
+
+      func urlSession(_: URLSession, didCreateTask task: URLSessionTask) {
+        Task { @MainActor in
+          let callback = callback
+          progressObservation = task.progress.observe(\.fractionCompleted) {
+            progress, _ in
+            callback?(progress.fractionCompleted)
+          }
+        }
+      }
+    }
+
+    let delegate = Delegate(progress)
+    return try await download(for: request, delegate: delegate)
+  }
+}

--- a/Common/Sources/Common/UserDefaults.swift
+++ b/Common/Sources/Common/UserDefaults.swift
@@ -13,7 +13,7 @@ let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "UserDef
 
 extension UserDefaults {
   @MainActor
-  public static let group = UserDefaults(suiteName: "group.com.paulgessinger.swift-paperless")!
+  public static let group = UserDefaults(suiteName: AppGroup.identifier)!
 
   public func load<Value>(_: Value.Type, key: String, storage: UserDefaults = .standard) throws
     -> Value? where Value: Decodable

--- a/Common/Tests/CommonTests/ContentStoreTests.swift
+++ b/Common/Tests/CommonTests/ContentStoreTests.swift
@@ -51,37 +51,29 @@ struct ContentStoreTests {
   }
 
   @Test
-  func storeWritesBlobAndReturnsHit() throws {
+  func storeWritesBlobAtCanonicalPath() throws {
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("hello".utf8))
 
-    let hit = try store.store(
+    let url = try store.store(
       Self.key(), movingFrom: temp,
-      modified: Date(timeIntervalSince1970: 1000),
-      suggestedFilename: "invoice.pdf")
+      modified: Date(timeIntervalSince1970: 1000))
 
-    #expect(FileManager.default.fileExists(atPath: hit.canonicalURL.path))
-    #expect(FileManager.default.fileExists(atPath: hit.friendlyURL.path))
-    #expect(hit.friendlyURL.lastPathComponent == "invoice.pdf")
-    #expect(try Data(contentsOf: hit.canonicalURL) == Data("hello".utf8))
-    #expect(try Data(contentsOf: hit.friendlyURL) == Data("hello".utf8))
+    #expect(url == store.url(for: Self.key()))
+    #expect(try Data(contentsOf: url) == Data("hello".utf8))
   }
 
   @Test
-  func readReturnsHitWhenModifiedMatches() throws {
+  func readReturnsURLWhenModifiedMatches() throws {
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))
     // Sub-second precision on purpose: paperless `modified` timestamps carry
     // fractional seconds. If the sidecar dropped them (e.g. ISO-8601 whole-
     // second encoding), this read would miss and the cache would never hit.
     let modified = Date(timeIntervalSince1970: 1234.567891)
-    try store.store(
-      Self.key(), movingFrom: temp, modified: modified,
-      suggestedFilename: "a.pdf")
+    try store.store(Self.key(), movingFrom: temp, modified: modified)
 
-    let hit = store.read(Self.key(), freshAgainst: modified)
-    #expect(hit != nil)
-    #expect(hit?.suggestedFilename == "a.pdf")
+    #expect(store.read(Self.key(), freshAgainst: modified) != nil)
   }
 
   @Test
@@ -90,8 +82,7 @@ struct ContentStoreTests {
     let temp = try Self.writeTempFile(Data("x".utf8))
     try store.store(
       Self.key(), movingFrom: temp,
-      modified: Date(timeIntervalSince1970: 1),
-      suggestedFilename: "a.pdf")
+      modified: Date(timeIntervalSince1970: 1))
 
     #expect(
       store.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 2))
@@ -99,12 +90,10 @@ struct ContentStoreTests {
   }
 
   @Test
-  func readReturnsHitWhenBothNil() throws {
+  func readReturnsURLWhenBothNil() throws {
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))
-    try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "a.pdf")
+    try store.store(Self.key(), movingFrom: temp, modified: nil)
     #expect(store.read(Self.key(), freshAgainst: nil) != nil)
   }
 
@@ -114,206 +103,60 @@ struct ContentStoreTests {
     let temp = try Self.writeTempFile(Data("x".utf8))
     try store.store(
       Self.key(), movingFrom: temp,
-      modified: Date(timeIntervalSince1970: 1),
-      suggestedFilename: "a.pdf")
+      modified: Date(timeIntervalSince1970: 1))
     #expect(store.read(Self.key(), freshAgainst: nil) == nil)
 
     let (store2, _) = try Self.makeStore()
     let temp2 = try Self.writeTempFile(Data("x".utf8))
-    try store2.store(
-      Self.key(), movingFrom: temp2, modified: nil,
-      suggestedFilename: "a.pdf")
+    try store2.store(Self.key(), movingFrom: temp2, modified: nil)
     #expect(
       store2.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 1))
         == nil)
   }
 
   @Test
+  func readReturnsNilWhenSidecarMissing() throws {
+    let (store, root) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    let url = try store.store(Self.key(), movingFrom: temp, modified: nil)
+
+    // Wipe the sidecar but leave the blob. read() must NOT serve a hit
+    // because it can no longer validate freshness.
+    let sidecar = url.deletingLastPathComponent()
+      .appendingPathComponent("archive.meta.json")
+    try FileManager.default.removeItem(at: sidecar)
+    #expect(FileManager.default.fileExists(atPath: url.path))
+    _ = root  // silence unused warning
+
+    #expect(store.read(Self.key(), freshAgainst: nil) == nil)
+  }
+
+  @Test
   func storeOverwriteReplacesAtomically() throws {
     let (store, _) = try Self.makeStore()
     let first = try Self.writeTempFile(Data("first".utf8))
-    try store.store(
-      Self.key(), movingFrom: first, modified: nil,
-      suggestedFilename: "a.pdf")
+    try store.store(Self.key(), movingFrom: first, modified: nil)
 
     let second = try Self.writeTempFile(Data("second".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: second, modified: nil,
-      suggestedFilename: "a.pdf")
-    #expect(try Data(contentsOf: hit.canonicalURL) == Data("second".utf8))
-    #expect(try Data(contentsOf: hit.friendlyURL) == Data("second".utf8))
+    let url = try store.store(Self.key(), movingFrom: second, modified: nil)
+    #expect(try Data(contentsOf: url) == Data("second".utf8))
   }
 
   @Test
-  func friendlyLinkRematerializesAfterPurge() throws {
+  func deleteRemovesBlobAndSidecar() throws {
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "a.pdf")
-
-    try FileManager.default.removeItem(at: hit.friendlyURL)
-    #expect(!FileManager.default.fileExists(atPath: hit.friendlyURL.path))
-
-    let again = store.read(Self.key(), freshAgainst: nil)
-    #expect(again != nil)
-    #expect(FileManager.default.fileExists(atPath: again!.friendlyURL.path))
-    #expect(again?.friendlyURL.lastPathComponent == "a.pdf")
-  }
-
-  @Test
-  func friendlyLinkSharesInodeWithCanonical() throws {
-    let (store, _) = try Self.makeStore()
-    let temp = try Self.writeTempFile(Data("payload".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "a.pdf")
-
-    let canonAttr = try FileManager.default.attributesOfItem(
-      atPath: hit.canonicalURL.path)
-    let friendlyAttr = try FileManager.default.attributesOfItem(
-      atPath: hit.friendlyURL.path)
-    let canonInode = canonAttr[.systemFileNumber] as? NSNumber
-    let friendlyInode = friendlyAttr[.systemFileNumber] as? NSNumber
-    #expect(canonInode != nil)
-    #expect(canonInode == friendlyInode)
-  }
-
-  @Test
-  func friendlyNameCollisionGetsDisambiguated() throws {
-    let (store, _) = try Self.makeStore()
-
-    let temp1 = try Self.writeTempFile(Data("one".utf8))
-    let hit1 = try store.store(
-      Self.key(doc: 1), movingFrom: temp1, modified: nil,
-      suggestedFilename: "same.pdf")
-
-    let temp2 = try Self.writeTempFile(Data("two".utf8))
-    let hit2 = try store.store(
-      Self.key(doc: 2), movingFrom: temp2, modified: nil,
-      suggestedFilename: "same.pdf")
-
-    #expect(hit1.friendlyURL.lastPathComponent == "same.pdf")
-    #expect(hit2.friendlyURL.lastPathComponent == "same (2).pdf")
-    #expect(try Data(contentsOf: hit1.friendlyURL) == Data("one".utf8))
-    #expect(try Data(contentsOf: hit2.friendlyURL) == Data("two".utf8))
-  }
-
-  @Test
-  func sanitizesInvalidFilename() throws {
-    let (store, _) = try Self.makeStore()
-    let temp = try Self.writeTempFile(Data("x".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "evil/path\0with/slashes.pdf")
-    #expect(!hit.friendlyURL.lastPathComponent.contains("/"))
-    #expect(!hit.friendlyURL.lastPathComponent.contains("\0"))
-  }
-
-  @Test
-  func emptyFilenameFallsBackToKindBased() throws {
-    let (store, _) = try Self.makeStore()
-    let temp = try Self.writeTempFile(Data("x".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "")
-    #expect(hit.friendlyURL.lastPathComponent == "archive.pdf")
-  }
-
-  @Test
-  func renameCleansOldFriendlyLink() throws {
-    let (store, _) = try Self.makeStore()
-    let temp1 = try Self.writeTempFile(Data("v1".utf8))
-    let hit1 = try store.store(
-      Self.key(), movingFrom: temp1, modified: nil,
-      suggestedFilename: "old-name.pdf")
-    #expect(FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
-    #expect(hit1.friendlyURL.lastPathComponent == "old-name.pdf")
-
-    let temp2 = try Self.writeTempFile(Data("v2".utf8))
-    let hit2 = try store.store(
-      Self.key(), movingFrom: temp2, modified: nil,
-      suggestedFilename: "new-name.pdf")
-    #expect(hit2.friendlyURL.lastPathComponent == "new-name.pdf")
-    #expect(!FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
-  }
-
-  @Test
-  func renameLeavesOtherDocsFriendlyLinksAlone() throws {
-    let (store, _) = try Self.makeStore()
-
-    // Doc A: name "alpha.pdf"
-    let tempA = try Self.writeTempFile(Data("A".utf8))
-    let hitA = try store.store(
-      Self.key(doc: 1), movingFrom: tempA, modified: nil,
-      suggestedFilename: "alpha.pdf")
-
-    // Doc B: name "beta.pdf"
-    let tempB = try Self.writeTempFile(Data("B".utf8))
-    let hitB = try store.store(
-      Self.key(doc: 2), movingFrom: tempB, modified: nil,
-      suggestedFilename: "beta.pdf")
-
-    // Rename Doc A to "gamma.pdf"
-    let tempA2 = try Self.writeTempFile(Data("A2".utf8))
-    _ = try store.store(
-      Self.key(doc: 1), movingFrom: tempA2, modified: nil,
-      suggestedFilename: "gamma.pdf")
-
-    // alpha.pdf gone, beta.pdf still there
-    #expect(!FileManager.default.fileExists(atPath: hitA.friendlyURL.path))
-    #expect(FileManager.default.fileExists(atPath: hitB.friendlyURL.path))
-  }
-
-  @Test
-  func deleteRemovesDisambiguatedFriendlyLink() throws {
-    let (store, _) = try Self.makeStore()
-
-    let temp1 = try Self.writeTempFile(Data("one".utf8))
-    _ = try store.store(
-      Self.key(doc: 1), movingFrom: temp1, modified: nil,
-      suggestedFilename: "same.pdf")
-
-    let temp2 = try Self.writeTempFile(Data("two".utf8))
-    let hit2 = try store.store(
-      Self.key(doc: 2), movingFrom: temp2, modified: nil,
-      suggestedFilename: "same.pdf")
-    #expect(hit2.friendlyURL.lastPathComponent == "same (2).pdf")
-
-    try store.delete(Self.key(doc: 2))
-    #expect(!FileManager.default.fileExists(atPath: hit2.friendlyURL.path))
-  }
-
-  @Test
-  func deleteLeavesOtherDocsFriendlyLinksAlone() throws {
-    let (store, _) = try Self.makeStore()
-
-    let temp1 = try Self.writeTempFile(Data("one".utf8))
-    let hit1 = try store.store(
-      Self.key(doc: 1), movingFrom: temp1, modified: nil,
-      suggestedFilename: "same.pdf")
-
-    let temp2 = try Self.writeTempFile(Data("two".utf8))
-    _ = try store.store(
-      Self.key(doc: 2), movingFrom: temp2, modified: nil,
-      suggestedFilename: "same.pdf")
-
-    try store.delete(Self.key(doc: 2))
-    #expect(FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
-    #expect(try Data(contentsOf: hit1.friendlyURL) == Data("one".utf8))
-  }
-
-  @Test
-  func deleteRemovesBlobSidecarAndFriendly() throws {
-    let (store, _) = try Self.makeStore()
-    let temp = try Self.writeTempFile(Data("x".utf8))
-    let hit = try store.store(
-      Self.key(), movingFrom: temp, modified: nil,
-      suggestedFilename: "a.pdf")
+    let url = try store.store(Self.key(), movingFrom: temp, modified: nil)
 
     try store.delete(Self.key())
-    #expect(!FileManager.default.fileExists(atPath: hit.canonicalURL.path))
-    #expect(!FileManager.default.fileExists(atPath: hit.friendlyURL.path))
+    #expect(!FileManager.default.fileExists(atPath: url.path))
     #expect(store.read(Self.key(), freshAgainst: nil) == nil)
+  }
+
+  @Test
+  func deleteIsIdempotent() throws {
+    let (store, _) = try Self.makeStore()
+    try store.delete(Self.key())
+    try store.delete(Self.key())
   }
 }

--- a/Common/Tests/CommonTests/ContentStoreTests.swift
+++ b/Common/Tests/CommonTests/ContentStoreTests.swift
@@ -90,45 +90,48 @@ struct ContentStoreTests {
   }
 
   @Test
-  func readReturnsURLWhenBothNil() throws {
+  func readReturnsNilWhenAnyModifiedIsNil() throws {
+    // Both sides nil: still nil. A nil staleness signal is "we don't know",
+    // not "fresh". Callers without a timestamp should bypass the cache.
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))
     try store.store(Self.key(), movingFrom: temp, modified: nil)
-    #expect(store.read(Self.key(), freshAgainst: nil) != nil)
-  }
-
-  @Test
-  func readReturnsNilWhenOnlyOneSideIsNil() throws {
-    let (store, _) = try Self.makeStore()
-    let temp = try Self.writeTempFile(Data("x".utf8))
-    try store.store(
-      Self.key(), movingFrom: temp,
-      modified: Date(timeIntervalSince1970: 1))
     #expect(store.read(Self.key(), freshAgainst: nil) == nil)
 
+    // Sidecar has modified, caller doesn't: still nil.
     let (store2, _) = try Self.makeStore()
     let temp2 = try Self.writeTempFile(Data("x".utf8))
-    try store2.store(Self.key(), movingFrom: temp2, modified: nil)
+    try store2.store(
+      Self.key(), movingFrom: temp2,
+      modified: Date(timeIntervalSince1970: 1))
+    #expect(store2.read(Self.key(), freshAgainst: nil) == nil)
+
+    // Caller has modified, sidecar doesn't: still nil.
+    let (store3, _) = try Self.makeStore()
+    let temp3 = try Self.writeTempFile(Data("x".utf8))
+    try store3.store(Self.key(), movingFrom: temp3, modified: nil)
     #expect(
-      store2.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 1))
+      store3.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 1))
         == nil)
   }
 
   @Test
   func readReturnsNilWhenSidecarMissing() throws {
-    let (store, root) = try Self.makeStore()
+    let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))
-    let url = try store.store(Self.key(), movingFrom: temp, modified: nil)
+    let modified = Date(timeIntervalSince1970: 1234)
+    let url = try store.store(
+      Self.key(), movingFrom: temp, modified: modified)
 
     // Wipe the sidecar but leave the blob. read() must NOT serve a hit
-    // because it can no longer validate freshness.
+    // because it can no longer validate freshness, even when the caller
+    // supplies a real timestamp.
     let sidecar = url.deletingLastPathComponent()
       .appendingPathComponent("archive.meta.json")
     try FileManager.default.removeItem(at: sidecar)
     #expect(FileManager.default.fileExists(atPath: url.path))
-    _ = root  // silence unused warning
 
-    #expect(store.read(Self.key(), freshAgainst: nil) == nil)
+    #expect(store.read(Self.key(), freshAgainst: modified) == nil)
   }
 
   @Test

--- a/Common/Tests/CommonTests/ContentStoreTests.swift
+++ b/Common/Tests/CommonTests/ContentStoreTests.swift
@@ -1,0 +1,236 @@
+//
+//  ContentStoreTests.swift
+//  Common
+//
+
+import Foundation
+import Testing
+
+@testable import Common
+
+@Suite
+struct ContentStoreTests {
+  // Each test gets its own temp root via the package-internal init that
+  // bypasses the app-group container lookup.
+  static func makeStore() throws -> (ContentStore, URL) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ContentStoreTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: root, withIntermediateDirectories: true)
+    let store = try ContentStore(root: root)
+    return (store, root)
+  }
+
+  static func writeTempFile(_ bytes: Data) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("payload-\(UUID().uuidString)")
+    try bytes.write(to: url, options: .atomic)
+    return url
+  }
+
+  static let serverA = UUID()
+  static let serverB = UUID()
+
+  static func key(
+    server: UUID = serverA, doc: UInt = 42, version: String = "current",
+    kind: ContentStore.Kind = .archive
+  ) -> ContentStore.Key {
+    ContentStore.Key(
+      serverID: server, documentRemoteID: doc, versionID: version, kind: kind)
+  }
+
+  @Test
+  func urlIsDeterministic() throws {
+    let (store, _) = try Self.makeStore()
+    let k = Self.key()
+    #expect(store.url(for: k) == store.url(for: k))
+    #expect(store.url(for: k) != store.url(for: Self.key(doc: 43)))
+    #expect(store.url(for: k) != store.url(for: Self.key(server: Self.serverB)))
+    #expect(store.url(for: k) != store.url(for: Self.key(kind: .original)))
+    #expect(store.url(for: k) != store.url(for: Self.key(version: "other")))
+  }
+
+  @Test
+  func storeWritesBlobAndReturnsHit() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("hello".utf8))
+
+    let hit = try store.store(
+      Self.key(), movingFrom: temp,
+      modified: Date(timeIntervalSince1970: 1000),
+      suggestedFilename: "invoice.pdf")
+
+    #expect(FileManager.default.fileExists(atPath: hit.canonicalURL.path))
+    #expect(FileManager.default.fileExists(atPath: hit.friendlyURL.path))
+    #expect(hit.friendlyURL.lastPathComponent == "invoice.pdf")
+    #expect(try Data(contentsOf: hit.canonicalURL) == Data("hello".utf8))
+    #expect(try Data(contentsOf: hit.friendlyURL) == Data("hello".utf8))
+  }
+
+  @Test
+  func readReturnsHitWhenModifiedMatches() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    // Sub-second precision on purpose: paperless `modified` timestamps carry
+    // fractional seconds. If the sidecar dropped them (e.g. ISO-8601 whole-
+    // second encoding), this read would miss and the cache would never hit.
+    let modified = Date(timeIntervalSince1970: 1234.567891)
+    try store.store(
+      Self.key(), movingFrom: temp, modified: modified,
+      suggestedFilename: "a.pdf")
+
+    let hit = store.read(Self.key(), freshAgainst: modified)
+    #expect(hit != nil)
+    #expect(hit?.suggestedFilename == "a.pdf")
+  }
+
+  @Test
+  func readReturnsNilWhenModifiedDiffers() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    try store.store(
+      Self.key(), movingFrom: temp,
+      modified: Date(timeIntervalSince1970: 1),
+      suggestedFilename: "a.pdf")
+
+    #expect(
+      store.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 2))
+        == nil)
+  }
+
+  @Test
+  func readReturnsHitWhenBothNil() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "a.pdf")
+    #expect(store.read(Self.key(), freshAgainst: nil) != nil)
+  }
+
+  @Test
+  func readReturnsNilWhenOnlyOneSideIsNil() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    try store.store(
+      Self.key(), movingFrom: temp,
+      modified: Date(timeIntervalSince1970: 1),
+      suggestedFilename: "a.pdf")
+    #expect(store.read(Self.key(), freshAgainst: nil) == nil)
+
+    let (store2, _) = try Self.makeStore()
+    let temp2 = try Self.writeTempFile(Data("x".utf8))
+    try store2.store(
+      Self.key(), movingFrom: temp2, modified: nil,
+      suggestedFilename: "a.pdf")
+    #expect(
+      store2.read(Self.key(), freshAgainst: Date(timeIntervalSince1970: 1))
+        == nil)
+  }
+
+  @Test
+  func storeOverwriteReplacesAtomically() throws {
+    let (store, _) = try Self.makeStore()
+    let first = try Self.writeTempFile(Data("first".utf8))
+    try store.store(
+      Self.key(), movingFrom: first, modified: nil,
+      suggestedFilename: "a.pdf")
+
+    let second = try Self.writeTempFile(Data("second".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: second, modified: nil,
+      suggestedFilename: "a.pdf")
+    #expect(try Data(contentsOf: hit.canonicalURL) == Data("second".utf8))
+    #expect(try Data(contentsOf: hit.friendlyURL) == Data("second".utf8))
+  }
+
+  @Test
+  func friendlyLinkRematerializesAfterPurge() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "a.pdf")
+
+    try FileManager.default.removeItem(at: hit.friendlyURL)
+    #expect(!FileManager.default.fileExists(atPath: hit.friendlyURL.path))
+
+    let again = store.read(Self.key(), freshAgainst: nil)
+    #expect(again != nil)
+    #expect(FileManager.default.fileExists(atPath: again!.friendlyURL.path))
+    #expect(again?.friendlyURL.lastPathComponent == "a.pdf")
+  }
+
+  @Test
+  func friendlyLinkSharesInodeWithCanonical() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("payload".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "a.pdf")
+
+    let canonAttr = try FileManager.default.attributesOfItem(
+      atPath: hit.canonicalURL.path)
+    let friendlyAttr = try FileManager.default.attributesOfItem(
+      atPath: hit.friendlyURL.path)
+    let canonInode = canonAttr[.systemFileNumber] as? NSNumber
+    let friendlyInode = friendlyAttr[.systemFileNumber] as? NSNumber
+    #expect(canonInode != nil)
+    #expect(canonInode == friendlyInode)
+  }
+
+  @Test
+  func friendlyNameCollisionGetsDisambiguated() throws {
+    let (store, _) = try Self.makeStore()
+
+    let temp1 = try Self.writeTempFile(Data("one".utf8))
+    let hit1 = try store.store(
+      Self.key(doc: 1), movingFrom: temp1, modified: nil,
+      suggestedFilename: "same.pdf")
+
+    let temp2 = try Self.writeTempFile(Data("two".utf8))
+    let hit2 = try store.store(
+      Self.key(doc: 2), movingFrom: temp2, modified: nil,
+      suggestedFilename: "same.pdf")
+
+    #expect(hit1.friendlyURL.lastPathComponent == "same.pdf")
+    #expect(hit2.friendlyURL.lastPathComponent == "same (2).pdf")
+    #expect(try Data(contentsOf: hit1.friendlyURL) == Data("one".utf8))
+    #expect(try Data(contentsOf: hit2.friendlyURL) == Data("two".utf8))
+  }
+
+  @Test
+  func sanitizesInvalidFilename() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "evil/path\0with/slashes.pdf")
+    #expect(!hit.friendlyURL.lastPathComponent.contains("/"))
+    #expect(!hit.friendlyURL.lastPathComponent.contains("\0"))
+  }
+
+  @Test
+  func emptyFilenameFallsBackToKindBased() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "")
+    #expect(hit.friendlyURL.lastPathComponent == "archive.pdf")
+  }
+
+  @Test
+  func deleteRemovesBlobSidecarAndFriendly() throws {
+    let (store, _) = try Self.makeStore()
+    let temp = try Self.writeTempFile(Data("x".utf8))
+    let hit = try store.store(
+      Self.key(), movingFrom: temp, modified: nil,
+      suggestedFilename: "a.pdf")
+
+    try store.delete(Self.key())
+    #expect(!FileManager.default.fileExists(atPath: hit.canonicalURL.path))
+    #expect(!FileManager.default.fileExists(atPath: hit.friendlyURL.path))
+    #expect(store.read(Self.key(), freshAgainst: nil) == nil)
+  }
+}

--- a/Common/Tests/CommonTests/ContentStoreTests.swift
+++ b/Common/Tests/CommonTests/ContentStoreTests.swift
@@ -221,6 +221,89 @@ struct ContentStoreTests {
   }
 
   @Test
+  func renameCleansOldFriendlyLink() throws {
+    let (store, _) = try Self.makeStore()
+    let temp1 = try Self.writeTempFile(Data("v1".utf8))
+    let hit1 = try store.store(
+      Self.key(), movingFrom: temp1, modified: nil,
+      suggestedFilename: "old-name.pdf")
+    #expect(FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
+    #expect(hit1.friendlyURL.lastPathComponent == "old-name.pdf")
+
+    let temp2 = try Self.writeTempFile(Data("v2".utf8))
+    let hit2 = try store.store(
+      Self.key(), movingFrom: temp2, modified: nil,
+      suggestedFilename: "new-name.pdf")
+    #expect(hit2.friendlyURL.lastPathComponent == "new-name.pdf")
+    #expect(!FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
+  }
+
+  @Test
+  func renameLeavesOtherDocsFriendlyLinksAlone() throws {
+    let (store, _) = try Self.makeStore()
+
+    // Doc A: name "alpha.pdf"
+    let tempA = try Self.writeTempFile(Data("A".utf8))
+    let hitA = try store.store(
+      Self.key(doc: 1), movingFrom: tempA, modified: nil,
+      suggestedFilename: "alpha.pdf")
+
+    // Doc B: name "beta.pdf"
+    let tempB = try Self.writeTempFile(Data("B".utf8))
+    let hitB = try store.store(
+      Self.key(doc: 2), movingFrom: tempB, modified: nil,
+      suggestedFilename: "beta.pdf")
+
+    // Rename Doc A to "gamma.pdf"
+    let tempA2 = try Self.writeTempFile(Data("A2".utf8))
+    _ = try store.store(
+      Self.key(doc: 1), movingFrom: tempA2, modified: nil,
+      suggestedFilename: "gamma.pdf")
+
+    // alpha.pdf gone, beta.pdf still there
+    #expect(!FileManager.default.fileExists(atPath: hitA.friendlyURL.path))
+    #expect(FileManager.default.fileExists(atPath: hitB.friendlyURL.path))
+  }
+
+  @Test
+  func deleteRemovesDisambiguatedFriendlyLink() throws {
+    let (store, _) = try Self.makeStore()
+
+    let temp1 = try Self.writeTempFile(Data("one".utf8))
+    _ = try store.store(
+      Self.key(doc: 1), movingFrom: temp1, modified: nil,
+      suggestedFilename: "same.pdf")
+
+    let temp2 = try Self.writeTempFile(Data("two".utf8))
+    let hit2 = try store.store(
+      Self.key(doc: 2), movingFrom: temp2, modified: nil,
+      suggestedFilename: "same.pdf")
+    #expect(hit2.friendlyURL.lastPathComponent == "same (2).pdf")
+
+    try store.delete(Self.key(doc: 2))
+    #expect(!FileManager.default.fileExists(atPath: hit2.friendlyURL.path))
+  }
+
+  @Test
+  func deleteLeavesOtherDocsFriendlyLinksAlone() throws {
+    let (store, _) = try Self.makeStore()
+
+    let temp1 = try Self.writeTempFile(Data("one".utf8))
+    let hit1 = try store.store(
+      Self.key(doc: 1), movingFrom: temp1, modified: nil,
+      suggestedFilename: "same.pdf")
+
+    let temp2 = try Self.writeTempFile(Data("two".utf8))
+    _ = try store.store(
+      Self.key(doc: 2), movingFrom: temp2, modified: nil,
+      suggestedFilename: "same.pdf")
+
+    try store.delete(Self.key(doc: 2))
+    #expect(FileManager.default.fileExists(atPath: hit1.friendlyURL.path))
+    #expect(try Data(contentsOf: hit1.friendlyURL) == Data("one".utf8))
+  }
+
+  @Test
   func deleteRemovesBlobSidecarAndFriendly() throws {
     let (store, _) = try Self.makeStore()
     let temp = try Self.writeTempFile(Data("x".utf8))

--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -122,6 +122,15 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
   @IgnoreEncoding
   public var modified: Date?
 
+  // Server's storage filenames for the original (uploaded) and archived
+  // (paperless-generated PDF) versions. Optional because older paperless
+  // versions or in-progress consumption may omit them.
+  @IgnoreEncoding
+  public var originalFileName: String?
+
+  @IgnoreEncoding
+  public var archivedFileName: String?
+
   @CodedBy(NullCoder<UInt>())
   public var storagePath: UInt?
 
@@ -160,6 +169,18 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
 extension Document: Model {}
 extension Document: DocumentProtocol {}
 extension Document: PermissionsModel {}
+
+extension Document {
+  /// User-facing filename for exporting/sharing this document. Prefers the
+  /// server's stored filename for the requested version; falls back to the
+  /// title with a `.pdf` extension, or "document.pdf" if there is no title.
+  public func shareFilename(original: Bool) -> String {
+    let serverName = original ? originalFileName : archivedFileName
+    if let name = serverName, !name.isEmpty { return name }
+    let base = title.isEmpty ? "document" : title
+    return "\(base).pdf"
+  }
+}
 
 public struct ProtoDocument: DocumentProtocol, Equatable, Sendable {
   public var title: String

--- a/DataModel/Tests/DataModelTests/DocumentModelTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentModelTest.swift
@@ -43,6 +43,9 @@ struct DocumentModelTest {
     #expect(document.owner == .user(2))
     #expect(document.notes.count == 1)
 
+    #expect(document.originalFileName == "original.pdf")
+    #expect(document.archivedFileName == "archived.pdf")
+
     #expect(document.userCanChange == true)
 
     // No permissions by default

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -32,6 +32,11 @@ public class ApiRepository {
 
   private let urlSession: URLSession
   private let urlSessionDelegate: PaperlessURLSessionDelegate
+  private let contentStore: ContentStore?
+
+  // Per-key in-flight task map: two concurrent downloads of the same blob
+  // share one network request rather than racing into the ContentStore.
+  private var inFlightDownloads: [ContentStore.Key: Task<URL, Error>] = [:]
 
   nonisolated
     private let apiVersion: UInt?
@@ -48,9 +53,32 @@ public class ApiRepository {
     min(Self.maximumApiVersion, apiVersion ?? Self.maximumApiVersion)
   }
 
-  public init(connection: Connection, mode: Mode) async {
+  public convenience init(connection: Connection, mode: Mode) async {
+    let store = try? ContentStore()
+    await self.init(connection: connection, mode: mode, contentStore: store)
+  }
+
+  // Test seam: skips the backend-version discovery network call and accepts
+  // a caller-provided URLSession (typically backed by `MockURLProtocol`).
+  init(
+    connection: Connection, mode: Mode, contentStore: ContentStore?,
+    urlSession: URLSession, apiVersion: UInt? = nil,
+    backendVersion: Version? = nil
+  ) {
     self.connection = connection
     self.mode = mode
+    self.contentStore = contentStore
+    let delegate = PaperlessURLSessionDelegate(identityName: connection.identity)
+    urlSessionDelegate = delegate
+    self.urlSession = urlSession
+    self.apiVersion = apiVersion
+    self.backendVersion = backendVersion
+  }
+
+  init(connection: Connection, mode: Mode, contentStore: ContentStore?) async {
+    self.connection = connection
+    self.mode = mode
+    self.contentStore = contentStore
     let sanitizedUrl = Self.sanitizeUrlForLog(connection.url)
     let tokenStr = sanitize(token: connection.token)
     Logger.networking.notice(
@@ -457,32 +485,111 @@ extension ApiRepository: Repository {
 
   public func download(
     documentID: UInt, original: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
-  ) async throws
-    -> URL?
-  {
+  ) async throws -> URL {
+    // No Document handle → no modified timestamp to validate the cache,
+    // so always re-fetch. Callers should prefer download(document:...).
+    try await streamDownload(
+      documentID: documentID, original: original,
+      modified: nil, progress: progress)
+  }
+
+  public func download(
+    document: Document, original: Bool = false,
+    progress: (@Sendable (Double) -> Void)? = nil
+  ) async throws -> URL {
+    try await streamDownload(
+      documentID: document.id, original: original,
+      modified: document.modified, progress: progress)
+  }
+
+  private func streamDownload(
+    documentID: UInt, original: Bool,
+    modified: Date?, progress: (@Sendable (Double) -> Void)?
+  ) async throws -> URL {
     Logger.networking.notice("Downloading document (original: \(original))")
-    do {
-      let request = try request(.download(documentId: documentID, original: original))
 
-      let (data, response) = try await fetchData(
-        for: request,
-        progress: progress)
+    guard let contentStore else {
+      // App-group container unavailable (host tests, mis-configured entitlement).
+      // Fall back to streaming straight to a temp file with no cache.
+      return try await fetchToTemp(
+        documentID: documentID, original: original, progress: progress)
+    }
 
-      guard let suggestedFilename = response.suggestedFilename else {
-        Logger.networking.error("Cannot get suggested filename from response")
-        return nil
+    let key = ContentStore.Key(
+      serverID: connection.serverID,
+      documentRemoteID: documentID,
+      kind: original ? .original : .archive)
+
+    if let hit = contentStore.read(key, freshAgainst: modified) {
+      Logger.networking.info(
+        "ContentStore hit for documentID \(documentID) (original: \(original))")
+      progress?(1.0)
+      return hit.friendlyURL
+    }
+
+    if let existing = inFlightDownloads[key] {
+      return try await existing.value
+    }
+
+    let task = Task<URL, Error> { [contentStore] in
+      defer { inFlightDownloads[key] = nil }
+
+      let request = try request(
+        .download(documentId: documentID, original: original))
+      let (tempURL, response) = try await urlSession.getDownload(
+        for: request, progress: progress)
+
+      try validateDownloadResponse(response, request: request)
+
+      let suggested = response.suggestedFilename ?? "document.pdf"
+      let hit = try contentStore.store(
+        key, movingFrom: tempURL,
+        modified: modified, suggestedFilename: suggested)
+      return hit.friendlyURL
+    }
+    inFlightDownloads[key] = task
+    return try await task.value
+  }
+
+  private func fetchToTemp(
+    documentID: UInt, original: Bool,
+    progress: (@Sendable (Double) -> Void)?
+  ) async throws -> URL {
+    let request = try request(
+      .download(documentId: documentID, original: original))
+    let (tempURL, response) = try await urlSession.getDownload(
+      for: request, progress: progress)
+    try validateDownloadResponse(response, request: request)
+
+    let dest = URL(
+      fileURLWithPath: NSTemporaryDirectory(), isDirectory: true
+    ).appendingPathComponent(
+      response.suggestedFilename ?? "document.pdf")
+    if FileManager.default.fileExists(atPath: dest.path) {
+      _ = try FileManager.default.replaceItemAt(dest, withItemAt: tempURL)
+    } else {
+      try FileManager.default.moveItem(at: tempURL, to: dest)
+    }
+    return dest
+  }
+
+  private nonisolated func validateDownloadResponse(
+    _ response: URLResponse, request: URLRequest
+  ) throws {
+    guard let http = response as? HTTPURLResponse, let status = http.status else {
+      throw RequestError.invalidResponse
+    }
+    guard status == .ok else {
+      switch status {
+      case .forbidden:
+        throw RequestError.forbidden(body: Data())
+      case .unauthorized:
+        throw RequestError.unauthorized(body: Data())
+      case .notAcceptable:
+        throw RequestError.unsupportedVersion(sentVersion: nil)
+      default:
+        throw RequestError.unexpectedStatusCode(code: status, body: Data())
       }
-
-      let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-      let temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(suggestedFilename)
-
-      try data.write(to: temporaryFileURL, options: .atomic)
-      try await Task.sleep(for: .seconds(0.2))  // wait a little bit for the data to be flushed
-      return temporaryFileURL
-
-    } catch {
-      Logger.networking.error("Error downloading document: \(error)")
-      return nil
     }
   }
 

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -487,7 +487,8 @@ extension ApiRepository: Repository {
     documentID: UInt, original: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
   ) async throws -> URL {
     // No Document handle → no modified timestamp to validate the cache,
-    // so always re-fetch. Callers should prefer download(document:...).
+    // so streamDownload's nil-modified guard bypasses ContentStore and
+    // fetches fresh every call. Callers should prefer download(document:...).
     try await streamDownload(
       documentID: documentID, original: original,
       modified: nil, progress: progress)
@@ -508,9 +509,12 @@ extension ApiRepository: Repository {
   ) async throws -> URL {
     Logger.networking.notice("Downloading document (original: \(original))")
 
-    guard let contentStore else {
-      // App-group container unavailable (host tests, mis-configured entitlement).
-      // Fall back to streaming straight to a temp file with no cache.
+    // Without a staleness signal (modified timestamp) we can't validate a
+    // cached blob — and writing one back without `modified` would cache it
+    // indefinitely with no way to detect server-side changes. Bypass the
+    // ContentStore entirely in that case. Also fall back when the app-group
+    // container isn't available (host tests, mis-configured entitlement).
+    guard let contentStore, let modified else {
       return try await fetchToTemp(
         documentID: documentID, original: original, progress: progress)
     }

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -520,11 +520,11 @@ extension ApiRepository: Repository {
       documentRemoteID: documentID,
       kind: original ? .original : .archive)
 
-    if let hit = contentStore.read(key, freshAgainst: modified) {
+    if let cached = contentStore.read(key, freshAgainst: modified) {
       Logger.networking.info(
         "ContentStore hit for documentID \(documentID) (original: \(original))")
       progress?(1.0)
-      return hit.friendlyURL
+      return cached
     }
 
     if let existing = inFlightDownloads[key] {
@@ -541,11 +541,8 @@ extension ApiRepository: Repository {
 
       try validateDownloadResponse(response, request: request)
 
-      let suggested = response.suggestedFilename ?? "document.pdf"
-      let hit = try contentStore.store(
-        key, movingFrom: tempURL,
-        modified: modified, suggestedFilename: suggested)
-      return hit.friendlyURL
+      return try contentStore.store(
+        key, movingFrom: tempURL, modified: modified)
     }
     inFlightDownloads[key] = task
     return try await task.value

--- a/Networking/Sources/Networking/Api/Connection.swift
+++ b/Networking/Sources/Networking/Api/Connection.swift
@@ -25,14 +25,24 @@ public struct Connection: Equatable, Sendable {
     }
   }
 
+  public let serverID: UUID
   public let url: URL
   public let token: String?
   public let extraHeaders: [HeaderValue]
   public let identity: String?
 
+  // Stable UUID used for Connections without a real server identity
+  // (preview mode, legacy single-server fallback). ContentStore keys are
+  // deterministic against this so cached blobs survive across launches in
+  // those contexts.
+  public static let unidentifiedServerID = UUID(
+    uuidString: "00000000-0000-0000-0000-000000000000")!
+
   public init(
-    url: URL, token: String? = nil, extraHeaders: [HeaderValue] = [], identityName: String?
+    url: URL, token: String? = nil, extraHeaders: [HeaderValue] = [],
+    identityName: String?, serverID: UUID = Connection.unidentifiedServerID
   ) {
+    self.serverID = serverID
     self.url = url
     self.token = token
     self.extraHeaders = extraHeaders

--- a/Networking/Sources/Networking/Api/PreviewRepository.swift
+++ b/Networking/Sources/Networking/Api/PreviewRepository.swift
@@ -280,7 +280,7 @@ public class PreviewRepository: Repository {
   public func download(
     documentID _: UInt, original _: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
   )
-    async throws -> URL?
+    async throws -> URL
   {
     var elapsed = 0.0
     for i in 1...10 {
@@ -288,7 +288,10 @@ public class PreviewRepository: Repository {
       elapsed = Double(i) / 10.0 * downloadDelay
       progress?(elapsed)
     }
-    return Bundle.main.url(forResource: "demo2", withExtension: "pdf")
+    guard let url = Bundle.main.url(forResource: "demo2", withExtension: "pdf") else {
+      throw RepositoryError.documentNotFound
+    }
+    return url
   }
 
   public func tag(id: UInt) async -> Tag? { tags[id] }

--- a/Networking/Sources/Networking/Api/TransientRepository.swift
+++ b/Networking/Sources/Networking/Api/TransientRepository.swift
@@ -496,7 +496,7 @@ extension TransientRepository: Repository {
   public func download(
     documentID: UInt, original: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
   )
-    async throws -> URL?
+    async throws -> URL
   {
     // Simulate download progress
     for i in 1...10 {
@@ -504,7 +504,9 @@ extension TransientRepository: Repository {
       progress?(Double(i) / 10.0)
     }
 
-    guard let data = documentPDFData[documentID] else { return nil }
+    guard let data = documentPDFData[documentID] else {
+      throw RepositoryError.documentNotFound
+    }
     let outputURL = FileManager.default.temporaryDirectory
       .appendingPathComponent("transient-\(documentID)")
       .appendingPathExtension("pdf")

--- a/Networking/Sources/Networking/NullRepository.swift
+++ b/Networking/Sources/Networking/NullRepository.swift
@@ -24,8 +24,8 @@ public class NullRepository: Repository {
   public func download(
     documentID _: UInt, original _: Bool = false, progress _: (@Sendable (Double) -> Void)? = nil
   )
-    async throws -> URL?
-  { nil }
+    async throws -> URL
+  { throw NotImplemented() }
 
   public func tag(id _: UInt) async -> Tag? { nil }
   public func create(tag _: ProtoTag) async throws -> Tag { throw NotImplemented() }

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -76,10 +76,18 @@ public protocol Repository: Sendable {
   nonisolated
     func thumbnailRequest(document: Document) throws -> URLRequest
 
-  func download(documentID: UInt) async throws -> URL?
+  func download(documentID: UInt) async throws -> URL
 
   func download(documentID: UInt, original: Bool, progress: (@Sendable (Double) -> Void)?)
-    async throws -> URL?
+    async throws -> URL
+
+  // Preferred entry point: callers that already hold a Document supply it so
+  // the cache layer can use Document.modified as a staleness key without an
+  // extra round trip.
+  func download(
+    document: Document, original: Bool,
+    progress: (@Sendable (Double) -> Void)?
+  ) async throws -> URL
 
   func suggestions(documentId: UInt) async throws -> Suggestions
 
@@ -138,12 +146,24 @@ public protocol Repository: Sendable {
 }
 
 extension Repository {
-  public func download(documentID: UInt) async throws -> URL? {
+  public func download(documentID: UInt) async throws -> URL {
     try await download(documentID: documentID, original: false, progress: nil)
   }
 
-  public func download(documentID: UInt, original: Bool) async throws -> URL? {
+  public func download(documentID: UInt, original: Bool) async throws -> URL {
     try await download(documentID: documentID, original: original, progress: nil)
+  }
+
+  // Default impl for conformers that don't implement the Document-aware path:
+  // fall back to the id-keyed call. ApiRepository overrides this directly to
+  // avoid a redundant document fetch when threading staleness through the
+  // ContentStore.
+  public func download(
+    document: Document, original: Bool = false,
+    progress: (@Sendable (Double) -> Void)? = nil
+  ) async throws -> URL {
+    try await download(
+      documentID: document.id, original: original, progress: progress)
   }
 
   // Helper method documents with a title search

--- a/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
@@ -230,6 +230,28 @@ struct ApiRepositoryDownloadTest {
   }
 
   @Test
+  func documentWithNilModifiedAlwaysHitsNetwork() async throws {
+    // No staleness signal → bypass ContentStore entirely. Two back-to-back
+    // calls must each hit the network and the result must not appear in the
+    // cache for a subsequent lookup.
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let counter = Counter()
+    DownloadMockURLProtocol.responder = { req in
+      counter.bump()
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let doc = Self.makeDocument(modified: nil)
+    _ = try await repo.download(document: doc)
+    _ = try await repo.download(document: doc)
+    #expect(counter.value == 2)
+    #expect(
+      store.read(Self.canonicalKey(for: doc), freshAgainst: nil) == nil)
+  }
+
+  @Test
   func concurrentDownloadsForSameKeyDeduped() async throws {
     let (store, _) = try Self.makeStore()
     let repo = Self.makeRepo(contentStore: store)

--- a/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
@@ -56,13 +56,15 @@ final class DownloadMockURLProtocol: URLProtocol, @unchecked Sendable {
 @MainActor
 @Suite(.serialized)
 struct ApiRepositoryDownloadTest {
-  private static let baseURL = URL(string: "https://example.com")!
+  nonisolated static let baseURL = URL(string: "https://example.com")!
+  nonisolated static let serverID = UUID(
+    uuidString: "11111111-2222-3333-4444-555555555555")!
 
   static func makeRepo(contentStore: ContentStore) -> ApiRepository {
     let session = DownloadMockURLProtocol.makeSession()
     return ApiRepository(
       connection: Connection(
-        url: baseURL, token: "t", identityName: nil, serverID: UUID()),
+        url: baseURL, token: "t", identityName: nil, serverID: serverID),
       mode: .release,
       contentStore: contentStore,
       urlSession: session)
@@ -95,6 +97,15 @@ struct ApiRepositoryDownloadTest {
       added: nil, modified: modified, storagePath: nil)
   }
 
+  nonisolated static func canonicalKey(
+    for document: Document, original: Bool = false
+  ) -> ContentStore.Key {
+    ContentStore.Key(
+      serverID: serverID,
+      documentRemoteID: document.id,
+      kind: original ? .original : .archive)
+  }
+
   // Atomic counter for request-count assertions across concurrent callbacks.
   final class Counter: @unchecked Sendable {
     private let lock = NSLock()
@@ -113,7 +124,7 @@ struct ApiRepositoryDownloadTest {
   }
 
   @Test
-  func firstCallWritesToContentStoreAndReturnsFriendlyURL() async throws {
+  func firstCallWritesToContentStore() async throws {
     let (store, _) = try Self.makeStore()
     let repo = Self.makeRepo(contentStore: store)
     let payload = Data("HELLO".utf8)
@@ -122,7 +133,7 @@ struct ApiRepositoryDownloadTest {
 
     let url = try await repo.download(document: Self.makeDocument())
 
-    #expect(url.lastPathComponent == "invoice.pdf")
+    #expect(url == store.url(for: Self.canonicalKey(for: Self.makeDocument())))
     #expect(try Data(contentsOf: url) == payload)
   }
 
@@ -216,28 +227,6 @@ struct ApiRepositoryDownloadTest {
     await #expect(throws: (any Error).self) {
       _ = try await repo.download(document: Self.makeDocument())
     }
-  }
-
-  @Test
-  func friendlyNameSurvivesPurge() async throws {
-    let (store, _) = try Self.makeStore()
-    let repo = Self.makeRepo(contentStore: store)
-    DownloadMockURLProtocol.responder = { req in
-      (Self.okResponse(for: req, suggested: "report.pdf"), Data("P".utf8))
-    }
-    defer { DownloadMockURLProtocol.reset() }
-
-    let first = try await repo.download(document: Self.makeDocument())
-    #expect(first.lastPathComponent == "report.pdf")
-
-    // Simulate the OS purging the Friendly/ directory: the canonical blob
-    // stays, the friendly hardlink does not.
-    try FileManager.default.removeItem(at: first)
-    #expect(!FileManager.default.fileExists(atPath: first.path))
-
-    let second = try await repo.download(document: Self.makeDocument())
-    #expect(second.lastPathComponent == "report.pdf")
-    #expect(FileManager.default.fileExists(atPath: second.path))
   }
 
   @Test

--- a/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
@@ -1,0 +1,263 @@
+//
+//  ApiRepositoryDownloadTest.swift
+//  Networking
+//
+
+import Common
+import DataModel
+import Foundation
+import Testing
+
+@testable import Networking
+
+// Dedicated URLProtocol subclass with its own static responder, so this
+// suite doesn't race against other suites (e.g. OIDCClientTest) that also
+// use a mock URLProtocol global.
+final class DownloadMockURLProtocol: URLProtocol, @unchecked Sendable {
+  typealias Responder = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var _responder: Responder?
+
+  static var responder: Responder? {
+    get { lock.withLock { _responder } }
+    set { lock.withLock { _responder = newValue } }
+  }
+
+  static func reset() { responder = nil }
+
+  static func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [DownloadMockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  override class func canInit(with _: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let responder = Self.responder else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    do {
+      let (response, data) = try responder(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+@MainActor
+@Suite(.serialized)
+struct ApiRepositoryDownloadTest {
+  private static let baseURL = URL(string: "https://example.com")!
+
+  static func makeRepo(contentStore: ContentStore) -> ApiRepository {
+    let session = DownloadMockURLProtocol.makeSession()
+    return ApiRepository(
+      connection: Connection(
+        url: baseURL, token: "t", identityName: nil, serverID: UUID()),
+      mode: .release,
+      contentStore: contentStore,
+      urlSession: session)
+  }
+
+  static func makeStore() throws -> (ContentStore, URL) {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ApiRepoDownloadTest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: root, withIntermediateDirectories: true)
+    return (try ContentStore(root: root), root)
+  }
+
+  nonisolated static func okResponse(
+    for request: URLRequest, suggested: String = "invoice.pdf"
+  ) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+      headerFields: [
+        "Content-Disposition": "attachment; filename=\"\(suggested)\""
+      ])!
+  }
+
+  nonisolated static func makeDocument(
+    id: UInt = 7, modified: Date? = Date(timeIntervalSince1970: 1000)
+  ) -> Document {
+    Document(
+      id: id, title: "doc", asn: nil, documentType: nil, correspondent: nil,
+      created: Date(timeIntervalSince1970: 0), tags: [],
+      added: nil, modified: modified, storagePath: nil)
+  }
+
+  // Atomic counter for request-count assertions across concurrent callbacks.
+  final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int { lock.withLock { _value } }
+    func bump() { lock.withLock { _value += 1 } }
+  }
+
+  // Latest-value box for Sendable closures that mutate a captured value.
+  final class LastValue<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: T
+    init(_ initial: T) { _value = initial }
+    var value: T { lock.withLock { _value } }
+    func set(_ v: T) { lock.withLock { _value = v } }
+  }
+
+  @Test
+  func firstCallWritesToContentStoreAndReturnsFriendlyURL() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let payload = Data("HELLO".utf8)
+    DownloadMockURLProtocol.responder = { req in (Self.okResponse(for: req), payload) }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let url = try await repo.download(document: Self.makeDocument())
+
+    #expect(url.lastPathComponent == "invoice.pdf")
+    #expect(try Data(contentsOf: url) == payload)
+  }
+
+  @Test
+  func secondCallHitsCacheWithoutNetwork() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let counter = Counter()
+    DownloadMockURLProtocol.responder = { req in
+      counter.bump()
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    _ = try await repo.download(document: Self.makeDocument())
+    _ = try await repo.download(document: Self.makeDocument())
+
+    #expect(counter.value == 1)
+  }
+
+  @Test
+  func staleCacheRefetchesWhenModifiedChanges() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let counter = Counter()
+    DownloadMockURLProtocol.responder = { req in
+      counter.bump()
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    _ = try await repo.download(
+      document: Self.makeDocument(modified: Date(timeIntervalSince1970: 1)))
+    _ = try await repo.download(
+      document: Self.makeDocument(modified: Date(timeIntervalSince1970: 1)))
+    _ = try await repo.download(
+      document: Self.makeDocument(modified: Date(timeIntervalSince1970: 2)))
+
+    #expect(counter.value == 2)
+  }
+
+  @Test
+  func progressCallbackFires() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    DownloadMockURLProtocol.responder = { req in
+      (Self.okResponse(for: req), Data(repeating: 0xab, count: 8192))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let lastProgress = Counter()
+    _ = try await repo.download(
+      document: Self.makeDocument(),
+      progress: { _ in lastProgress.bump() })
+
+    // We don't get strict guarantees from URLSession.download about how many
+    // progress callbacks fire, but we should see at least one.
+    #expect(lastProgress.value >= 1)
+  }
+
+  @Test
+  func cacheHitFiresFinalProgress() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    DownloadMockURLProtocol.responder = { req in (Self.okResponse(for: req), Data()) }
+    defer { DownloadMockURLProtocol.reset() }
+
+    _ = try await repo.download(document: Self.makeDocument())
+
+    let captured = LastValue<Double>(0)
+    _ = try await repo.download(
+      document: Self.makeDocument(),
+      progress: { v in captured.set(v) })
+    #expect(captured.value == 1.0)
+  }
+
+  @Test
+  func unauthorizedResponseThrows() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    DownloadMockURLProtocol.responder = { req in
+      (
+        HTTPURLResponse(
+          url: req.url!, statusCode: 401, httpVersion: "HTTP/1.1",
+          headerFields: nil)!,
+        Data()
+      )
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    await #expect(throws: (any Error).self) {
+      _ = try await repo.download(document: Self.makeDocument())
+    }
+  }
+
+  @Test
+  func friendlyNameSurvivesPurge() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    DownloadMockURLProtocol.responder = { req in
+      (Self.okResponse(for: req, suggested: "report.pdf"), Data("P".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let first = try await repo.download(document: Self.makeDocument())
+    #expect(first.lastPathComponent == "report.pdf")
+
+    // Simulate the OS purging the Friendly/ directory: the canonical blob
+    // stays, the friendly hardlink does not.
+    try FileManager.default.removeItem(at: first)
+    #expect(!FileManager.default.fileExists(atPath: first.path))
+
+    let second = try await repo.download(document: Self.makeDocument())
+    #expect(second.lastPathComponent == "report.pdf")
+    #expect(FileManager.default.fileExists(atPath: second.path))
+  }
+
+  @Test
+  func concurrentDownloadsForSameKeyDeduped() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let counter = Counter()
+    DownloadMockURLProtocol.responder = { req in
+      counter.bump()
+      // Slight delay to ensure both callers reach the dedupe gate
+      Thread.sleep(forTimeInterval: 0.05)
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    async let a = repo.download(document: Self.makeDocument())
+    async let b = repo.download(document: Self.makeDocument())
+    let urls = try await [a, b]
+
+    #expect(counter.value == 1)
+    #expect(urls[0] == urls[1])
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,2 +1,3 @@
 - Recently-viewed documents now open offline; their files are cached on disk and survive app launches
+- Document thumbnails persist across launches, so the document list shows them instantly without a network round trip
 - Large document downloads no longer buffer the whole file in memory, reducing memory pressure (especially in the Share Extension)

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,2 @@
+- Recently-viewed documents now open offline; their files are cached on disk and survive app launches
+- Large document downloads no longer buffer the whole file in memory, reducing memory pressure (especially in the Share Extension)

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -74,7 +74,18 @@ class DocumentDetailModel {
   }
 
   func loadDocument() async {
-    async let updated = try await store.document(id: document.id)
+    // Resolve the fresh document FIRST so the download path can validate
+    // the ContentStore cache against the server's current `modified`
+    // timestamp. If we kicked off both in parallel, a stale `modified`
+    // could validate an out-of-date cached PDF before the metadata refresh
+    // landed — surfacing old content alongside fresh metadata.
+    do {
+      if let updated = try await store.document(id: document.id) {
+        document = updated
+      }
+    } catch {
+      Logger.shared.error("Error updating document with full perms for editing: \(error)")
+    }
 
     switch download {
     case .initial:
@@ -112,14 +123,6 @@ class DocumentDetailModel {
 
     default:
       break
-    }
-
-    do {
-      if let updated = try await updated {
-        document = updated
-      }
-    } catch {
-      Logger.shared.error("Error updating document with full perms for editing: \(error)")
     }
   }
 

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -84,19 +84,14 @@ class DocumentDetailModel {
         download = .loading
       }
       do {
-        guard
-          let url = try await store.repository.download(
-            documentID: document.id,
-            original: false,
-            progress: { @Sendable value in
-              Task { @MainActor in
-                self.downloadProgress = value
-              }
-            })
-        else {
-          download = .error
-          break
-        }
+        let url = try await store.repository.download(
+          document: document,
+          original: false,
+          progress: { @Sendable value in
+            Task { @MainActor in
+              self.downloadProgress = value
+            }
+          })
 
         guard let pdfDocument = await PDFDocument.loadBackground(url: url) else {
           download = .error
@@ -132,11 +127,7 @@ class DocumentDetailModel {
     guard case .initial = originalDownload else { return }
     originalDownload = .loading
     do {
-      guard let url = try await store.repository.download(documentID: document.id, original: true)
-      else {
-        originalDownload = .error
-        return
-      }
+      let url = try await store.repository.download(document: document, original: true)
       originalDownload = .loaded(url: url)
     } catch {
       originalDownload = .error

--- a/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
@@ -686,7 +686,9 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
               }
 
               if case .loaded(url: let url, document: _) = viewModel.download {
-                ShareLink(item: url) {
+                NamedShareLink(
+                  url: url, name: viewModel.document.shareFilename(original: false)
+                ) {
                   Label(localized: .app(.shareSheet), systemImage: "square.and.arrow.down")
                 }
               }

--- a/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailViewV3.swift
@@ -330,6 +330,7 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
   @State private var dragging = false
 
   @State private var showShareLinkSheet = false
+  @State private var sharedFile: NamedShareItem?
 
   @State private var safeAreaInsets = EdgeInsets()
   @State private var shareLinkUrl: URL?
@@ -686,9 +687,11 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
               }
 
               if case .loaded(url: let url, document: _) = viewModel.download {
-                NamedShareLink(
-                  url: url, name: viewModel.document.shareFilename(original: false)
-                ) {
+                Button {
+                  sharedFile = NamedShareItem(
+                    url: url,
+                    name: viewModel.document.shareFilename(original: false))
+                } label: {
                   Label(localized: .app(.shareSheet), systemImage: "square.and.arrow.down")
                 }
               }
@@ -702,6 +705,7 @@ struct DocumentDetailViewV3: DocumentDetailViewProtocol {
     .sheet(isPresented: $showShareLinkSheet) {
       ShareLinkView(document: viewModel.document)
     }
+    .namedShareSheet(item: $sharedFile)
 
     .sheet(isPresented: $showEditSheet) {
       editDetent = defaultEditDetent

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -511,12 +511,18 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       if case .loaded(url: let url) = viewModel.originalDownload { url } else { nil }
 
     Menu {
-      ShareLink(item: archiveURL ?? URL(filePath: "/")) {
+      NamedShareLink(
+        url: archiveURL ?? URL(filePath: "/"),
+        name: viewModel.document.shareFilename(original: false)
+      ) {
         Label(localized: .app(.shareArchive), systemImage: "doc.zipper")
       }
       .disabled(archiveURL == nil)
 
-      ShareLink(item: originalURL ?? URL(filePath: "/")) {
+      NamedShareLink(
+        url: originalURL ?? URL(filePath: "/"),
+        name: viewModel.document.shareFilename(original: true)
+      ) {
         Label(localized: .app(.shareOriginal), systemImage: "doc")
       }
       .disabled(originalURL == nil)

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -73,6 +73,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
   @SceneStorage("DocumentDetailEditInspectorVisible") private var showEditInspector = true
   @State private var showDeleteConfirmation = false
   @State private var deleted = false
+  @State private var sharedFile: NamedShareItem?
 
   @ObservedObject private var appSettings = AppSettings.shared
 
@@ -511,18 +512,24 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       if case .loaded(url: let url) = viewModel.originalDownload { url } else { nil }
 
     Menu {
-      NamedShareLink(
-        url: archiveURL ?? URL(filePath: "/"),
-        name: viewModel.document.shareFilename(original: false)
-      ) {
+      Button {
+        if let url = archiveURL {
+          sharedFile = NamedShareItem(
+            url: url,
+            name: viewModel.document.shareFilename(original: false))
+        }
+      } label: {
         Label(localized: .app(.shareArchive), systemImage: "doc.zipper")
       }
       .disabled(archiveURL == nil)
 
-      NamedShareLink(
-        url: originalURL ?? URL(filePath: "/"),
-        name: viewModel.document.shareFilename(original: true)
-      ) {
+      Button {
+        if let url = originalURL {
+          sharedFile = NamedShareItem(
+            url: url,
+            name: viewModel.document.shareFilename(original: true))
+        }
+      } label: {
         Label(localized: .app(.shareOriginal), systemImage: "doc")
       }
       .disabled(originalURL == nil)
@@ -752,6 +759,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         ShareLinkView(document: viewModel.document)
       }
     }
+    .namedShareSheet(item: $sharedFile)
 
     .sheet(isPresented: $showPreview) {
       previewContent

--- a/swift-paperless/Views/Document/DocumentPreview.swift
+++ b/swift-paperless/Views/Document/DocumentPreview.swift
@@ -84,20 +84,15 @@ private final class IntegratedDocumentPreviewModel {
       hasReceivedProgress = false
       downloadProgress = 0
       do {
-        guard
-          let url = try await store.repository.download(
-            documentID: document.id,
-            original: false,
-            progress: { @Sendable value in
-              Task { @MainActor in
-                self.hasReceivedProgress = true
-                self.downloadProgress = value
-              }
-            })
-        else {
-          download = .error
-          return
-        }
+        let url = try await store.repository.download(
+          document: document,
+          original: false,
+          progress: { @Sendable value in
+            Task { @MainActor in
+              self.hasReceivedProgress = true
+              self.downloadProgress = value
+            }
+          })
 
         guard let pdfDocument = await PDFDocument.loadBackground(url: url) else {
           download = .error


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 12 in a stack** made with GitButler:
- <kbd>&nbsp;12&nbsp;</kbd> #618 
- <kbd>&nbsp;11&nbsp;</kbd> #617 
- <kbd>&nbsp;10&nbsp;</kbd> #600 
- <kbd>&nbsp;9&nbsp;</kbd> #598 
- <kbd>&nbsp;8&nbsp;</kbd> #597 
- <kbd>&nbsp;7&nbsp;</kbd> #596 
- <kbd>&nbsp;6&nbsp;</kbd> #595 
- <kbd>&nbsp;5&nbsp;</kbd> #592 
- <kbd>&nbsp;4&nbsp;</kbd> #591 
- <kbd>&nbsp;3&nbsp;</kbd> #590 
- <kbd>&nbsp;2&nbsp;</kbd> #588 
- <kbd>&nbsp;1&nbsp;</kbd> #578 👈 
<!-- GitButler Footer Boundary Bottom -->

