### PR TITLE
docs: Remove swift-case-paths from third-party libraries list

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -35,7 +35,3 @@ Swift Paperless uses the following third-party libraries for various features:
 ## BezelKit
 [GitHub](https://github.com/markbattistella/BezelKit)
 MIT License
-
-## swift-case-paths
-[GitHub](https://github.com/pointfreeco/swift-case-paths)
-MIT License


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #578 
- <kbd>&nbsp;1&nbsp;</kbd> #580 👈 
<!-- GitButler Footer Boundary Bottom -->

