### PR TITLE
chore: Trim unused and redundant package dependencies

### DIFF
--- a/AppShared/Package.swift
+++ b/AppShared/Package.swift
@@ -22,13 +22,9 @@ let package = Package(
     .package(path: "../DataModel"),
     .package(path: "../Networking"),
     .package(url: "https://github.com/kean/Nuke", .upToNextMajor(from: "12.0.0")),
-    .package(
-      url: "https://github.com/gonzalezreal/swift-markdown-ui.git",
-      .upToNextMajor(from: "2.3.1")),
     .package(url: "https://github.com/groue/Semaphore", .upToNextMajor(from: "0.1.0")),
     .package(
       url: "https://github.com/apple/swift-async-algorithms", .upToNextMajor(from: "1.0.0")),
-    .package(url: "https://github.com/markbattistella/BezelKit", .upToNextMajor(from: "4.1.1")),
     .package(
       url: "https://github.com/liamnichols/xcstrings-tool-plugin", .upToNextMajor(from: "1.2.0")),
   ],
@@ -41,11 +37,8 @@ let package = Package(
         .product(name: "Networking", package: "Networking"),
         .product(name: "Nuke", package: "Nuke"),
         .product(name: "NukeUI", package: "Nuke"),
-        .product(name: "NukeExtensions", package: "Nuke"),
-        .product(name: "MarkdownUI", package: "swift-markdown-ui"),
         .product(name: "Semaphore", package: "Semaphore"),
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-        .product(name: "BezelKit", package: "BezelKit"),
       ],
       resources: [
         .process("Resources/Localization")

--- a/Networking/Package.swift
+++ b/Networking/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
   dependencies: [
     .package(path: "../Common"),
     .package(path: "../DataModel"),
-    .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.4"),
     .package(url: "https://github.com/groue/Semaphore", from: "0.1.0"),
   ],
   targets: [
@@ -30,7 +29,6 @@ let package = Package(
       dependencies: [
         .product(name: "Common", package: "Common"),
         .product(name: "DataModel", package: "DataModel"),
-        .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "Semaphore", package: "Semaphore"),
       ],
       path: "Sources",

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -5,7 +5,6 @@
 //  Created by Paul Gessinger on 18.02.23.
 //
 
-import AsyncAlgorithms
 import Common
 import DataModel
 import Foundation

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -8,10 +8,6 @@ Swift Paperless uses the following third-party libraries for various features:
 [GitHub](https://github.com/apple/swift-async-algorithms)
 *Apache-2.0 license*
 
-## swift-collections
-[GitHub](https://github.com/apple/swift-collections)
-*Apache-2.0 license*
-
 ## Semaphore
 [GitHub](https://github.com/groue/Semaphore)
 *MIT license*

--- a/project.yml
+++ b/project.yml
@@ -37,18 +37,9 @@ packages:
   swift-markdown-ui:
     url: https://github.com/gonzalezreal/swift-markdown-ui.git
     majorVersion: 2.3.1
-  Semaphore:
-    url: https://github.com/groue/Semaphore
-    majorVersion: 0.1.0
-  swift-async-algorithms:
-    url: https://github.com/apple/swift-async-algorithms
-    majorVersion: 1.0.0
   BezelKit:
     url: https://github.com/markbattistella/BezelKit
     majorVersion: 4.1.1
-  swift-collections:
-    url: https://github.com/apple/swift-collections.git
-    majorVersion: 1.0.0
   xcstrings-tool-plugin:
     url: https://github.com/liamnichols/xcstrings-tool-plugin
     majorVersion: 1.2.0
@@ -75,14 +66,9 @@ targets:
       - package: Nuke
         product: Nuke
       - package: Nuke
-        product: NukeExtensions
-      - package: Nuke
         product: NukeUI
       - package: swift-markdown-ui
         product: MarkdownUI
-      - package: Semaphore
-      - package: swift-async-algorithms
-        product: AsyncAlgorithms
       - package: BezelKit
       - package: AppShared
       - package: Common
@@ -105,13 +91,6 @@ targets:
       - path: swift-paperless/PrivacyInfo.xcprivacy
     dependencies:
       - package: AppShared
-      - package: Nuke
-        product: NukeUI
-      - package: Semaphore
-      - package: swift-async-algorithms
-        product: AsyncAlgorithms
-      - package: Common
-      - package: DataModel
       - package: Networking
 
   swift-paperlessUITests:

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -6,7 +6,6 @@
 //
 
 import AppShared
-import AsyncAlgorithms
 import Combine
 import Common
 import DataModel


### PR DESCRIPTION
Drop NukeExtensions and swift-collections (never imported). Remove
MarkdownUI and BezelKit from AppShared (app-only). Drop
swift-async-algorithms from Networking and stale imports. Simplify
project.yml target deps to rely on transitive linking via AppShared.