### PR TITLE
feat: Document versions model + version-keyed content store

### DIFF
--- a/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
@@ -217,19 +217,6 @@ public final class NeedsAuthRepository<Wrapped: Repository>: Repository {
     try wrapped.thumbnailRequest(document: document)
   }
 
-  public func download(documentID: UInt) async throws -> URL {
-    try await intercept { try await wrapped.download(documentID: documentID) }
-  }
-
-  public func download(
-    documentID: UInt, original: Bool, progress: (@Sendable (Double) -> Void)?
-  ) async throws -> URL {
-    try await intercept {
-      try await wrapped.download(
-        documentID: documentID, original: original, progress: progress)
-    }
-  }
-
   public func download(
     document: Document, original: Bool,
     progress: (@Sendable (Double) -> Void)?

--- a/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
+++ b/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
@@ -31,7 +31,13 @@ public struct DocumentPreviewImage: View {
         .scaledToFit()
     }
 
-    .task {
+    // Keyed on the version, not bare: a bare `.task` runs once per view
+    // identity, and a list refresh swaps in a new `Document` at the same row
+    // position without changing that identity — so a version added or deleted
+    // server-side would keep showing the thumbnail from the first load.
+    // `versionQueryID` is exactly what `thumbnailRequest` puts in the URL, so
+    // this re-fires when the URL would change and never otherwise.
+    .task(id: document.versionQueryID) {
       image.transaction = Transaction(animation: .linear(duration: 0.1))
       do {
         image.pipeline = store.imagePipeline

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -8,7 +8,14 @@
 import Foundation
 import os
 
-/// On-disk blob cache keyed by `(serverID, documentRemoteID, versionID, kind)`.
+/// On-disk blob cache keyed by `(serverID, versionID, kind)`.
+///
+/// `versionID` is the server-side document version row id; since paperless-ngx
+/// stores versions as sibling rows in the document table, version ids share a
+/// namespace with document ids, so a single id uniquely identifies the
+/// content. For documents without a `versions` array (older backends, or
+/// single-file docs) callers pass the document id directly — it equals the
+/// root version id server-side.
 ///
 /// Lives in the app-group container so the Share Extension (and a future
 /// File Provider extension) can read it on a locked device. Files are written
@@ -35,18 +42,11 @@ public struct ContentStore: Sendable {
 
   public struct Key: Hashable, Sendable {
     public let serverID: UUID
-    public let documentRemoteID: UInt
-    public let versionID: String
+    public let versionID: UInt
     public let kind: Kind
 
-    public static let currentVersion = "current"
-
-    public init(
-      serverID: UUID, documentRemoteID: UInt,
-      versionID: String = Key.currentVersion, kind: Kind
-    ) {
+    public init(serverID: UUID, versionID: UInt, kind: Kind) {
       self.serverID = serverID
-      self.documentRemoteID = documentRemoteID
       self.versionID = versionID
       self.kind = kind
     }
@@ -86,8 +86,7 @@ public struct ContentStore: Sendable {
   private func directory(for key: Key) -> URL {
     canonicalRoot
       .appendingPathComponent(key.serverID.uuidString, isDirectory: true)
-      .appendingPathComponent(String(key.documentRemoteID), isDirectory: true)
-      .appendingPathComponent(key.versionID, isDirectory: true)
+      .appendingPathComponent(String(key.versionID), isDirectory: true)
   }
 
   public func url(for key: Key) -> URL {

--- a/Common/Tests/CommonTests/ContentStoreTests.swift
+++ b/Common/Tests/CommonTests/ContentStoreTests.swift
@@ -32,11 +32,10 @@ struct ContentStoreTests {
   static let serverB = UUID()
 
   static func key(
-    server: UUID = serverA, doc: UInt = 42, version: String = "current",
+    server: UUID = serverA, version: UInt = 42,
     kind: ContentStore.Kind = .archive
   ) -> ContentStore.Key {
-    ContentStore.Key(
-      serverID: server, documentRemoteID: doc, versionID: version, kind: kind)
+    ContentStore.Key(serverID: server, versionID: version, kind: kind)
   }
 
   @Test
@@ -44,10 +43,18 @@ struct ContentStoreTests {
     let (store, _) = try Self.makeStore()
     let k = Self.key()
     #expect(store.url(for: k) == store.url(for: k))
-    #expect(store.url(for: k) != store.url(for: Self.key(doc: 43)))
+    #expect(store.url(for: k) != store.url(for: Self.key(version: 43)))
     #expect(store.url(for: k) != store.url(for: Self.key(server: Self.serverB)))
     #expect(store.url(for: k) != store.url(for: Self.key(kind: .original)))
-    #expect(store.url(for: k) != store.url(for: Self.key(version: "other")))
+  }
+
+  @Test
+  func urlIncludesVersionInPath() throws {
+    let (store, _) = try Self.makeStore()
+    let url = store.url(for: Self.key(version: 35, kind: .archive))
+    #expect(url.pathComponents.contains("35"))
+    #expect(url.pathComponents.contains(Self.serverA.uuidString))
+    #expect(url.lastPathComponent == "archive.pdf")
   }
 
   @Test

--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -52,6 +52,25 @@ public struct DocumentNote: Identifiable, Equatable, Sendable, Hashable {
   }
 }
 
+public struct DocumentVersion: Identifiable, Equatable, Sendable, Hashable {
+  public var id: UInt
+  public var added: Date
+  public var label: String?
+  public var checksum: String?
+  public var isRoot: Bool
+
+  public init(
+    id: UInt, added: Date, label: String? = nil,
+    checksum: String? = nil, isRoot: Bool
+  ) {
+    self.id = id
+    self.added = added
+    self.label = label
+    self.checksum = checksum
+    self.isRoot = isRoot
+  }
+}
+
 public struct Document: Identifiable, Equatable, Hashable, Sendable {
   public var id: UInt
   public var title: String
@@ -77,6 +96,13 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
 
   public var notes: NotesPayload = .init()
   public var customFields: CustomFieldRawEntryList
+
+  // Server-side version rows for this document, newest-first or order-undefined
+  // depending on backend. Empty on backends predating multi-version support.
+  // `currentVersionID` and `rootVersionID` resolve the right id even when this
+  // is empty by falling back to `self.id` — the document id equals the root
+  // version id on the server (versions are sibling rows in the same table).
+  public var versions: [DocumentVersion] = []
 
   // Presense of this depends on the endpoint
   // If we didn't get a value, we likely just modified
@@ -109,6 +135,7 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
     pageCount: Int? = nil,
     notes: NotesPayload = .init(),
     customFields: CustomFieldRawEntryList = CustomFieldRawEntryList(),
+    versions: [DocumentVersion] = [],
     userCanChange: Bool = true,
     permissions: Permissions? = nil,
     setPermissions: Permissions? = nil
@@ -129,6 +156,7 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
     self.pageCount = pageCount
     self.notes = notes
     self.customFields = customFields
+    self.versions = versions
     self.userCanChange = userCanChange
     self.permissions = permissions
     self.setPermissions = setPermissions
@@ -148,6 +176,21 @@ extension Document {
     if let name = serverName, !name.isEmpty { return name }
     let base = title.isEmpty ? "document" : title
     return "\(base).pdf"
+  }
+
+  /// Id of the version the server returns when no `?version=` query is sent.
+  /// paperless serves the newest version by default; we mirror that by picking
+  /// the latest `added`. Falls back to `self.id` when `versions` is empty
+  /// (older backends, single-file documents) — the document id equals the
+  /// root version id server-side, so this fallback is correct, not a fudge.
+  public var currentVersionID: UInt {
+    versions.max(by: { $0.added < $1.added })?.id ?? id
+  }
+
+  /// Id of the original/root version. Same fallback rationale as
+  /// `currentVersionID`.
+  public var rootVersionID: UInt {
+    versions.first(where: \.isRoot)?.id ?? id
   }
 }
 

--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -97,8 +97,10 @@ public struct Document: Identifiable, Equatable, Hashable, Sendable {
   public var notes: NotesPayload = .init()
   public var customFields: CustomFieldRawEntryList
 
-  // Server-side version rows for this document, newest-first or order-undefined
-  // depending on backend. Empty on backends predating multi-version support.
+  // Server-side version rows for this document. The serializer sorts these
+  // id-descending (newest first), but nothing here relies on that — the
+  // accessors below order explicitly. Empty on backends predating
+  // multi-version support, which means anything before v3.0.0-beta.
   // `currentVersionID` and `rootVersionID` resolve the right id even when this
   // is empty by falling back to `self.id` — the document id equals the root
   // version id on the server (versions are sibling rows in the same table).
@@ -179,12 +181,29 @@ extension Document {
   }
 
   /// Id of the version the server returns when no `?version=` query is sent.
-  /// paperless serves the newest version by default; we mirror that by picking
-  /// the latest `added`. Falls back to `self.id` when `versions` is empty
-  /// (older backends, single-file documents) — the document id equals the
-  /// root version id server-side, so this fallback is correct, not a fudge.
+  /// paperless resolves that with `order_by("-id").first()`, so we order by
+  /// id too — *not* by `added`, which can disagree after an import or restore
+  /// preserves original timestamps. Ids are unique primary keys, so this
+  /// ordering is total and the result never depends on array order.
+  ///
+  /// Falls back to `self.id` when `versions` is empty (older backends,
+  /// single-file documents) — the document id equals the root version id
+  /// server-side, so this fallback is correct, not a fudge.
   public var currentVersionID: UInt {
-    versions.max(by: { $0.added < $1.added })?.id ?? id
+    versions.max(by: { $0.id < $1.id })?.id ?? id
+  }
+
+  /// Version id to put in a `?version=` query, or `nil` when the parameter
+  /// should be omitted entirely.
+  ///
+  /// With no versions, `currentVersionID` is `self.id` — the root id, which is
+  /// exactly what the backend picks anyway, so sending it conveys nothing.
+  /// Omitting it keeps request URLs byte-identical to what pre-versions builds
+  /// sent, which matters because Nuke keys its thumbnail data cache on the URL
+  /// string: sending a redundant parameter would invalidate every cached
+  /// thumbnail for every user whose server has no multi-version support.
+  public var versionQueryID: UInt? {
+    versions.isEmpty ? nil : currentVersionID
   }
 
   /// Id of the original/root version. Same fallback rationale as

--- a/DataModel/Tests/DataModelTests/DocumentVersionTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentVersionTest.swift
@@ -1,0 +1,72 @@
+//
+//  DocumentVersionTest.swift
+//  DataModel
+//
+
+import Foundation
+import Testing
+
+@testable import DataModel
+
+@Suite
+struct DocumentVersionTest {
+  static func makeDocument(id: UInt = 16, versions: [DocumentVersion] = []) -> Document {
+    Document(
+      id: id, title: "doc",
+      created: Date(timeIntervalSince1970: 0), tags: [],
+      versions: versions)
+  }
+
+  @Test(
+    "Empty versions array falls back to the document id (doc id == root version id server-side)")
+  func emptyVersionsFallsBackToDocumentId() {
+    let doc = Self.makeDocument(id: 42, versions: [])
+    #expect(doc.currentVersionID == 42)
+    #expect(doc.rootVersionID == 42)
+  }
+
+  @Test("Single version: currentVersionID is that version, rootVersionID respects isRoot")
+  func singleVersion() {
+    let doc = Self.makeDocument(
+      id: 16,
+      versions: [
+        DocumentVersion(
+          id: 16, added: Date(timeIntervalSince1970: 1000),
+          label: "V1", isRoot: true)
+      ])
+    #expect(doc.currentVersionID == 16)
+    #expect(doc.rootVersionID == 16)
+  }
+
+  @Test("Two versions: newest by `added` wins for currentVersionID, root wins for rootVersionID")
+  func twoVersionsPicksNewestAndRoot() {
+    let doc = Self.makeDocument(
+      id: 16,
+      versions: [
+        DocumentVersion(
+          id: 16, added: Date(timeIntervalSince1970: 1_000),
+          label: "V1", isRoot: true),
+        DocumentVersion(
+          id: 35, added: Date(timeIntervalSince1970: 2_000),
+          label: "V2", isRoot: false),
+      ])
+    #expect(doc.currentVersionID == 35)
+    #expect(doc.rootVersionID == 16)
+  }
+
+  @Test("Version order in the array does not change resolution")
+  func versionOrderIndependent() {
+    let v1 = DocumentVersion(
+      id: 16, added: Date(timeIntervalSince1970: 1_000),
+      label: "V1", isRoot: true)
+    let v2 = DocumentVersion(
+      id: 35, added: Date(timeIntervalSince1970: 2_000),
+      label: "V2", isRoot: false)
+
+    let docAscending = Self.makeDocument(versions: [v1, v2])
+    let docDescending = Self.makeDocument(versions: [v2, v1])
+
+    #expect(docAscending.currentVersionID == docDescending.currentVersionID)
+    #expect(docAscending.rootVersionID == docDescending.rootVersionID)
+  }
+}

--- a/DataModel/Tests/DataModelTests/DocumentVersionTest.swift
+++ b/DataModel/Tests/DataModelTests/DocumentVersionTest.swift
@@ -38,7 +38,7 @@ struct DocumentVersionTest {
     #expect(doc.rootVersionID == 16)
   }
 
-  @Test("Two versions: newest by `added` wins for currentVersionID, root wins for rootVersionID")
+  @Test("Two versions: highest id wins for currentVersionID, root wins for rootVersionID")
   func twoVersionsPicksNewestAndRoot() {
     let doc = Self.makeDocument(
       id: 16,
@@ -68,5 +68,59 @@ struct DocumentVersionTest {
 
     #expect(docAscending.currentVersionID == docDescending.currentVersionID)
     #expect(docAscending.rootVersionID == docDescending.rootVersionID)
+  }
+
+  // paperless resolves the default version with `order_by("-id").first()`
+  // (documents/versioning.py, get_latest_version_for_root), so a newer row with
+  // an older `added` must still win. `added` can trail id after an import or a
+  // restore preserves the original timestamps.
+  @Test("Highest id wins even when its `added` timestamp is older")
+  func idWinsOverAddedTimestamp() {
+    let doc = Self.makeDocument(
+      id: 16,
+      versions: [
+        DocumentVersion(
+          id: 16, added: Date(timeIntervalSince1970: 9_000),
+          label: "V1", isRoot: true),
+        DocumentVersion(
+          id: 35, added: Date(timeIntervalSince1970: 1_000),
+          label: "V2 (restored, original timestamp preserved)", isRoot: false),
+      ])
+    #expect(doc.currentVersionID == 35)
+    #expect(doc.rootVersionID == 16)
+  }
+
+  // Ordering by id is total because ids are unique primary keys. Ordering by
+  // `added` was not: `max(by:)` returns an unspecified element among ties, so
+  // `versionOrderIndependent` above did not actually hold for equal timestamps.
+  @Test("Equal `added` timestamps still resolve deterministically")
+  func equalAddedTimestampsResolveByID() {
+    let sameInstant = Date(timeIntervalSince1970: 1_000)
+    let v1 = DocumentVersion(id: 16, added: sameInstant, label: "V1", isRoot: true)
+    let v2 = DocumentVersion(id: 35, added: sameInstant, label: "V2", isRoot: false)
+
+    #expect(Self.makeDocument(versions: [v1, v2]).currentVersionID == 35)
+    #expect(Self.makeDocument(versions: [v2, v1]).currentVersionID == 35)
+  }
+
+  @Test("versionQueryID is nil without versions, so no redundant `?version=` is sent")
+  func versionQueryIDOmittedWhenNoVersions() {
+    #expect(Self.makeDocument(id: 42, versions: []).versionQueryID == nil)
+  }
+
+  @Test("versionQueryID matches currentVersionID once the server reports versions")
+  func versionQueryIDPresentWithVersions() {
+    let doc = Self.makeDocument(
+      id: 16,
+      versions: [
+        DocumentVersion(
+          id: 16, added: Date(timeIntervalSince1970: 1_000),
+          label: "V1", isRoot: true),
+        DocumentVersion(
+          id: 35, added: Date(timeIntervalSince1970: 2_000),
+          label: "V2", isRoot: false),
+      ])
+    #expect(doc.versionQueryID == 35)
+    #expect(doc.versionQueryID == doc.currentVersionID)
   }
 }

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -462,49 +462,40 @@ extension ApiRepository: Repository {
   }
 
   public func download(
-    documentID: UInt, original: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
-  ) async throws -> URL {
-    // No Document handle → no modified timestamp to validate the cache,
-    // so streamDownload's nil-modified guard bypasses ContentStore and
-    // fetches fresh every call. Callers should prefer download(document:...).
-    try await streamDownload(
-      documentID: documentID, original: original,
-      modified: nil, progress: progress)
-  }
-
-  public func download(
     document: Document, original: Bool = false,
     progress: (@Sendable (Double) -> Void)? = nil
   ) async throws -> URL {
-    try await streamDownload(
-      documentID: document.id, original: original,
-      modified: document.modified, progress: progress)
+    try await streamDownload(document: document, original: original, progress: progress)
   }
 
   private func streamDownload(
-    documentID: UInt, original: Bool,
-    modified: Date?, progress: (@Sendable (Double) -> Void)?
+    document: Document, original: Bool,
+    progress: (@Sendable (Double) -> Void)?
   ) async throws -> URL {
     Logger.networking.notice("Downloading document (original: \(original))")
+
+    let version = document.currentVersionID
 
     // Without a staleness signal (modified timestamp) we can't validate a
     // cached blob — and writing one back without `modified` would cache it
     // indefinitely with no way to detect server-side changes. Bypass the
     // ContentStore entirely in that case. Also fall back when the app-group
     // container isn't available (host tests, mis-configured entitlement).
-    guard let contentStore, let modified else {
+    guard let contentStore, let modified = document.modified else {
       return try await fetchToTemp(
-        documentID: documentID, original: original, progress: progress)
+        documentID: document.id, original: original, version: version,
+        progress: progress)
     }
 
     let key = ContentStore.Key(
       serverID: connection.serverID,
-      documentRemoteID: documentID,
+      versionID: version,
       kind: original ? .original : .archive)
 
     if let cached = contentStore.read(key, freshAgainst: modified) {
       Logger.networking.info(
-        "ContentStore hit for documentID \(documentID) (original: \(original))")
+        "ContentStore hit for documentID \(document.id) version \(version) (original: \(original))"
+      )
       progress?(1.0)
       return cached
     }
@@ -517,7 +508,7 @@ extension ApiRepository: Repository {
       defer { inFlightDownloads[key] = nil }
 
       let request = try request(
-        .download(documentId: documentID, original: original))
+        .download(documentId: document.id, original: original, version: version))
       let (tempURL, response) = try await urlSession.getDownload(
         for: request, progress: progress)
 
@@ -531,11 +522,11 @@ extension ApiRepository: Repository {
   }
 
   private func fetchToTemp(
-    documentID: UInt, original: Bool,
+    documentID: UInt, original: Bool, version: UInt?,
     progress: (@Sendable (Double) -> Void)?
   ) async throws -> URL {
     let request = try request(
-      .download(documentId: documentID, original: original))
+      .download(documentId: documentID, original: original, version: version))
     let (tempURL, response) = try await urlSession.getDownload(
       for: request, progress: progress)
     try validateDownloadResponse(response, request: request)
@@ -824,7 +815,8 @@ extension ApiRepository: Repository {
     func thumbnailRequest(document: Document) throws -> URLRequest
   {
     Logger.networking.debug("Get thumbnail for document \(document.id, privacy: .public)")
-    let url = try url(Endpoint.thumbnail(documentId: document.id))
+    let url = try url(
+      Endpoint.thumbnail(documentId: document.id, version: document.currentVersionID))
 
     var request = URLRequest(url: url)
     addTokenTo(request: &request)

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -36,7 +36,19 @@ public class ApiRepository {
 
   // Per-key in-flight task map: two concurrent downloads of the same blob
   // share one network request rather than racing into the ContentStore.
-  private var inFlightDownloads: [ContentStore.Key: Task<URL, Error>] = [:]
+  //
+  // Keyed by the staleness stamp as well as the content key. Coalescing on the
+  // content key alone would merge callers holding the same version but
+  // different `modified` timestamps, and whichever won the race would write its
+  // own stamp into the sidecar — recording the blob as fresher than it is if
+  // the loser held the newer stamp, which `read(_:freshAgainst:)` would then
+  // happily serve.
+  private struct DownloadKey: Hashable {
+    let content: ContentStore.Key
+    let modified: Date
+  }
+
+  private var inFlightDownloads: [DownloadKey: Task<URL, Error>] = [:]
 
   nonisolated
     private let apiVersion: UInt?
@@ -474,7 +486,12 @@ extension ApiRepository: Repository {
   ) async throws -> URL {
     Logger.networking.notice("Downloading document (original: \(original))")
 
+    // Two different notions of "version" here, deliberately kept apart:
+    // `version` always addresses a concrete row and partitions the local cache
+    // path, whereas `queryVersion` is nil unless the server actually reported
+    // versions, so we don't append a redundant `?version=` to the request URL.
     let version = document.currentVersionID
+    let queryVersion = document.versionQueryID
 
     // Without a staleness signal (modified timestamp) we can't validate a
     // cached blob — and writing one back without `modified` would cache it
@@ -483,7 +500,7 @@ extension ApiRepository: Repository {
     // container isn't available (host tests, mis-configured entitlement).
     guard let contentStore, let modified = document.modified else {
       return try await fetchToTemp(
-        documentID: document.id, original: original, version: version,
+        documentID: document.id, original: original, version: queryVersion,
         progress: progress)
     }
 
@@ -491,6 +508,7 @@ extension ApiRepository: Repository {
       serverID: connection.serverID,
       versionID: version,
       kind: original ? .original : .archive)
+    let inFlightKey = DownloadKey(content: key, modified: modified)
 
     if let cached = contentStore.read(key, freshAgainst: modified) {
       Logger.networking.info(
@@ -500,15 +518,15 @@ extension ApiRepository: Repository {
       return cached
     }
 
-    if let existing = inFlightDownloads[key] {
+    if let existing = inFlightDownloads[inFlightKey] {
       return try await existing.value
     }
 
     let task = Task<URL, Error> { [contentStore] in
-      defer { inFlightDownloads[key] = nil }
+      defer { inFlightDownloads[inFlightKey] = nil }
 
       let request = try request(
-        .download(documentId: document.id, original: original, version: version))
+        .download(documentId: document.id, original: original, version: queryVersion))
       let (tempURL, response) = try await urlSession.getDownload(
         for: request, progress: progress)
 
@@ -517,7 +535,7 @@ extension ApiRepository: Repository {
       return try contentStore.store(
         key, movingFrom: tempURL, modified: modified)
     }
-    inFlightDownloads[key] = task
+    inFlightDownloads[inFlightKey] = task
     return try await task.value
   }
 
@@ -816,7 +834,7 @@ extension ApiRepository: Repository {
   {
     Logger.networking.debug("Get thumbnail for document \(document.id, privacy: .public)")
     let url = try url(
-      Endpoint.thumbnail(documentId: document.id, version: document.currentVersionID))
+      Endpoint.thumbnail(documentId: document.id, version: document.versionQueryID))
 
     var request = URLRequest(url: url)
     addTokenTo(request: &request)

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -143,14 +143,23 @@ extension Endpoint {
       queryItems: [URLQueryItem(name: "id", value: String(noteId))])
   }
 
-  public static func thumbnail(documentId: UInt) -> Endpoint {
-    Endpoint(path: "/api/documents/\(documentId)/thumb", queryItems: [])
+  public static func thumbnail(documentId: UInt, version: UInt? = nil) -> Endpoint {
+    var queryItems: [URLQueryItem] = []
+    if let version {
+      queryItems.append(URLQueryItem(name: "version", value: String(version)))
+    }
+    return Endpoint(path: "/api/documents/\(documentId)/thumb", queryItems: queryItems)
   }
 
-  public static func download(documentId: UInt, original: Bool = false) -> Endpoint {
+  public static func download(
+    documentId: UInt, original: Bool = false, version: UInt? = nil
+  ) -> Endpoint {
     var queryItems: [URLQueryItem] = []
     if original {
       queryItems.append(URLQueryItem(name: "original", value: "true"))
+    }
+    if let version {
+      queryItems.append(URLQueryItem(name: "version", value: String(version)))
     }
     return Endpoint(path: "/api/documents/\(documentId)/download", queryItems: queryItems)
   }

--- a/Networking/Sources/Networking/Api/PreviewRepository.swift
+++ b/Networking/Sources/Networking/Api/PreviewRepository.swift
@@ -278,7 +278,8 @@ public class PreviewRepository: Repository {
   public func create(document _: ProtoDocument, file _: URL, filename _: String) async throws {}
 
   public func download(
-    documentID _: UInt, original _: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
+    document _: Document, original _: Bool = false,
+    progress: (@Sendable (Double) -> Void)? = nil
   )
     async throws -> URL
   {

--- a/Networking/Sources/Networking/Api/TransientRepository.swift
+++ b/Networking/Sources/Networking/Api/TransientRepository.swift
@@ -494,7 +494,8 @@ extension TransientRepository: Repository {
   }
 
   public func download(
-    documentID: UInt, original: Bool = false, progress: (@Sendable (Double) -> Void)? = nil
+    document: Document, original: Bool = false,
+    progress: (@Sendable (Double) -> Void)? = nil
   )
     async throws -> URL
   {
@@ -504,11 +505,11 @@ extension TransientRepository: Repository {
       progress?(Double(i) / 10.0)
     }
 
-    guard let data = documentPDFData[documentID] else {
+    guard let data = documentPDFData[document.id] else {
       throw RepositoryError.documentNotFound
     }
     let outputURL = FileManager.default.temporaryDirectory
-      .appendingPathComponent("transient-\(documentID)")
+      .appendingPathComponent("transient-\(document.id)")
       .appendingPathExtension("pdf")
     try data.write(to: outputURL, options: .atomic)
     return outputURL

--- a/Networking/Sources/Networking/Api/Wire/ApiDocument.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiDocument.swift
@@ -37,6 +37,8 @@ public struct ApiDocument: Codable, Sendable {
   // payload normalizes that to just a count.
   var notes: ApiNotesPayload?
   var custom_fields: CustomFieldRawEntryList?
+  // Read-only on the wire; absent on backends predating multi-version support.
+  var versions: [ApiDocumentVersion]?
   var user_can_change: Bool?
   var permissions: Permissions?
 }
@@ -60,6 +62,7 @@ extension ApiDocument {
       pageCount: page_count,
       notes: notes?.domain ?? NotesPayload(),
       customFields: custom_fields ?? CustomFieldRawEntryList(),
+      versions: versions?.map(\.domain) ?? [],
       userCanChange: user_can_change ?? true
     )
     doc.permissions = permissions

--- a/Networking/Sources/Networking/Api/Wire/ApiDocumentVersion.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiDocumentVersion.swift
@@ -1,0 +1,31 @@
+//
+//  ApiDocumentVersion.swift
+//  Networking
+//
+
+import DataModel
+import Foundation
+
+// MARK: - Wire type for the per-document `versions` array
+//
+// Matches paperless-ngx OpenAPI `DocumentVersionInfo`. `version_label` and
+// `checksum` are nullable; the rest are required. Read-only — there is no
+// corresponding Update variant because new versions are created via the
+// (out-of-scope) `POST /documents/{id}/update_version/` multipart endpoint,
+// not by writing this struct back.
+
+struct ApiDocumentVersion: Codable, Sendable {
+  var id: UInt
+  var added: Date
+  var version_label: String?
+  var checksum: String?
+  var is_root: Bool
+}
+
+extension ApiDocumentVersion {
+  var domain: DocumentVersion {
+    DocumentVersion(
+      id: id, added: added, label: version_label,
+      checksum: checksum, isRoot: is_root)
+  }
+}

--- a/Networking/Sources/Networking/NullRepository.swift
+++ b/Networking/Sources/Networking/NullRepository.swift
@@ -22,7 +22,8 @@ public class NullRepository: Repository {
   }
 
   public func download(
-    documentID _: UInt, original _: Bool = false, progress _: (@Sendable (Double) -> Void)? = nil
+    document _: Document, original _: Bool = false,
+    progress _: (@Sendable (Double) -> Void)? = nil
   )
     async throws -> URL
   { throw NotImplemented() }

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -85,14 +85,9 @@ public protocol Repository<Documents, Tasks>: Sendable {
   nonisolated
     func thumbnailRequest(document: Document) throws -> URLRequest
 
-  func download(documentID: UInt) async throws -> URL
-
-  func download(documentID: UInt, original: Bool, progress: (@Sendable (Double) -> Void)?)
-    async throws -> URL
-
-  // Preferred entry point: callers that already hold a Document supply it so
-  // the cache layer can use Document.modified as a staleness key without an
-  // extra round trip.
+  // Conformers receive a full Document handle so the cache layer can use
+  // Document.modified as a staleness key and Document.currentVersionID to
+  // address the right server-side version row.
   func download(
     document: Document, original: Bool,
     progress: (@Sendable (Double) -> Void)?
@@ -155,24 +150,14 @@ public protocol Repository<Documents, Tasks>: Sendable {
 }
 
 extension Repository {
-  public func download(documentID: UInt) async throws -> URL {
-    try await download(documentID: documentID, original: false, progress: nil)
-  }
-
-  public func download(documentID: UInt, original: Bool) async throws -> URL {
-    try await download(documentID: documentID, original: original, progress: nil)
-  }
-
-  // Default impl for conformers that don't implement the Document-aware path:
-  // fall back to the id-keyed call. ApiRepository overrides this directly to
-  // avoid a redundant document fetch when threading staleness through the
-  // ContentStore.
+  // Trampoline that supplies defaults for callers that don't need a progress
+  // callback or always want the archive variant. Delegates straight to the
+  // protocol requirement.
   public func download(
     document: Document, original: Bool = false,
     progress: (@Sendable (Double) -> Void)? = nil
   ) async throws -> URL {
-    try await download(
-      documentID: document.id, original: original, progress: progress)
+    try await download(document: document, original: original, progress: progress)
   }
 
   // Helper method documents with a title search

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -151,13 +151,20 @@ public protocol Repository<Documents, Tasks>: Sendable {
 
 extension Repository {
   // Trampoline that supplies defaults for callers that don't need a progress
-  // callback or always want the archive variant. Delegates straight to the
-  // protocol requirement.
+  // callback or always want the archive variant.
+  //
+  // Deliberately `download(document:original:)` and not
+  // `download(document:original:progress:)`: default argument values don't
+  // participate in witness matching, so the three-argument spelling would have
+  // the same signature as the protocol requirement and become its default
+  // witness — a body that calls itself. Conformers omitting the method would
+  // then compile cleanly and infinitely recurse at runtime. Dropping `progress`
+  // here makes the signature distinct, so it cannot satisfy the requirement and
+  // the compiler keeps enforcing that every conformer implements it.
   public func download(
-    document: Document, original: Bool = false,
-    progress: (@Sendable (Double) -> Void)? = nil
+    document: Document, original: Bool = false
   ) async throws -> URL {
-    try await download(document: document, original: original, progress: progress)
+    try await download(document: document, original: original, progress: nil)
   }
 
   // Helper method documents with a title search

--- a/Networking/Tests/NetworkingTests/ApiDocumentTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiDocumentTest.swift
@@ -88,6 +88,48 @@ struct ApiDocumentTest {
     #expect(document.permissions == nil)
   }
 
+  @Test("Decodes the versions array from a multi-version document payload")
+  func testVersionsDecode() throws {
+    let data = try #require(testData("Data/Document/document_versions.json"))
+    let document = try decoder.decode(ApiDocument.self, from: data).domain
+
+    #expect(document.id == 16)
+    #expect(document.title == "Versioned sample document")
+    #expect(document.notes.count == 2)
+    #expect(document.customFields.count == 2)
+    #expect(document.versions.count == 2)
+
+    let v2 = try #require(document.versions.first { $0.id == 35 })
+    #expect(v2.label == "V2")
+    #expect(
+      v2.checksum
+        == "e01dfa2f3493d94fe91cc0d92652d5ecbf58e6b4d641c68d92e3d14c861ef1c2")
+    #expect(v2.isRoot == false)
+
+    let v1 = try #require(document.versions.first { $0.id == 16 })
+    #expect(v1.label == "V1")
+    #expect(
+      v1.checksum
+        == "501ebfb7eadb0278de132157b4728a3e52c772a95396258422ea010836774846")
+    #expect(v1.isRoot == true)
+
+    // V2 was added after V1, so it's the current version.
+    #expect(document.currentVersionID == 35)
+    #expect(document.rootVersionID == 16)
+  }
+
+  @Test("Older backends without a `versions` field produce an empty array")
+  func testVersionsAbsent() throws {
+    let data = try #require(testData("Data/Document/full.json"))
+    let document = try decoder.decode(ApiDocument.self, from: data).domain
+
+    #expect(document.versions.isEmpty)
+    // Fallback: doc id == root version id server-side, so both resolvers
+    // return the document id when the versions array is empty.
+    #expect(document.currentVersionID == document.id)
+    #expect(document.rootVersionID == document.id)
+  }
+
   @Test("Tests that the user_can_change field is correctly decoded, even if not present")
   func testUserCanChangeDefault() throws {
     let data = try #require(testData("Data/Document/full_no_user_can_change.json"))

--- a/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
@@ -102,7 +102,7 @@ struct ApiRepositoryDownloadTest {
   ) -> ContentStore.Key {
     ContentStore.Key(
       serverID: serverID,
-      documentRemoteID: document.id,
+      versionID: document.currentVersionID,
       kind: original ? .original : .archive)
   }
 

--- a/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryDownloadTest.swift
@@ -89,12 +89,14 @@ struct ApiRepositoryDownloadTest {
   }
 
   nonisolated static func makeDocument(
-    id: UInt = 7, modified: Date? = Date(timeIntervalSince1970: 1000)
+    id: UInt = 7, modified: Date? = Date(timeIntervalSince1970: 1000),
+    versions: [DocumentVersion] = []
   ) -> Document {
     Document(
       id: id, title: "doc", asn: nil, documentType: nil, correspondent: nil,
       created: Date(timeIntervalSince1970: 0), tags: [],
-      added: nil, modified: modified, storagePath: nil)
+      added: nil, modified: modified, storagePath: nil,
+      versions: versions)
   }
 
   nonisolated static func canonicalKey(
@@ -270,5 +272,75 @@ struct ApiRepositoryDownloadTest {
 
     #expect(counter.value == 1)
     #expect(urls[0] == urls[1])
+  }
+
+  // Coalescing is keyed on the staleness stamp too. Two callers holding the
+  // same version but different `modified` must not share a task — the winner
+  // would otherwise write its own stamp into the sidecar for both, and a blob
+  // recorded as fresher than it is would then survive `freshAgainst:`.
+  @Test
+  func concurrentDownloadsWithDifferentModifiedNotDeduped() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let counter = Counter()
+    DownloadMockURLProtocol.responder = { req in
+      counter.bump()
+      Thread.sleep(forTimeInterval: 0.05)
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let older = Self.makeDocument(modified: Date(timeIntervalSince1970: 1000))
+    let newer = Self.makeDocument(modified: Date(timeIntervalSince1970: 2000))
+    async let a = repo.download(document: older)
+    async let b = repo.download(document: newer)
+    _ = try await [a, b]
+
+    #expect(counter.value == 2)
+  }
+
+  // Nuke keys its thumbnail data cache on the URL string, and the ContentStore
+  // path is keyed separately, so a redundant `?version=` on the request URL
+  // buys nothing and would invalidate every cached thumbnail on upgrade.
+  @Test
+  func noVersionQueryWhenServerReportsNoVersions() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let seenURL = LastValue<URL?>(nil)
+    DownloadMockURLProtocol.responder = { req in
+      seenURL.set(req.url)
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    _ = try await repo.download(document: Self.makeDocument(versions: []))
+    let query =
+      URLComponents(url: try #require(seenURL.value), resolvingAgainstBaseURL: false)?
+      .queryItems ?? []
+    #expect(!query.contains { $0.name == "version" })
+  }
+
+  @Test
+  func versionQuerySentWhenServerReportsVersions() async throws {
+    let (store, _) = try Self.makeStore()
+    let repo = Self.makeRepo(contentStore: store)
+    let seenURL = LastValue<URL?>(nil)
+    DownloadMockURLProtocol.responder = { req in
+      seenURL.set(req.url)
+      return (Self.okResponse(for: req), Data("X".utf8))
+    }
+    defer { DownloadMockURLProtocol.reset() }
+
+    let doc = Self.makeDocument(
+      id: 7,
+      versions: [
+        DocumentVersion(id: 7, added: Date(timeIntervalSince1970: 1000), isRoot: true),
+        DocumentVersion(id: 91, added: Date(timeIntervalSince1970: 2000), isRoot: false),
+      ])
+    _ = try await repo.download(document: doc)
+    let query =
+      URLComponents(url: try #require(seenURL.value), resolvingAgainstBaseURL: false)?
+      .queryItems ?? []
+    #expect(query.contains(URLQueryItem(name: "version", value: "91")))
   }
 }

--- a/Networking/Tests/NetworkingTests/Data/Document/document_versions.json
+++ b/Networking/Tests/NetworkingTests/Data/Document/document_versions.json
@@ -1,0 +1,73 @@
+{
+    "id": 16,
+    "correspondent": 13,
+    "document_type": null,
+    "storage_path": null,
+    "title": "Versioned sample document",
+    "content": "Sample document content for version decoding tests.",
+    "tags": [],
+    "created": "2025-05-01",
+    "created_date": "2025-05-01",
+    "modified": "2026-05-27T18:33:38.117362Z",
+    "added": "2025-06-09T09:51:07.344847Z",
+    "deleted_at": null,
+    "archive_serial_number": null,
+    "original_file_name": "sample-original.pdf",
+    "archived_file_name": "2025-05-01 sample-archived.pdf",
+    "duplicate_documents": [],
+    "owner": null,
+    "user_can_change": true,
+    "is_shared_by_requester": false,
+    "notes": [
+        {
+            "id": 16,
+            "note": "Note from authenticated user",
+            "created": "2025-09-05T18:58:45.010766Z",
+            "user": {
+                "id": 4,
+                "username": "testuser",
+                "first_name": "",
+                "last_name": ""
+            }
+        },
+        {
+            "id": 17,
+            "note": "Note without user",
+            "created": "2025-09-05T18:59:43.356117Z",
+            "user": null
+        }
+    ],
+    "custom_fields": [
+        {
+            "value": [
+                16,
+                3,
+                28
+            ],
+            "field": 9
+        },
+        {
+            "value": "Sample custom field value",
+            "field": 13
+        }
+    ],
+    "page_count": 1,
+    "mime_type": "application/pdf",
+    "root_document": null,
+    "versions": [
+        {
+            "id": 35,
+            "added": "2026-05-26T17:46:20.249790Z",
+            "version_label": "V2",
+            "checksum": "e01dfa2f3493d94fe91cc0d92652d5ecbf58e6b4d641c68d92e3d14c861ef1c2",
+            "is_root": false
+        },
+        {
+            "id": 16,
+            "added": "2025-06-09T09:51:07.344847Z",
+            "version_label": "V1",
+            "checksum": "501ebfb7eadb0278de132157b4728a3e52c772a95396258422ea010836774846",
+            "is_root": true
+        }
+    ]
+}

--- a/Networking/Tests/NetworkingTests/EndpointTest.swift
+++ b/Networking/Tests/NetworkingTests/EndpointTest.swift
@@ -94,10 +94,26 @@ import Testing
     #expect(endpoint.queryItems.isEmpty)
   }
 
+  @Test func testThumbnailWithVersion() {
+    let endpoint = Endpoint.thumbnail(documentId: 16, version: 35)
+    #expect(endpoint.path == "/api/documents/16/thumb")
+    #expect(endpoint.queryItems == [URLQueryItem(name: "version", value: "35")])
+  }
+
   @Test func testDownload() {
     let endpoint = Endpoint.download(documentId: 400)
     #expect(endpoint.path == "/api/documents/400/download")
     #expect(endpoint.queryItems.isEmpty)
+  }
+
+  @Test func testDownloadWithOriginalAndVersion() {
+    let endpoint = Endpoint.download(documentId: 16, original: true, version: 35)
+    #expect(endpoint.path == "/api/documents/16/download")
+    #expect(
+      endpoint.queryItems == [
+        URLQueryItem(name: "original", value: "true"),
+        URLQueryItem(name: "version", value: "35"),
+      ])
   }
 
   @Test func testSuggestions() {

--- a/swift-paperless/Views/Document/DocumentPreview.swift
+++ b/swift-paperless/Views/Document/DocumentPreview.swift
@@ -344,7 +344,10 @@ private struct IntegratedDocumentPreview: View {
     .animation(.easeOut(duration: 0.3), value: showLoadingOverlay)
     .animation(.easeOut(duration: Self.pdfFadeInDuration), value: downloadState)
 
-    .task {
+    // Keyed on the version for the same reason as the list cell: a refresh in
+    // an already-open detail view keeps this view's identity, so a bare
+    // `.task` would leave the placeholder thumbnail on the previous version.
+    .task(id: document.versionQueryID) {
       image.transaction = Transaction(animation: .linear(duration: 0.1))
       image.pipeline = store.imagePipeline
       do {


### PR DESCRIPTION
This pull request introduces support for document versioning in the data model, networking layer, and content cache. The main changes add a new `DocumentVersion` type, update the `Document` model to include a list of versions, and ensure that downloads and thumbnails are version-aware. The content cache keying is revised to use version IDs, and the API layer is updated to parse and use version information from the backend. Tests are added and updated to validate the new versioning behavior.

**Data Model and Versioning Support:**
* Added a new `DocumentVersion` struct and a `versions: [DocumentVersion]` property to the `Document` model, along with computed properties `currentVersionID` and `rootVersionID` for resolving the correct version ID. [[1]](diffhunk://#diff-474515b4032f071afc715e58a420e2eb57d34badaf8c317d78217a3ae30b39feR55-R73) [[2]](diffhunk://#diff-474515b4032f071afc715e58a420e2eb57d34badaf8c317d78217a3ae30b39feR100-R106) [[3]](diffhunk://#diff-474515b4032f071afc715e58a420e2eb57d34badaf8c317d78217a3ae30b39feR180-R194)
* Updated the model initializer and equality/hash implementations to include `versions`. [[1]](diffhunk://#diff-474515b4032f071afc715e58a420e2eb57d34badaf8c317d78217a3ae30b39feR138) [[2]](diffhunk://#diff-474515b4032f071afc715e58a420e2eb57d34badaf8c317d78217a3ae30b39feR159)
* Added comprehensive tests for version resolution logic in `DocumentVersionTest.swift`.

**Networking Layer Updates:**
* Updated API wire types to parse and expose the `versions` array from the backend, including a new `ApiDocumentVersion` struct and mapping logic. [[1]](diffhunk://#diff-72306145cdc8cd791186ae863aa57ba1168e28ad2942e5a716528b19eb15bd60R40-R41) [[2]](diffhunk://#diff-72306145cdc8cd791186ae863aa57ba1168e28ad2942e5a716528b19eb15bd60R65) [[3]](diffhunk://#diff-4da7ac3c8b5eb599e396e16e9ad68697bde09cf7746ff6ce1957881ae882345fR1-R31)
* Refactored repository interfaces and implementations to require a `Document` (not just an ID) for downloads, ensuring version and modified date are available for correct cache validation. [[1]](diffhunk://#diff-f0918b1347afcd63fa90f692953627c496a8187f2a76e55a8f662ecd2c9465f5L464-R498) [[2]](diffhunk://#diff-f0918b1347afcd63fa90f692953627c496a8187f2a76e55a8f662ecd2c9465f5L534-R529) [[3]](diffhunk://#diff-495b980c6a2a194333e3ee8002de5910907515fc1f81046e3ba53b793dd303beL281-R282) [[4]](diffhunk://#diff-a4b007092547c91479c5cb5e697eb66b0d0cb9dd8dac28dd659b3e8de32f55d9L497-R498) [[5]](diffhunk://#diff-a4b007092547c91479c5cb5e697eb66b0d0cb9dd8dac28dd659b3e8de32f55d9L507-R512) [[6]](diffhunk://#diff-11c730b4da38686f182277ede7813f26d61bc15d02c44df3abefaeaacac404c8L25-R26)
* Updated endpoints for downloads and thumbnails to accept an optional version parameter and include it in API requests. [[1]](diffhunk://#diff-e6b8c18691e50bd6b3dc5751ba3ed21e029a2cde5ffdb6850ba997c98f0bc290L146-R163) [[2]](diffhunk://#diff-f0918b1347afcd63fa90f692953627c496a8187f2a76e55a8f662ecd2c9465f5L520-R511) [[3]](diffhunk://#diff-f0918b1347afcd63fa90f692953627c496a8187f2a76e55a8f662ecd2c9465f5L827-R819)

**Content Cache (ContentStore) Changes:**
* Changed `ContentStore.Key` to use only `(serverID, versionID, kind)` (removing `documentRemoteID` and string version IDs), and updated all usages accordingly. [[1]](diffhunk://#diff-b11372b13579e5990e8ca49436f04ad6c63d0513314fd3943d162ac22c381de9L11-R18) [[2]](diffhunk://#diff-b11372b13579e5990e8ca49436f04ad6c63d0513314fd3943d162ac22c381de9L38-L49) [[3]](diffhunk://#diff-b11372b13579e5990e8ca49436f04ad6c63d0513314fd3943d162ac22c381de9L89-R89) [[4]](diffhunk://#diff-8414b4ede75152478f37da91f3176c55cd5ea64776f8cdc4c202cde0984f0b07L35-R57)
* Added tests to ensure the cache path includes the version ID.

**Repository Interface and Implementation Cleanup:**
* Removed old download methods that accepted only document IDs, enforcing the use of the new version-aware methods.

These changes ensure that all document downloads, thumbnails, and cached content are correctly tied to the appropriate document version, providing robust support for multi-version documents and future-proofing for backend enhancements.


## Behavioural notes (raised in review)

Three consequences of this change that are easy to miss from the diff. All of them are
bounded by the same fact: **multi-version support exists only from paperless-ngx
v3.0.0-beta.rc1**, so on every 2.x backend `versions` is empty, `currentVersionID` is
just `id`, and behaviour is unchanged from before this PR.

**1. A stale `Document` now selects a version, not merely a stale copy.**
`currentVersionID` is read off the caller's `Document`, and two production call sites can
hold one that predates a server-side version bump — `DocumentPreview.loadDocument` (from
the list row) and `DocumentDetailModel`, which deliberately fires a provisional download
before the metadata round-trip completes. Previously that staleness only cost a cache
check; now it can also pick a different file. The provisional download is superseded once
`store.document(id:)` returns, so the effect is a briefly-rendered older version rather
than a stuck one — but it is the biggest behavioural shift here.

**2. `?version=` is only sent when the server reported versions.** `currentVersionID`
falls back to `document.id`, so an unconditional query parameter would go out on *every*
download and thumbnail request. Nuke keys its data cache on the URL string, so that would
invalidate every cached thumbnail for every user on first launch after upgrade — to
convey an id the backend would have picked anyway. `Document.versionQueryID` is `nil`
when `versions` is empty, keeping URLs byte-identical for non-versioned servers. This
also means the parameter never reaches a backend that predates the feature.

**3. Version-keyed `ContentStore` paths remove the bound on cache growth.** Under the old
key a re-download overwrote the same path, so the store was self-limiting at one blob per
document per kind. Keyed by version, each new version gets its own directory and nothing
reclaims the old one — and there is no eviction today (`ContentStore.delete(_:)` has no
production callers; `purge()` is reachable only from the debug "clear local storage"
action). Stage 14's refcounting is the intended fix, so this ships a real steady-state
disk regression that persists for several PRs. Unbounded on a versioned backend, a no-op
on any 2.x one.

### Verification

Version-resolution behaviour is covered by unit tests only — **this has not been
exercised against a live multi-version backend.** The default-version ordering was
matched against the paperless-ngx source (`get_latest_version_for_root` uses
`order_by("-id")`, `documents/versioning.py`), not observed empirically.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)  👈
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->

