### PR TITLE
refactor: Migrate DocumentStore and ConnectionManager to @Observable

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -5,40 +5,39 @@
 //  Created by Paul Gessinger on 16.04.23.
 //
 
-import Combine
 import Common
 import DataModel
 import Foundation
 import Networking
 import Nuke
+import Persistence
 import Semaphore
 import SwiftUI
 import os
 
 @MainActor
-public final class DocumentStore: ObservableObject, Sendable {
-  // MARK: Publishers
+@Observable
+public final class DocumentStore: Sendable {
+  // MARK: Observed state
 
-  @Published public private(set) var documents: [UInt: Document] = [:]
-  @Published public private(set) var correspondents: [UInt: Correspondent] = [:]
-  @Published public private(set) var documentTypes: [UInt: DocumentType] = [:]
-  @Published public private(set) var tags: [UInt: Tag] = [:]
-  @Published public private(set) var savedViews: [UInt: SavedView] = [:]
-  @Published public private(set) var storagePaths: [UInt: StoragePath] = [:]
+  public private(set) var documents: [UInt: Document] = [:]
+  public private(set) var correspondents: [UInt: Correspondent] = [:]
+  public private(set) var documentTypes: [UInt: DocumentType] = [:]
+  public private(set) var tags: [UInt: Tag] = [:]
+  public private(set) var savedViews: [UInt: SavedView] = [:]
+  public private(set) var storagePaths: [UInt: StoragePath] = [:]
 
-  @Published public private(set) var users: [UInt: User] = [:]
-  @Published public private(set) var groups: [UInt: UserGroup] = [:]
-  @Published public private(set) var currentUser: User?
+  public private(set) var users: [UInt: User] = [:]
+  public private(set) var groups: [UInt: UserGroup] = [:]
+  public private(set) var currentUser: User?
 
-  @Published public private(set) var customFields: [UInt: CustomField] = [:]
+  public private(set) var customFields: [UInt: CustomField] = [:]
 
-  @Published public private(set) var serverConfiguration: ServerConfiguration?
+  public private(set) var serverConfiguration: ServerConfiguration?
 
-  @Published public private(set) var tasks: [PaperlessTask] = []
+  public private(set) var tasks: [PaperlessTask] = []
 
-  @Published
   public private(set) var permissions: UserPermissions = .empty
-  @Published
   public private(set) var settings = UISettingsSettings()
 
   public var activeTasks: [PaperlessTask] {
@@ -47,7 +46,7 @@ public final class DocumentStore: ObservableObject, Sendable {
 
   // MARK: Members
 
-  public enum Event {
+  public enum Event: Sendable {
     case deleted(document: Document)
     case changed(document: Document)
     case changeReceived(document: Document)
@@ -57,17 +56,17 @@ public final class DocumentStore: ObservableObject, Sendable {
     case taskError(task: PaperlessTask)
   }
 
-  public var eventPublisher =
-    PassthroughSubject<Event, Never>()
+  public let events = Broadcaster<Event>()
 
   public let semaphore = AsyncSemaphore(value: 1)
   public let fetchAllSemaphore = AsyncSemaphore(value: 1)
 
   public private(set) var repository: any Repository
 
-  @Published public private(set) var imagePipeline: ImagePipeline
+  public private(set) var imagePipeline: ImagePipeline
 
-  private var taskUpdateTask: Task<Void, Never>?
+  @ObservationIgnored
+  private nonisolated(unsafe) var taskUpdateTask: Task<Void, Never>?
 
   // MARK: Methods
 
@@ -99,7 +98,7 @@ public final class DocumentStore: ObservableObject, Sendable {
         Task {
           // don't send the errors all at once if there's multiple
           for task in newErrors {
-            eventPublisher.send(.taskError(task: task))
+            events.emit(.taskError(task: task))
             try? await Task.sleep(for: .seconds(2))
           }
         }
@@ -145,7 +144,7 @@ public final class DocumentStore: ObservableObject, Sendable {
     self.repository = repository
     imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
     if reload {
-      eventPublisher.send(.repositoryChanged)
+      events.emit(.repositoryChanged)
       clear()
     }
   }
@@ -186,7 +185,7 @@ public final class DocumentStore: ObservableObject, Sendable {
   public func updateDocument(_ document: Document) async throws -> Document {
     Logger.shared.info("Updating document with ID \(document.id, privacy: .public)")
     try checkPermission(.change, for: .document)
-    eventPublisher.send(.changed(document: document))
+    events.emit(.changed(document: document))
 
     var document = document
 
@@ -200,7 +199,7 @@ public final class DocumentStore: ObservableObject, Sendable {
 
     let updated = try await repository.update(document: document)
     documents[updated.id] = updated
-    eventPublisher.send(.changeReceived(document: updated))
+    events.emit(.changeReceived(document: updated))
     return updated
   }
 
@@ -209,26 +208,26 @@ public final class DocumentStore: ObservableObject, Sendable {
     try checkPermission(.delete, for: .document)
     try await repository.delete(document: document)
     documents.removeValue(forKey: document.id)
-    eventPublisher.send(.deleted(document: document))
+    events.emit(.deleted(document: document))
   }
 
   public func deleteNote(from document: Document, id: UInt) async throws {
     Logger.shared.info("Deleting note with ID \(id, privacy: .public)")
     try checkPermission(.delete, for: .note)
-    eventPublisher.send(.changed(document: document))
+    events.emit(.changed(document: document))
     _ = try await repository.deleteNote(id: id, documentId: document.id)
 
-    eventPublisher.send(.changeReceived(document: document))
+    events.emit(.changeReceived(document: document))
   }
 
   public func addNote(to document: Document, note: ProtoDocument.Note) async throws {
     Logger.shared.info("Adding note to document \(document.id, privacy: .public)")
     try checkPermission(.add, for: .note)
-    eventPublisher.send(.changed(document: document))
+    events.emit(.changed(document: document))
 
     _ = try await repository.createNote(documentId: document.id, note: note)
 
-    eventPublisher.send(.changeReceived(document: document))
+    events.emit(.changeReceived(document: document))
   }
 
   public func notes(for document: Document) async throws -> [Document.Note] {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -66,7 +66,7 @@ public final class DocumentStore: Sendable {
   public private(set) var imagePipeline: ImagePipeline
 
   @ObservationIgnored
-  private nonisolated(unsafe) var taskUpdateTask: Task<Void, Never>?
+  private var taskUpdateTask: Task<Void, Never>?
 
   // MARK: Methods
 

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -6,7 +6,6 @@
 //
 
 import AuthenticationServices
-import Combine
 import Common
 import CryptoKit
 import DataModel
@@ -165,7 +164,8 @@ public struct StoredConnection: Equatable, Identifiable, Sendable {
 }
 
 @MainActor
-public class ConnectionManager: ObservableObject {
+@Observable
+public class ConnectionManager {
   private struct PreviewLaunchArguments {
     let mode: Bool?
     let url: String?
@@ -223,19 +223,21 @@ public class ConnectionManager: ObservableObject {
     }
   }
 
-  public enum Event {
+  public enum Event: Sendable {
     case connectionChange(animated: Bool)
     case logout
   }
 
-  public var eventPublisher =
-    PassthroughSubject<Event, Never>()
+  public let events = Broadcaster<Event>()
 
+  @ObservationIgnored
   private let previewArguments: PreviewLaunchArguments?
   public let previewMode: Bool
 
+  @ObservationIgnored
   private let database: Database
-  private var observationTask: Task<Void, Never>?
+  @ObservationIgnored
+  private nonisolated(unsafe) var observationTask: Task<Void, Never>?
 
   public init(database: Database, previewMode: Bool? = nil) {
     self.database = database
@@ -294,11 +296,7 @@ public class ConnectionManager: ObservableObject {
   /// that follows it — is authoritative and reconciles this dict against the
   /// table; being equality-guarded, it is a no-op when the eager write already
   /// matched.
-  public private(set) var connections: [UUID: StoredConnection] = [:] {
-    willSet {
-      objectWillChange.send()
-    }
-  }
+  public private(set) var connections: [UUID: StoredConnection] = [:]
 
   /// Active server pointer.
   ///
@@ -306,18 +304,32 @@ public class ConnectionManager: ObservableObject {
   /// Share Extension picks up active-server changes through UserDefaults' free
   /// cross-process syncing. The "dangling pointer after row delete" case is
   /// handled in ``applyHydrate(records:)`` and ``logout(animated:)``.
+  ///
+  /// The @UserDefaultsBacked property wrapper is incompatible with the
+  /// @Observable macro's auto-tracking, so observation is wired manually
+  /// via access(keyPath:) / withMutation(keyPath:) around the private
+  /// backing storage.
+  @ObservationIgnored
   @UserDefaultsBacked("ActiveConnectionId", storage: .group)
-  public var activeConnectionId: UUID? = nil {
-    willSet {
-      objectWillChange.send()
+  private var _activeConnectionId: UUID? = nil
+
+  public var activeConnectionId: UUID? {
+    get {
+      access(keyPath: \.activeConnectionId)
+      return _activeConnectionId
+    }
+    set {
+      withMutation(keyPath: \.activeConnectionId) {
+        _activeConnectionId = newValue
+      }
     }
   }
 
   /// Per-connection "needs auth" set. Hydrated from the `needs_auth` column;
-  /// kept as a published Set<UUID> here so the existing banner / lock-badge
+  /// kept as a Set<UUID> here so the existing banner / lock-badge
   /// `.onChange(of: needsAuthIds)` watchers keep firing without touching the
   /// SwiftUI sites in this commit.
-  @Published public private(set) var needsAuthIds: Set<UUID> = []
+  public private(set) var needsAuthIds: Set<UUID> = []
 
   /// Apply a fresh snapshot of records to the in-memory dict and the
   /// needs-auth set. Called by both the bootstrap read and the observer.
@@ -380,7 +392,7 @@ public class ConnectionManager: ObservableObject {
   // the app shell observes this and presents `ReauthSheet`. Decoupled from
   // `needsAuthIds` so the banner can show without auto-presenting a sheet —
   // user consent stays explicit.
-  @Published public var reauthRequested: UUID? = nil
+  public var reauthRequested: UUID? = nil
 
   public func requestReauth(for id: UUID) {
     Logger.api.info(
@@ -394,7 +406,7 @@ public class ConnectionManager: ObservableObject {
 
   public func setActiveConnection(id: UUID, animated: Bool = true) {
     activeConnectionId = id
-    eventPublisher.send(.connectionChange(animated: animated))
+    events.emit(.connectionChange(animated: animated))
   }
 
   public func isServerUnique(_ url: URL) -> Bool {
@@ -539,11 +551,11 @@ public class ConnectionManager: ObservableObject {
       } else {
         Logger.api.info("Setting active connection to nil")
         self.activeConnectionId = nil
-        eventPublisher.send(.logout)
+        events.emit(.logout)
       }
     } else {
       activeConnectionId = nil
-      eventPublisher.send(.logout)
+      events.emit(.logout)
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -165,7 +165,7 @@ public struct StoredConnection: Equatable, Identifiable, Sendable {
 
 @MainActor
 @Observable
-public class ConnectionManager {
+public final class ConnectionManager {
   private struct PreviewLaunchArguments {
     let mode: Bool?
     let url: String?
@@ -237,7 +237,7 @@ public class ConnectionManager {
   @ObservationIgnored
   private let database: Database
   @ObservationIgnored
-  private nonisolated(unsafe) var observationTask: Task<Void, Never>?
+  private var observationTask: Task<Void, Never>?
 
   public init(database: Database, previewMode: Bool? = nil) {
     self.database = database

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -305,10 +305,17 @@ public final class ConnectionManager {
   /// cross-process syncing. The "dangling pointer after row delete" case is
   /// handled in ``applyHydrate(records:)`` and ``logout(animated:)``.
   ///
-  /// The @UserDefaultsBacked property wrapper is incompatible with the
-  /// @Observable macro's auto-tracking, so observation is wired manually
-  /// via access(keyPath:) / withMutation(keyPath:) around the private
-  /// backing storage.
+  /// A property wrapper cannot sit on an `@Observable`-tracked property at all:
+  /// the macro rewrites `x` into computed accessors over generated storage named
+  /// `_x`, which collides with the wrapper's own `_x` and fails to compile with
+  /// *"ambiguous reference to member '_x'"*. So the wrapper keeps the storage,
+  /// `@ObservationIgnored` keeps the macro off it, and the public property is
+  /// hand-written using the same `access` / `withMutation` pair the macro would
+  /// have generated.
+  ///
+  /// Note the key path is the **public** ``activeConnectionId``, not the private
+  /// storage: the registrar has to be keyed on what callers actually read, or
+  /// observers would never be notified.
   @ObservationIgnored
   @UserDefaultsBacked("ActiveConnectionId", storage: .group)
   private var _activeConnectionId: UUID? = nil

--- a/AppShared/Sources/AppShared/Utilities/View+onEvent.swift
+++ b/AppShared/Sources/AppShared/Utilities/View+onEvent.swift
@@ -1,0 +1,65 @@
+import Persistence
+import SwiftUI
+
+extension View {
+  /// Listen to a ``Broadcaster`` for the lifetime of this view's `@State`
+  /// storage. Shape matches `.onReceive(publisher:perform:)` but is backed by
+  /// an `AsyncStream` subscription whose `Task` outlives view
+  /// disappear/reappear cycles (NavigationStack push/pop) — `.task` and
+  /// `for await` would cancel on disappear and drop events.
+  public func onEvent<Element>(
+    from broadcaster: Broadcaster<Element>,
+    perform action: @escaping @MainActor (Element) -> Void
+  ) -> some View {
+    modifier(BroadcasterEventModifier(broadcaster: broadcaster, action: action))
+  }
+}
+
+/// Indirection so the long-lived subscription always invokes the handler from
+/// the *current* view value.
+///
+/// The subscription is created once and deliberately outlives disappear /
+/// reappear, so it cannot capture the handler directly: a closure captured at
+/// first appear would read stale `let`/`var` view properties forever.
+/// `.onReceive` gets this for free — its `SubscriptionView` swaps in the
+/// latest closure on every update — so matching that shape means refreshing
+/// the handler by hand on each `body` evaluation.
+///
+/// `@unchecked Sendable`: `action` is written in `body` and read in the sink
+/// handler, both of which are main-actor isolated.
+private final class EventActionBox<Element>: @unchecked Sendable {
+  var action: (@MainActor (Element) -> Void)?
+}
+
+private struct BroadcasterEventModifier<Element: Sendable>: ViewModifier {
+  let broadcaster: Broadcaster<Element>
+  let action: @MainActor (Element) -> Void
+
+  @State private var box = EventActionBox<Element>()
+  @State private var subscription: Subscription?
+
+  func body(content: Content) -> some View {
+    box.action = action
+
+    return
+      content
+      .onAppear {
+        if subscription == nil {
+          subscription = makeSubscription()
+        }
+      }
+      // A broadcaster swapped underneath a live view would otherwise keep
+      // delivering from the old one.
+      .onChange(of: ObjectIdentifier(broadcaster)) { _, _ in
+        subscription?.cancel()
+        subscription = makeSubscription()
+      }
+  }
+
+  private func makeSubscription() -> Subscription {
+    let box = box
+    return broadcaster.sink { element in
+      box.action?(element)
+    }
+  }
+}

--- a/AppShared/Sources/AppShared/Utilities/View+onEvent.swift
+++ b/AppShared/Sources/AppShared/Utilities/View+onEvent.swift
@@ -15,15 +15,25 @@ extension View {
   }
 }
 
-/// Indirection so the long-lived subscription always invokes the handler from
-/// the *current* view value.
+/// A mutable, `@State`-owned slot holding the *latest* handler closure, so the
+/// long-lived subscription can call forward into the current view value instead
+/// of the one that existed when it was created.
 ///
-/// The subscription is created once and deliberately outlives disappear /
-/// reappear, so it cannot capture the handler directly: a closure captured at
-/// first appear would read stale `let`/`var` view properties forever.
-/// `.onReceive` gets this for free — its `SubscriptionView` swaps in the
-/// latest closure on every update — so matching that shape means refreshing
-/// the handler by hand on each `body` evaluation.
+/// Why the indirection is needed: SwiftUI recreates the `ViewModifier` **struct**
+/// on every update, and each new struct carries a fresh `action` closure that has
+/// captured the current view's properties. The subscription, though, is created
+/// once in `onAppear` and deliberately outlives disappear/reappear (that is the
+/// whole point — see ``SwiftUICore/View/onEvent(from:perform:)``). If it captured
+/// `action` directly, it would pin the *first* closure forever, and any plain
+/// `let`/`var` view property that closure reads would be permanently stale.
+///
+/// `.onReceive` avoids this for free: its internal `SubscriptionView` is handed
+/// the newest closure on every update. Matching that shape by hand means storing
+/// the closure somewhere with view-lifetime identity (`@State`) and overwriting
+/// it on each `body` evaluation — which is what this class is.
+///
+/// Only the *closure* is refreshed; the subscription and its `Task` are untouched,
+/// so no events are dropped in the process.
 ///
 /// `@unchecked Sendable`: `action` is written in `body` and read in the sink
 /// handler, both of which are main-actor isolated.
@@ -35,10 +45,15 @@ private struct BroadcasterEventModifier<Element: Sendable>: ViewModifier {
   let broadcaster: Broadcaster<Element>
   let action: @MainActor (Element) -> Void
 
+  // Both need view-lifetime identity, not struct-lifetime: `@State` survives the
+  // struct being recreated on every update.
   @State private var box = EventActionBox<Element>()
   @State private var subscription: Subscription?
 
   func body(content: Content) -> some View {
+    // Hand the current closure to the box on every update — see ``EventActionBox``.
+    // Safe to do during `body`: the box is a plain class, so writing to it
+    // invalidates nothing and cannot loop.
     box.action = action
 
     return
@@ -48,8 +63,11 @@ private struct BroadcasterEventModifier<Element: Sendable>: ViewModifier {
           subscription = makeSubscription()
         }
       }
-      // A broadcaster swapped underneath a live view would otherwise keep
-      // delivering from the old one.
+      // Resubscribe if a *different* broadcaster is passed in; otherwise events
+      // would keep arriving from the old one. `Broadcaster` is a non-Equatable
+      // reference type, so it can't be the `onChange` value directly —
+      // `ObjectIdentifier` is the cheap Equatable stand-in for "same instance",
+      // making this fire on identity change and never on content change.
       .onChange(of: ObjectIdentifier(broadcaster)) { _, _ in
         subscription?.cancel()
         subscription = makeSubscription()

--- a/AppShared/Sources/AppShared/Views/ConnectionStatusBanner.swift
+++ b/AppShared/Sources/AppShared/Views/ConnectionStatusBanner.swift
@@ -18,7 +18,7 @@ import Common
 import SwiftUI
 
 public struct NeedsAuthBanner: View {
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @Environment(NetworkMonitor.self) private var networkMonitor
 
   public init() {}

--- a/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
@@ -79,7 +79,7 @@ private struct InvalidFieldView: View {
 
 private struct AddCustomFieldView: View {
   @Binding public var customFields: [CustomFieldInstance]
-  @EnvironmentObject public var store: DocumentStore
+  @Environment(DocumentStore.self) public var store
   @EnvironmentObject public var errorController: ErrorController
 
   @Environment(\.dismiss) private var dismiss
@@ -155,7 +155,7 @@ public struct CustomFieldsEditView<D: DocumentProtocol>: View {
   @Binding public var document: D
   @State private var customFields: [CustomFieldInstance] = []
 
-  @EnvironmentObject public var store: DocumentStore
+  @Environment(DocumentStore.self) public var store
   @Environment(\.locale) private var locale
   @Environment(\.isEnabled) private var isEnabled
 
@@ -383,7 +383,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
 
 #Preview("Fully equipped") {
   @Previewable
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()
@@ -394,7 +394,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
   NavigationStack {
     if document != nil {
       CustomFieldsEditView(document: Binding($document)!)
-        .environmentObject(store)
+        .environment(store)
         .environmentObject(errorController)
         .environment(\.locale, .init(identifier: "en_US"))
     }
@@ -410,7 +410,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
 
 #Preview("Empty") {
   @Previewable
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()
@@ -421,7 +421,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
   NavigationStack {
     if document != nil {
       CustomFieldsEditView(document: Binding($document)!)
-        .environmentObject(store)
+        .environment(store)
         .environmentObject(errorController)
         .environment(\.locale, .init(identifier: "en_US"))
     }

--- a/AppShared/Sources/AppShared/Views/CustomFields/DocumentLinkView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/DocumentLinkView.swift
@@ -14,7 +14,7 @@ private struct SearchView: View {
   @Binding public var selected: [Document]
   public let document: Document?
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @State private var searchText = ""
   @State private var matchingDocuments: [Document] = []
 
@@ -110,7 +110,7 @@ public struct DocumentSelectionView: View {
     self.document = document
   }
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(\.colorScheme) private var colorScheme
 
   @State private var selected: [Document] = []
@@ -233,7 +233,7 @@ private let field = CustomField(id: 9, name: "Custom doc link", dataType: .docum
 #Preview {
   @Previewable @State var instance = CustomFieldInstance(field: field, value: .documentLink([2]))
   @Previewable
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
   @Previewable @State var document: Document? = nil
 
   NavigationStack {
@@ -247,7 +247,7 @@ private let field = CustomField(id: 9, name: "Custom doc link", dataType: .docum
       }
     }
   }
-  .environmentObject(store)
+  .environment(store)
   .task {
     let documents = [
       ("Invoice #123", "file1.pdf"),

--- a/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
+++ b/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
@@ -20,7 +20,7 @@ private struct CreateNoteView: View {
   @FocusState private var focused: Bool
 
   @Environment(\.dismiss) private var dismiss
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   private func saveNote() async {
@@ -89,7 +89,7 @@ public struct DocumentNoteView: View {
 
   @State private var notes: [Document.Note] = []
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   @Environment(\.dismiss) private var dismiss
@@ -214,7 +214,7 @@ public struct DocumentNoteView: View {
 // - MARK: Preview
 
 private struct PreviewHelper: View {
-  @StateObject public var store = DocumentStore(repository: PreviewRepository(downloadDelay: 3.0))
+  @State public var store = DocumentStore(repository: PreviewRepository(downloadDelay: 3.0))
   @StateObject public var errorController = ErrorController()
 
   @State public var document: Document?
@@ -234,7 +234,7 @@ private struct PreviewHelper: View {
         }
       }
     }
-    .environmentObject(store)
+    .environment(store)
     .environmentObject(errorController)
 
     .task {

--- a/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
+++ b/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
@@ -81,7 +81,7 @@ public struct DocumentCellAspect: View {
 }
 
 public struct DocumentCell: View {
-  @ObservedObject public var store: DocumentStore
+  public var store: DocumentStore
   @Environment(\.redactionReasons) public var redactionReasons
 
   public var document: Document
@@ -197,7 +197,7 @@ public struct DocumentCell: View {
 }
 
 #Preview {
-  @Previewable @StateObject var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore(repository: TransientRepository())
   @Previewable @State var documents = [Document]()
 
   List {

--- a/AppShared/Sources/AppShared/Views/DocumentAsnEditingView.swift
+++ b/AppShared/Sources/AppShared/Views/DocumentAsnEditingView.swift
@@ -17,7 +17,7 @@ where DocumentType: DocumentProtocol & Equatable {
 
   @State private var checking = false
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.isEnabled) private var isEnabled: Bool
 

--- a/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
@@ -272,7 +272,7 @@ where
 {
   public typealias Element = Manager.Model.Element
 
-  @ObservedObject public var store: DocumentStore
+  public var store: DocumentStore
 
   @EnvironmentObject public var errorController: ErrorController
 
@@ -449,7 +449,7 @@ where
 }
 
 private struct FilterViewPreviewHelper<T: Pickable>: View {
-  @StateObject public var store = DocumentStore(repository: PreviewRepository())
+  @State public var store = DocumentStore(repository: PreviewRepository())
   @State public var filterState = FilterState.Filter.any
   @State public var elements: [(UInt, String)] = []
 
@@ -470,7 +470,7 @@ private struct FilterViewPreviewHelper<T: Pickable>: View {
         .map { ($0.key, $0.value.name) }
         .sorted(by: { $0.1 < $1.1 })
     }
-    .environmentObject(store)
+    .environment(store)
   }
 }
 

--- a/AppShared/Sources/AppShared/Views/Filter/DateFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/DateFilterView.swift
@@ -55,7 +55,7 @@ private struct DateFilterModeView: View {
 
   @State private var modeValue: Argument
   @State private var rangeValues: [Range] = []
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   public init(value: Binding<Argument>) {
     _value = value
@@ -143,7 +143,7 @@ public struct DateFilterView: View {
   @State private var query: FilterState.DateFilter
 
   @Environment(\.dismiss) private var dismiss
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   public init(query: Binding<FilterState.DateFilter>) {
     _queryOut = query

--- a/AppShared/Sources/AppShared/Views/Filter/TagFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/TagFilterView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import os
 
 public struct TagFilterView: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   @StateObject private var searchDebounce = DebounceObject(delay: 0.1)
 
@@ -253,13 +253,13 @@ public struct TagFilterView: View {
 }
 
 #Preview {
-  @Previewable @StateObject var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore(repository: TransientRepository())
 
   @Previewable @State var filterState = FilterState.default
 
   NavigationStack {
     TagFilterView(selectedTags: $filterState.tags)
-      .environmentObject(store)
+      .environment(store)
 
       .toolbar {
         ToolbarItem {

--- a/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
+++ b/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
@@ -128,7 +128,7 @@ public struct CreateDocumentView: View {
   public let share: Bool
   public let title: String
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @EnvironmentObject private var connectionManager: ConnectionManager
 
@@ -446,11 +446,13 @@ public struct CreateDocumentView: View {
         }
       }
 
-      .onReceive(store.eventPublisher) { event in
-        switch event {
-        case .repositoryWillChange:
-          resetDocument()
-        default: break
+      .task {
+        for await event in store.events.subscribe() {
+          switch event {
+          case .repositoryWillChange:
+            resetDocument()
+          default: break
+          }
         }
       }
 
@@ -466,7 +468,7 @@ public struct CreateDocumentView: View {
 // - MARK: Previews
 
 private struct PreviewHelperView: View {
-  @StateObject private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore(repository: PreviewRepository())
   @StateObject private var errorController = ErrorController()
   @StateObject private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
@@ -477,7 +479,7 @@ private struct PreviewHelperView: View {
 
   public var body: some View {
     CreateDocumentView(sourceUrl: url, share: share)
-      .environmentObject(store)
+      .environment(store)
       .environmentObject(errorController)
       .environmentObject(connectionManager)
   }

--- a/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
+++ b/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
@@ -446,13 +446,11 @@ public struct CreateDocumentView: View {
         }
       }
 
-      .task {
-        for await event in store.events.subscribe() {
-          switch event {
-          case .repositoryWillChange:
-            resetDocument()
-          default: break
-          }
+      .onEvent(from: store.events) { event in
+        switch event {
+        case .repositoryWillChange:
+          resetDocument()
+        default: break
         }
       }
 

--- a/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
+++ b/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
@@ -130,7 +130,7 @@ public struct CreateDocumentView: View {
 
   @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
 
   @State private var document = ProtoDocument()
   @State private var status = Status.none
@@ -470,7 +470,7 @@ public struct CreateDocumentView: View {
 private struct PreviewHelperView: View {
   @State private var store = DocumentStore(repository: PreviewRepository())
   @StateObject private var errorController = ErrorController()
-  @StateObject private var connectionManager = ConnectionManager(
+  @State private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
 
   private let url = Bundle.main.url(forResource: "demo2", withExtension: "pdf")!
@@ -481,7 +481,7 @@ private struct PreviewHelperView: View {
     CreateDocumentView(sourceUrl: url, share: share)
       .environment(store)
       .environmentObject(errorController)
-      .environmentObject(connectionManager)
+      .environment(connectionManager)
   }
 }
 

--- a/AppShared/Sources/AppShared/Views/MainLoadingView.swift
+++ b/AppShared/Sources/AppShared/Views/MainLoadingView.swift
@@ -98,7 +98,7 @@ public struct MainLoadingView: View {
 }
 
 #Preview {
-  @Previewable @StateObject var manager = ConnectionManager(
+  @Previewable @State var manager = ConnectionManager(
     database: try! Database.inMemory())
 
   MainLoadingView(

--- a/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
+++ b/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
@@ -26,7 +26,7 @@ where T: Identifiable & LocalizedResource, T.ID == UInt, E: PermissionsModel {
   public let storePath: KeyPath<DocumentStore, [UInt: T]>
   public let name: KeyPath<T, String>
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   private var displayElements: [T] {
     store[keyPath: storePath]
       .values
@@ -117,7 +117,7 @@ where T: Identifiable & LocalizedResource, T.ID == UInt, E: PermissionsModel {
 
 private struct OwnerPicker<Object>: View where Object: PermissionsModel {
   @Environment(\.dismiss) private var dismiss
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   @Binding public var object: Object
 
@@ -234,7 +234,7 @@ public struct PermissionsEditView<Object>: View where Object: PermissionsModel {
     }
   }
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private var permissions: Permissions {
     object.permissions ?? .init()
@@ -416,7 +416,7 @@ public struct PermissionsEditView<Object>: View where Object: PermissionsModel {
 // - MARK: Previews
 
 private struct PreviewHelper: View {
-  @EnvironmentObject public var store: DocumentStore
+  @Environment(DocumentStore.self) public var store
   @State public var document: Document?
   @State public var navPath = NavigationPath()
 
@@ -463,11 +463,11 @@ private struct PreviewHelper: View {
 
 #Preview {
   @Previewable
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
   @Previewable
   @StateObject var errorController = ErrorController()
 
   return PreviewHelper()
-    .environmentObject(store)
+    .environment(store)
     .environmentObject(errorController)
 }

--- a/AppShared/Sources/AppShared/Views/SavedViewEditView.swift
+++ b/AppShared/Sources/AppShared/Views/SavedViewEditView.swift
@@ -22,7 +22,7 @@ public struct SavedViewEditView<Element>: View where Element: SavedViewProtocol 
     !savedView.name.isEmpty && editable
   }
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   public init(
     element savedView: Element,

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -104,7 +104,7 @@ public struct ConnectionsView: View {
 
   @State private var showExtraHeader = false
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   public init(connectionManager: ConnectionManager, showLoginSheet: Binding<Bool>) {
     self.connectionManager = connectionManager

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -18,7 +18,7 @@ extension StoredConnection {
 }
 
 private struct ConnectionSelectionViews: View {
-  @ObservedObject public var connectionManager: ConnectionManager
+  public var connectionManager: ConnectionManager
   public let animated: Bool
 
   public var body: some View {
@@ -49,7 +49,7 @@ private struct ConnectionSelectionViews: View {
 }
 
 public struct ConnectionSelectionMenu: View {
-  @ObservedObject public var connectionManager: ConnectionManager
+  public var connectionManager: ConnectionManager
   public let animated: Bool
 
   public var body: some View {
@@ -90,7 +90,7 @@ public struct ConnectionSelectionMenu: View {
 }
 
 public struct ConnectionsView: View {
-  @ObservedObject private var connectionManager: ConnectionManager
+  private var connectionManager: ConnectionManager
   @Binding public var showLoginSheet: Bool
 
   @ScaledMetric(relativeTo: .title) private var plusIconSize = 18.0
@@ -274,7 +274,7 @@ public struct ConnectionsView: View {
 public struct ConnectionQuickChangeMenu: View {
   public init() {}
 
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
 
   public var body: some View {
     if connectionManager.connections.count > 1 {

--- a/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
@@ -81,7 +81,7 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
   public typealias Element = Manager.Model.Element
 
   @EnvironmentObject public var errorController: ErrorController
-  @EnvironmentObject public var store: DocumentStore
+  @Environment(DocumentStore.self) public var store
   @Environment(\.editMode) private var editMode
 
   @State public var model: Manager.Model?
@@ -328,7 +328,7 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
 }
 
 private struct Container<M: ManagerProtocol>: View {
-  @StateObject public var store = DocumentStore(repository: PreviewRepository())
+  @State public var store = DocumentStore(repository: PreviewRepository())
   @StateObject public var errorController = ErrorController()
 
   public var body: some View {
@@ -336,7 +336,7 @@ private struct Container<M: ManagerProtocol>: View {
       ManageView<M>()
         .navigationTitle("Title")
     }
-    .environmentObject(store)
+    .environment(store)
     .task {
       try? await store.fetchAll()
     }

--- a/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
@@ -16,7 +16,7 @@ public struct TrashView: View {
   public init() {}
 
   @State private var documents: [Document] = []
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @State public var editMode: EditMode = .inactive
   @EnvironmentObject private var errorController: ErrorController
 
@@ -138,14 +138,14 @@ public struct TrashView: View {
 }
 
 #Preview {
-  @Previewable @StateObject var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore(repository: TransientRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var ready = false
 
   NavigationStack {
     if ready {
       TrashView()
-        .environmentObject(store)
+        .environment(store)
         .environmentObject(errorController)
     }
   }

--- a/AppShared/Sources/AppShared/Views/Tags/TagEditView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagEditView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 import os
 
 public struct TagEditView<Element>: View where Element: TagProtocol & Sendable {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(\.colorScheme) private var colorScheme
 
   public var onSave: ((Element) throws -> Void)?
@@ -162,7 +162,7 @@ extension TagEditView where Element == ProtoTag {
 // MARK: - Parent picker
 
 public struct TagParentPickerView: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(\.dismiss) private var dismiss
 
   @Binding public var selection: UInt?

--- a/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 // - MARK: TagEditView
 public struct DocumentTagEditView<D>: View where D: DocumentProtocol {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   @Binding public var document: D
@@ -27,7 +27,7 @@ public struct DocumentTagEditView<D>: View where D: DocumentProtocol {
   @Namespace private var animation
 
   private struct CreateTag: View {
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @EnvironmentObject private var errorController: ErrorController
     @Environment(\.dismiss) private var dismiss
 

--- a/AppShared/Sources/AppShared/Views/Tags/TagView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagView.swift
@@ -212,5 +212,5 @@ private func tag(_ id: UInt, _ name: String, _ color: Color) -> Tag {
 #Preview("Placeholder") {
   TagsView()
     .redacted(reason: .placeholder)
-    .environmentObject(DocumentStore(repository: NullRepository()))
+    .environment(DocumentStore(repository: NullRepository()))
 }

--- a/Persistence/Sources/Persistence/Observation/Broadcaster.swift
+++ b/Persistence/Sources/Persistence/Observation/Broadcaster.swift
@@ -8,9 +8,15 @@ import Foundation
 ///
 /// Same shape as Combine's `PassthroughSubject` (drop-on-floor for late
 /// subscribers, no replay), but consumed as an `AsyncSequence`. Used here to
-/// observe GRDB table changes; will also back the `CacheChange` signal in
-/// later stages of the offline-cache plan and the event-bus migration on
-/// `DocumentStore` / `ConnectionManager`.
+/// observe GRDB table changes; also backs the discrete-event channels on
+/// `DocumentStore` / `ConnectionManager` (Stage 6) and will back the
+/// `CacheChange` signal in later offline-cache stages.
+///
+/// For SwiftUI consumers, prefer ``sink(_:)`` (returns a ``Subscription``
+/// that can be stored in `@State` via `.store(in:)`) over a bare
+/// `.task { for await … in subscribe() }` — `.task` is cancelled when the
+/// attached view disappears (e.g. on NavigationStack push), which drops
+/// events while a pushed child view is on screen.
 public final class Broadcaster<Element: Sendable>: @unchecked Sendable {
   private let lock = NSLock()
   private var continuations: [UUID: AsyncStream<Element>.Continuation] = [:]

--- a/Persistence/Sources/Persistence/Observation/Broadcaster.swift
+++ b/Persistence/Sources/Persistence/Observation/Broadcaster.swift
@@ -12,11 +12,11 @@ import Foundation
 /// `DocumentStore` / `ConnectionManager` (Stage 6) and will back the
 /// `CacheChange` signal in later offline-cache stages.
 ///
-/// For SwiftUI consumers, prefer ``sink(_:)`` (returns a ``Subscription``
-/// that can be stored in `@State` via `.store(in:)`) over a bare
-/// `.task { for await … in subscribe() }` — `.task` is cancelled when the
-/// attached view disappears (e.g. on NavigationStack push), which drops
-/// events while a pushed child view is on screen.
+/// For SwiftUI consumers, prefer AppShared's `.onEvent(from:perform:)` — or
+/// ``sink(_:)`` directly, holding the returned ``Subscription`` in `@State` —
+/// over a bare `.task { for await … in subscribe() }`: `.task` is cancelled
+/// when the attached view disappears (e.g. on NavigationStack push), which
+/// drops events while a pushed child view is on screen.
 public final class Broadcaster<Element: Sendable>: @unchecked Sendable {
   private let lock = NSLock()
   private var continuations: [UUID: AsyncStream<Element>.Continuation] = [:]

--- a/Persistence/Sources/Persistence/Observation/Subscription.swift
+++ b/Persistence/Sources/Persistence/Observation/Subscription.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// A handle to a long-lived task that will be cancelled when the handle
+/// deallocates, matching the lifecycle shape of Combine's `AnyCancellable`.
+///
+/// Designed to be stored in SwiftUI `@State`-owned containers (typically
+/// `Set<Subscription>`) so the underlying `Task` survives view appearance
+/// cycles — particularly NavigationStack push/pop where the parent view
+/// transiently "disappears" — and is torn down only when the view's state
+/// storage is freed.
+public final class Subscription: @unchecked Sendable, Hashable {
+  private let task: Task<Void, Never>
+
+  init(_ task: Task<Void, Never>) {
+    self.task = task
+  }
+
+  /// Cancel the underlying task immediately. The Subscription itself stays
+  /// allocated until its container releases it.
+  public func cancel() {
+    task.cancel()
+  }
+
+  deinit {
+    task.cancel()
+  }
+
+  public static func == (lhs: Subscription, rhs: Subscription) -> Bool {
+    lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+}
+
+extension Subscription {
+  /// Store the subscription in a `Set`, matching Combine's
+  /// `AnyCancellable.store(in:)` shape.
+  public func store(in set: inout Set<Subscription>) {
+    set.insert(self)
+  }
+
+  /// Store the subscription in any range-replaceable collection
+  /// (e.g. `[Subscription]`).
+  public func store<C: RangeReplaceableCollection>(in collection: inout C)
+  where C.Element == Subscription {
+    collection.append(self)
+  }
+}
+
+extension Broadcaster {
+  /// Subscribe with a handler closure and return a ``Subscription`` whose
+  /// lifetime owns the underlying receive task. Cancel by calling
+  /// ``Subscription/cancel()`` or by releasing the handle (typically via
+  /// the `Set<Subscription>` it was stored in).
+  ///
+  /// Mirrors Combine's `Publisher.sink(receiveValue:)`. The handler runs on
+  /// the main actor, matching `.onReceive`'s default delivery context for
+  /// SwiftUI consumers.
+  public func sink(
+    _ handler: @escaping @MainActor (Element) -> Void
+  ) -> Subscription {
+    let stream = subscribe()
+    let task = Task { @MainActor in
+      for await element in stream {
+        handler(element)
+      }
+    }
+    return Subscription(task)
+  }
+}
+
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  extension View {
+    /// Listen to a ``Broadcaster`` for the lifetime of this view's `@State`
+    /// storage. Shape matches `.onReceive(publisher:perform:)` but is
+    /// backed by an `AsyncStream` subscription whose `Task` outlives view
+    /// disappear/reappear cycles (NavigationStack push/pop) — `.task` and
+    /// `for await` would cancel on disappear and drop events.
+    public func onEvent<Element>(
+      from broadcaster: Broadcaster<Element>,
+      perform action: @escaping @MainActor (Element) -> Void
+    ) -> some View {
+      modifier(BroadcasterEventModifier(broadcaster: broadcaster, action: action))
+    }
+  }
+
+  private struct BroadcasterEventModifier<Element: Sendable>: ViewModifier {
+    let broadcaster: Broadcaster<Element>
+    let action: @MainActor (Element) -> Void
+
+    @State private var subscription: Subscription?
+
+    func body(content: Content) -> some View {
+      content.onAppear {
+        if subscription == nil {
+          subscription = broadcaster.sink(action)
+        }
+      }
+    }
+  }
+#endif

--- a/Persistence/Sources/Persistence/Observation/Subscription.swift
+++ b/Persistence/Sources/Persistence/Observation/Subscription.swift
@@ -3,20 +3,19 @@ import Foundation
 /// A handle to a long-lived task that will be cancelled when the handle
 /// deallocates, matching the lifecycle shape of Combine's `AnyCancellable`.
 ///
-/// Designed to be stored in SwiftUI `@State`-owned containers (typically
-/// `Set<Subscription>`) so the underlying `Task` survives view appearance
-/// cycles — particularly NavigationStack push/pop where the parent view
-/// transiently "disappears" — and is torn down only when the view's state
-/// storage is freed.
-public final class Subscription: @unchecked Sendable, Hashable {
+/// Designed to be held by SwiftUI `@State` storage so the underlying `Task`
+/// survives view appearance cycles — particularly NavigationStack push/pop
+/// where the parent view transiently "disappears" — and is torn down only
+/// when the view's state storage is freed.
+public final class Subscription: Sendable {
   private let task: Task<Void, Never>
 
-  init(_ task: Task<Void, Never>) {
+  public init(_ task: Task<Void, Never>) {
     self.task = task
   }
 
   /// Cancel the underlying task immediately. The Subscription itself stays
-  /// allocated until its container releases it.
+  /// allocated until its owner releases it.
   public func cancel() {
     task.cancel()
   }
@@ -24,36 +23,12 @@ public final class Subscription: @unchecked Sendable, Hashable {
   deinit {
     task.cancel()
   }
-
-  public static func == (lhs: Subscription, rhs: Subscription) -> Bool {
-    lhs === rhs
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(ObjectIdentifier(self))
-  }
-}
-
-extension Subscription {
-  /// Store the subscription in a `Set`, matching Combine's
-  /// `AnyCancellable.store(in:)` shape.
-  public func store(in set: inout Set<Subscription>) {
-    set.insert(self)
-  }
-
-  /// Store the subscription in any range-replaceable collection
-  /// (e.g. `[Subscription]`).
-  public func store<C: RangeReplaceableCollection>(in collection: inout C)
-  where C.Element == Subscription {
-    collection.append(self)
-  }
 }
 
 extension Broadcaster {
   /// Subscribe with a handler closure and return a ``Subscription`` whose
   /// lifetime owns the underlying receive task. Cancel by calling
-  /// ``Subscription/cancel()`` or by releasing the handle (typically via
-  /// the `Set<Subscription>` it was stored in).
+  /// ``Subscription/cancel()`` or by releasing the handle.
   ///
   /// Mirrors Combine's `Publisher.sink(receiveValue:)`. The handler runs on
   /// the main actor, matching `.onReceive`'s default delivery context for
@@ -70,36 +45,3 @@ extension Broadcaster {
     return Subscription(task)
   }
 }
-
-#if canImport(SwiftUI)
-  import SwiftUI
-
-  extension View {
-    /// Listen to a ``Broadcaster`` for the lifetime of this view's `@State`
-    /// storage. Shape matches `.onReceive(publisher:perform:)` but is
-    /// backed by an `AsyncStream` subscription whose `Task` outlives view
-    /// disappear/reappear cycles (NavigationStack push/pop) — `.task` and
-    /// `for await` would cancel on disappear and drop events.
-    public func onEvent<Element>(
-      from broadcaster: Broadcaster<Element>,
-      perform action: @escaping @MainActor (Element) -> Void
-    ) -> some View {
-      modifier(BroadcasterEventModifier(broadcaster: broadcaster, action: action))
-    }
-  }
-
-  private struct BroadcasterEventModifier<Element: Sendable>: ViewModifier {
-    let broadcaster: Broadcaster<Element>
-    let action: @MainActor (Element) -> Void
-
-    @State private var subscription: Subscription?
-
-    func body(content: Content) -> some View {
-      content.onAppear {
-        if subscription == nil {
-          subscription = broadcaster.sink(action)
-        }
-      }
-    }
-  }
-#endif

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -42,7 +42,7 @@ struct ShareView: View {
     return ConnectionManager(database: database)
   }()
 
-  @StateObject private var store = DocumentStore(repository: NullRepository())
+  @State private var store = DocumentStore(repository: NullRepository())
   @State private var storeReady = false
 
   @StateObject private var errorController = ErrorController()
@@ -72,7 +72,7 @@ struct ShareView: View {
     if let conn = connectionManager.connection {
       Logger.api.trace("Valid connection from connection manager: \(String(describing: conn))")
       Task {
-        store.eventPublisher.send(.repositoryWillChange)
+        store.events.emit(.repositoryWillChange)
         await store.set(
           repository: ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode))
         storeReady = true
@@ -144,7 +144,7 @@ struct ShareView: View {
                 .id(url)
                 // @FIXME: Gives a white band at the bottom, not ideal
                 .padding(.bottom, 40)
-                .environmentObject(store)
+                .environment(store)
                 .environmentObject(errorController)
                 .environmentObject(connectionManager)
                 .accentColor(Color(.accent))

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -21,7 +21,7 @@ struct ShareView: View {
   // If the bootstrap fails (corrupt file, missing app-group), fall back to
   // an in-memory database so the extension still renders the disabled
   // "no active server" state cleanly instead of crashing.
-  @StateObject private var connectionManager: ConnectionManager = {
+  @State private var connectionManager: ConnectionManager = {
     let database: Database
     do {
       database = try Database()
@@ -146,7 +146,7 @@ struct ShareView: View {
                 .padding(.bottom, 40)
                 .environment(store)
                 .environmentObject(errorController)
-                .environmentObject(connectionManager)
+                .environment(connectionManager)
                 .accentColor(Color(.accent))
               } else {
                 ProgressView()

--- a/swift-paperless/Views/DataScannerView.swift
+++ b/swift-paperless/Views/DataScannerView.swift
@@ -45,7 +45,7 @@ struct HighlightView: View {
 
   var haptics = false
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   var patterns: [Regex<AnyRegexOutput>]
 
@@ -351,7 +351,7 @@ struct HighlightView: View {
 private struct DetailView: View {
   var document: Document
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(\.dismiss) private var dismiss
 
   var body: some View {
@@ -381,7 +381,7 @@ struct TypeAsnView: View {
   }
 
   @State private var text = ""
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @FocusState private var focused: Bool
   @State private var status = Status.none
 
@@ -517,7 +517,7 @@ struct TypeAsnView: View {
 
 struct DataScannerView: View {
   @Environment(\.dismiss) private var dismiss
-  @ObservedObject var store: DocumentStore
+  var store: DocumentStore
 
   @State private var document: Document?
   @State private var showTypeAsn = false

--- a/swift-paperless/Views/Document/Detail/DocumentDetailView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailView.swift
@@ -21,7 +21,7 @@ protocol DocumentDetailViewProtocol: View {
 
 struct DocumentDetailView: View {
   private var store: DocumentStore
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @State var document: Document
   var navPath: Binding<[NavigationState]>?
 

--- a/swift-paperless/Views/Document/Detail/DocumentDetailView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentDetailView.swift
@@ -20,7 +20,7 @@ protocol DocumentDetailViewProtocol: View {
 }
 
 struct DocumentDetailView: View {
-  @ObservedObject private var store: DocumentStore
+  private var store: DocumentStore
   @EnvironmentObject private var connectionManager: ConnectionManager
   @State var document: Document
   var navPath: Binding<[NavigationState]>?

--- a/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
@@ -15,7 +15,7 @@ struct DocumentMetadataView: View {
   @Binding var document: Document
   @Binding var metadata: Metadata?
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   @Environment(\.dismiss) private var dismiss
@@ -115,7 +115,7 @@ struct DocumentMetadataView: View {
 // - MARK: Preview
 
 #Preview {
-  @Previewable @StateObject var store = DocumentStore(
+  @Previewable @State var store = DocumentStore(
     repository: PreviewRepository(downloadDelay: 3.0))
   @Previewable @StateObject var errorController = ErrorController()
 
@@ -136,6 +136,6 @@ struct DocumentMetadataView: View {
       }
     }
   }
-  .environmentObject(store)
+  .environment(store)
   .environmentObject(errorController)
 }

--- a/swift-paperless/Views/Document/Detail/ShareLinkView.swift
+++ b/swift-paperless/Views/Document/Detail/ShareLinkView.swift
@@ -30,7 +30,7 @@ struct ShareLinkView: View {
 
   @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
 
   @ScaledMetric(relativeTo: .body) var fontSize = 14
 
@@ -254,7 +254,7 @@ private struct CreateShareLinkView: View {
   @StateObject var errorController = ErrorController()
 
   @Previewable
-  @StateObject var connectionManager = ConnectionManager(database: try! Database.inMemory())
+  @State var connectionManager = ConnectionManager(database: try! Database.inMemory())
 
   @Previewable @State var document: Document? = nil
 
@@ -265,7 +265,7 @@ private struct CreateShareLinkView: View {
   }
   .environment(store)
   .environmentObject(errorController)
-  .environmentObject(connectionManager)
+  .environment(connectionManager)
   .task {
     do {
       let protoDoc = ProtoDocument(

--- a/swift-paperless/Views/Document/Detail/ShareLinkView.swift
+++ b/swift-paperless/Views/Document/Detail/ShareLinkView.swift
@@ -28,7 +28,7 @@ extension DataModel.ShareLink.FileVersion {
 struct ShareLinkView: View {
   let document: Document
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @EnvironmentObject private var connectionManager: ConnectionManager
 
@@ -169,7 +169,7 @@ extension DataModel.ShareLink.FileVersion {
 
 private struct CreateShareLinkView: View {
   @EnvironmentObject private var errorController: ErrorController
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   @Environment(\.dismiss) private var dismiss
 
@@ -248,7 +248,7 @@ private struct CreateShareLinkView: View {
 
 #Preview {
   @Previewable
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()
@@ -263,7 +263,7 @@ private struct CreateShareLinkView: View {
       ShareLinkView(document: document)
     }
   }
-  .environmentObject(store)
+  .environment(store)
   .environmentObject(errorController)
   .environmentObject(connectionManager)
   .task {

--- a/swift-paperless/Views/Document/Detail/V4/AsnEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/AsnEditSheet.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct AsnEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/CorrespondentEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/CorrespondentEditSheet.swift
@@ -13,10 +13,10 @@ import SwiftUI
 struct CorrespondentEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private struct CreateCorrespondentView: View {
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @EnvironmentObject private var errorController: ErrorController
     @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/CustomFieldsEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/CustomFieldsEditSheet.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct CustomFieldsEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
   @Environment(\.locale) private var locale

--- a/swift-paperless/Views/Document/Detail/V4/DateEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DateEditSheet.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct DateEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -950,7 +950,7 @@ extension Tag {
 private struct DocumentDetailViewV4PreviewHelper: View {
   @State private var store = DocumentStore(repository: TransientRepository())
   @StateObject private var errorController = ErrorController()
-  @StateObject private var connectionManager = ConnectionManager(
+  @State private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
 
   @State private var document: Document?

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -795,13 +795,11 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     // External mutations (e.g. the document-list swipe action that strips
     // inbox tags) update the store but don't reach our local copy. Sync from
     // the server-confirmed event so the edit panel stays in lock-step.
-    .task {
-      for await event in store.events.subscribe() {
-        guard case .changeReceived(let updated) = event,
-          updated.id == viewModel.document.id
-        else { continue }
-        viewModel.document = updated
-      }
+    .onEvent(from: store.events) { event in
+      guard case .changeReceived(let updated) = event,
+        updated.id == viewModel.document.id
+      else { return }
+      viewModel.document = updated
     }
   }
 }

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -72,7 +72,7 @@ private enum AuxiliarySheet: Identifiable, Hashable {
 @MainActor
 struct DocumentDetailViewV4: DocumentDetailViewProtocol {
   @State private var viewModel: DocumentDetailModel
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(RouteManager.self) private var routeManager
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -764,13 +764,13 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       switch sheet {
       case .metadata:
         DocumentMetadataView(document: $viewModel.document, metadata: $viewModel.metadata)
-          .environmentObject(store)
+          .environment(store)
           .environmentObject(errorController)
           .sheetZoomTransition(sourceID: TransitionID.metadata, in: namespace)
 
       case .notes:
         DocumentNoteView(document: $viewModel.document)
-          .environmentObject(store)
+          .environment(store)
           .environmentObject(errorController)
           .sheetZoomTransition(sourceID: TransitionID.notes, in: namespace)
 
@@ -795,11 +795,13 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     // External mutations (e.g. the document-list swipe action that strips
     // inbox tags) update the store but don't reach our local copy. Sync from
     // the server-confirmed event so the edit panel stays in lock-step.
-    .onReceive(store.eventPublisher) { event in
-      guard case .changeReceived(let updated) = event,
-        updated.id == viewModel.document.id
-      else { return }
-      viewModel.document = updated
+    .task {
+      for await event in store.events.subscribe() {
+        guard case .changeReceived(let updated) = event,
+          updated.id == viewModel.document.id
+        else { continue }
+        viewModel.document = updated
+      }
     }
   }
 }
@@ -946,7 +948,7 @@ extension Tag {
 }
 
 private struct DocumentDetailViewV4PreviewHelper: View {
-  @StateObject private var store = DocumentStore(repository: TransientRepository())
+  @State private var store = DocumentStore(repository: TransientRepository())
   @StateObject private var errorController = ErrorController()
   @StateObject private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
@@ -973,7 +975,7 @@ private struct DocumentDetailViewV4PreviewHelper: View {
         Text("No document")
       }
     }
-    .environmentObject(store)
+    .environment(store)
     .environmentObject(errorController)
     .environment(RouteManager())
     .task {

--- a/swift-paperless/Views/Document/Detail/V4/DocumentTypeEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentTypeEditSheet.swift
@@ -13,10 +13,10 @@ import SwiftUI
 struct DocumentTypeEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private struct CreateDocumentTypeView: View {
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @EnvironmentObject private var errorController: ErrorController
     @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/OwnerEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/OwnerEditSheet.swift
@@ -14,7 +14,7 @@ import os
 struct OwnerEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/SingleSelectPickerSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/SingleSelectPickerSheet.swift
@@ -15,7 +15,7 @@ private let singleSelectPickerDisplayLimit = 200
 struct SingleSelectPickerSheet<Item: Model & Named & Hashable & Sendable, CreateView: View>: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/StoragePathEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/StoragePathEditSheet.swift
@@ -13,10 +13,10 @@ import SwiftUI
 struct StoragePathEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private struct CreateStoragePathView: View {
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @EnvironmentObject private var errorController: ErrorController
     @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/TagsEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/TagsEditSheet.swift
@@ -15,7 +15,7 @@ private let tagsEditDisplayLimit = 200
 struct TagsEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   @Environment(\.dismiss) private var dismiss
@@ -39,7 +39,7 @@ struct TagsEditSheet: View {
   }
 
   private struct CreateTagView: View {
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @EnvironmentObject private var errorController: ErrorController
     @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/Detail/V4/TitleEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/TitleEditSheet.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct TitleEditSheet: View {
   @Bindable var viewModel: DocumentDetailModel
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -16,7 +16,7 @@ import os
 
 struct LoadingDocumentList: View {
   @State private var documents: [Document] = []
-  @StateObject private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore(repository: PreviewRepository())
 
   var body: some View {
     List {
@@ -186,7 +186,7 @@ struct DocumentList: View {
 
         } preview: {
           PopupDocumentPreview(document: document)
-            .environmentObject(store)
+            .environment(store)
         }
 
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
@@ -334,7 +334,11 @@ struct DocumentList: View {
       viewModel.ready = true
     }
 
-    .onReceive(store.eventPublisher, perform: onReceiveEvent)
+    .task {
+      for await event in store.events.subscribe() {
+        onReceiveEvent(event: event)
+      }
+    }
 
     // @FIXME: This somehow causes ERROR: not found in table Localizable of bundle CFBundle 0x600001730200 empty string
     .confirmationDialog(

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -6,11 +6,11 @@
 //
 
 import AppShared
-import Combine
 import DataModel
 import Foundation
 import Networking
 import Nuke
+import Persistence
 import SwiftUI
 import os
 
@@ -334,11 +334,7 @@ struct DocumentList: View {
       viewModel.ready = true
     }
 
-    .task {
-      for await event in store.events.subscribe() {
-        onReceiveEvent(event: event)
-      }
-    }
+    .onEvent(from: store.events, perform: onReceiveEvent)
 
     // @FIXME: This somehow causes ERROR: not found in table Localizable of bundle CFBundle 0x600001730200 empty string
     .confirmationDialog(

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -10,7 +10,6 @@ import DataModel
 import Foundation
 import Networking
 import Nuke
-import Persistence
 import SwiftUI
 import os
 

--- a/swift-paperless/Views/Document/DocumentPreview.swift
+++ b/swift-paperless/Views/Document/DocumentPreview.swift
@@ -232,7 +232,7 @@ private struct PDFPagingPreview: View {
 }
 
 private struct IntegratedDocumentPreview: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @State private var showLoadingOverlay = false
   @State private var thumbnailHidden = false
   var document: Document
@@ -394,7 +394,7 @@ private struct IntegratedDocumentPreview: View {
 }
 
 struct PopupDocumentPreview: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @State private var viewModel = IntegratedDocumentPreviewModel()
   var document: Document
 

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -58,7 +58,7 @@ struct DocumentNotFoundError: DisplayableError {
 
 @MainActor
 struct DocumentView: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var connectionManager: ConnectionManager
   @EnvironmentObject private var errorController: ErrorController
   @Environment(RouteManager.self) private var routeManager
@@ -693,7 +693,7 @@ struct DocumentView: View {
         callback: createCallback,
         title: createDocumentTitle
       )
-      .environmentObject(store)
+      .environment(store)
       .environmentObject(errorController)
     }
 
@@ -757,7 +757,7 @@ struct DocumentView: View {
       fatalError("Invalid task view navigation state pushed")
     }
     return TasksView(navPath: navPath)
-      .environmentObject(store)
+      .environment(store)
       .environmentObject(errorController)
   }
 }
@@ -765,7 +765,7 @@ struct DocumentView: View {
 // - MARK: Previews
 
 #Preview("DocumentView") {
-  @Previewable @StateObject var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @StateObject var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
@@ -773,7 +773,7 @@ struct DocumentView: View {
   @Previewable @State var showSettings = false
 
   DocumentView(showSettings: $showSettings)
-    .environmentObject(store)
+    .environment(store)
     .environmentObject(errorController)
     .environmentObject(connectionManager)
     .environment(RouteManager())

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -59,7 +59,7 @@ struct DocumentNotFoundError: DisplayableError {
 @MainActor
 struct DocumentView: View {
   @Environment(DocumentStore.self) private var store
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @EnvironmentObject private var errorController: ErrorController
   @Environment(RouteManager.self) private var routeManager
   @Environment(NetworkMonitor.self) private var networkMonitor
@@ -767,7 +767,7 @@ struct DocumentView: View {
 #Preview("DocumentView") {
   @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
   @Previewable @State var networkMonitor = NetworkMonitor()
   @Previewable @State var showSettings = false
@@ -775,7 +775,7 @@ struct DocumentView: View {
   DocumentView(showSettings: $showSettings)
     .environment(store)
     .environmentObject(errorController)
-    .environmentObject(connectionManager)
+    .environment(connectionManager)
     .environment(RouteManager())
     .environment(networkMonitor)
 }

--- a/swift-paperless/Views/Document/FilterAssembly.swift
+++ b/swift-paperless/Views/Document/FilterAssembly.swift
@@ -114,7 +114,7 @@ struct FilterAssembly: View {
 @available(iOS 26.0, *)
 #Preview {
   @Previewable @State var filterModel = FilterModel()
-  @Previewable @StateObject var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @StateObject var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
@@ -133,7 +133,7 @@ struct FilterAssembly: View {
 
     .safeAreaInset(edge: .top) {
       FilterAssembly(filterModel: filterModel)
-        .environmentObject(store)
+        .environment(store)
         .environmentObject(errorController)
         // @TODO: Is this needed even?
         .environmentObject(connectionManager)

--- a/swift-paperless/Views/Document/FilterAssembly.swift
+++ b/swift-paperless/Views/Document/FilterAssembly.swift
@@ -116,7 +116,7 @@ struct FilterAssembly: View {
   @Previewable @State var filterModel = FilterModel()
   @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
   @Previewable @State var searchText = ""
 
@@ -136,7 +136,7 @@ struct FilterAssembly: View {
         .environment(store)
         .environmentObject(errorController)
         // @TODO: Is this needed even?
-        .environmentObject(connectionManager)
+        .environment(connectionManager)
         .environment(filterModel)
     }
 

--- a/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
+++ b/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
@@ -95,7 +95,7 @@ struct FilterAssemblyiOS18: View {
 
 #Preview {
   @Previewable @State var filterModel = FilterModel()
-  @Previewable @StateObject var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @StateObject var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
@@ -109,7 +109,7 @@ struct FilterAssemblyiOS18: View {
 
     .safeAreaInset(edge: .top) {
       FilterAssemblyiOS18(filterModel: filterModel)
-        .environmentObject(store)
+        .environment(store)
         .environmentObject(errorController)
         .environmentObject(connectionManager)
         .environment(filterModel)

--- a/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
+++ b/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
@@ -97,7 +97,7 @@ struct FilterAssemblyiOS18: View {
   @Previewable @State var filterModel = FilterModel()
   @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   NavigationStack {
@@ -111,7 +111,7 @@ struct FilterAssemblyiOS18: View {
       FilterAssemblyiOS18(filterModel: filterModel)
         .environment(store)
         .environmentObject(errorController)
-        .environmentObject(connectionManager)
+        .environment(connectionManager)
         .environment(filterModel)
     }
 

--- a/swift-paperless/Views/Filter/CustomFieldFilterView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldFilterView.swift
@@ -35,7 +35,7 @@ extension Binding where Value == CustomFieldQuery {
 private struct OpView: View {
   @Binding var op: OpContent
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private var defaultField: CustomField? {
     store.customFields.values
@@ -708,7 +708,7 @@ private struct ExprView: View {
   @State var field: CustomField
   @Binding var expr: ExprContent
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private var fields: [CustomField] {
     Array(
@@ -847,7 +847,7 @@ struct CustomFieldFilterView: View {
 
   @State private var state = QueryState.valid
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(\.dismiss) private var dismiss
 
   init(query: Binding<CustomFieldQuery>) {
@@ -974,7 +974,7 @@ private let customFields = [
 ]
 
 private struct PreviewHelper<C: View>: View {
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
 
   @State var show = false
 
@@ -1027,7 +1027,7 @@ private struct PreviewHelper<C: View>: View {
         show = true
       } catch {}
     }
-    .environmentObject(store)
+    .environment(store)
   }
 }
 

--- a/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
@@ -123,7 +123,7 @@ extension EnvironmentValues {
 
 struct CustomFieldQueryDisplayView: View {
   let query: CustomFieldQuery
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   init(query: CustomFieldQuery) {
     self.query = query
@@ -198,7 +198,7 @@ private let customFields = [
 ]
 
 private struct PreviewHelper<C: View>: View {
-  @StateObject var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore(repository: TransientRepository())
 
   @State var show = false
 
@@ -253,7 +253,7 @@ private struct PreviewHelper<C: View>: View {
         show = true
       } catch {}
     }
-    .environmentObject(store)
+    .environment(store)
   }
 }
 

--- a/swift-paperless/Views/Filter/FilterBar.swift
+++ b/swift-paperless/Views/Filter/FilterBar.swift
@@ -32,7 +32,7 @@ private struct SavedViewError: LocalizedError {
 }
 
 private struct FilterMenu<Content: View>: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(FilterModel.self) private var filterModel
   @EnvironmentObject private var errorController: ErrorController
   @Binding var savedView: ProtoSavedView?
@@ -197,7 +197,7 @@ private struct CircleCounter<Value: CustomStringConvertible>: View {
 // MARK: Common Element View
 
 private struct CommonElementLabel<Element: Pickable>: View {
-  @EnvironmentObject var store: DocumentStore
+  @Environment(DocumentStore.self) var store
 
   let state: FilterState.Filter
 
@@ -357,7 +357,7 @@ private struct PilliOS18<Label: View>: View {
 
 private struct SortMenu: View {
   @Environment(FilterModel.self) private var filterModel
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private var eligibleSortFields: [SortField] {
     let isAdvancedSearch =
@@ -430,7 +430,7 @@ private struct SortMenu: View {
 }
 
 struct FilterBar: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @Environment(FilterModel.self) private var filterModel
   @Environment(\.dismiss) private var dismiss
   @Environment(RouteManager.self) private var routeManager
@@ -545,7 +545,7 @@ struct FilterBar: View {
     var savedView: ProtoSavedView
 
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var store: DocumentStore
+    @Environment(DocumentStore.self) private var store
     @Environment(FilterModel.self) private var filterModel
 
     var body: some View {
@@ -959,14 +959,14 @@ private let customFields = [
 ]
 
 #Preview {
-  @Previewable @StateObject var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore(repository: TransientRepository())
   @Previewable @State var filterModel = FilterModel()
   @Previewable @StateObject var errorController = ErrorController()
 
   NavigationStack {
     Form {
       FilterBar()
-        .environmentObject(store)
+        .environment(store)
         .environment(filterModel)
         .environmentObject(errorController)
         .environment(RouteManager())

--- a/swift-paperless/Views/Login/LoginView.swift
+++ b/swift-paperless/Views/Login/LoginView.swift
@@ -15,7 +15,7 @@ protocol LoginViewProtocol: View {
 }
 
 struct LoginView: LoginViewProtocol {
-  @ObservedObject var connectionManager: ConnectionManager
+  var connectionManager: ConnectionManager
   var initial = true
 
   @ObservedObject private var appSettings = AppSettings.shared

--- a/swift-paperless/Views/Login/LoginViewV2.swift
+++ b/swift-paperless/Views/Login/LoginViewV2.swift
@@ -81,7 +81,7 @@ struct LoginFooterView<Content: View>: View {
 
 @MainActor
 struct LoginViewV2: LoginViewProtocol {
-  @ObservedObject var connectionManager: ConnectionManager
+  var connectionManager: ConnectionManager
   var initial: Bool = false
 
   @State private var viewModel = LoginViewModel()

--- a/swift-paperless/Views/Login/ReauthSheet.swift
+++ b/swift-paperless/Views/Login/ReauthSheet.swift
@@ -26,7 +26,7 @@ import os
 struct ReauthSheet: View {
   let stored: StoredConnection
 
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.dismiss) private var dismiss
 
@@ -139,7 +139,7 @@ private struct ReauthPreamble: View {
 // MARK: - Previews
 
 #Preview("Reauth") {
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
   @Previewable @StateObject var errorController = ErrorController()
 
@@ -151,6 +151,6 @@ private struct ReauthPreamble: View {
   )
 
   ReauthSheet(stored: stored)
-    .environmentObject(connectionManager)
+    .environment(connectionManager)
     .environmentObject(errorController)
 }

--- a/swift-paperless/Views/Settings/DebugMenuView.swift
+++ b/swift-paperless/Views/Settings/DebugMenuView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 import os
 
 struct DebugMenuView: View {
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @ObservedObject private var appSettings = AppSettings.shared
   @State private var showResetConfirmation = false
   @State private var exportResult: ExportResult?
@@ -125,12 +125,12 @@ struct DebugMenuView: View {
 }
 
 #Preview("Debug menu") {
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   NavigationStack {
     DebugMenuView()
-      .environmentObject(connectionManager)
+      .environment(connectionManager)
   }
 }
 

--- a/swift-paperless/Views/Settings/PreferencesView.swift
+++ b/swift-paperless/Views/Settings/PreferencesView.swift
@@ -8,7 +8,7 @@ struct PreferencesView: View {
   @ObservedObject private var appSettings = AppSettings.shared
 
   @EnvironmentObject private var biometricLockManager: BiometricLockManager
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   var body: some View {
     Form {

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -14,7 +14,7 @@ import os
 // MARK: - Settings View
 
 struct SettingsView: View {
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var connectionManager: ConnectionManager
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.openURL) private var openURL
@@ -289,7 +289,7 @@ struct SettingsView: View {
 }
 
 #Preview("SettingsView") {
-  @Previewable @StateObject var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @StateObject var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
@@ -298,7 +298,7 @@ struct SettingsView: View {
   }
   .sheet(isPresented: .constant(true)) {
     SettingsView()
-      .environmentObject(store)
+      .environment(store)
       .environmentObject(connectionManager)
   }
 }

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -15,7 +15,7 @@ import os
 
 struct SettingsView: View {
   @Environment(DocumentStore.self) private var store
-  @EnvironmentObject private var connectionManager: ConnectionManager
+  @Environment(ConnectionManager.self) private var connectionManager
   @EnvironmentObject private var errorController: ErrorController
   @Environment(\.openURL) private var openURL
   @Environment(\.dismiss) private var dismiss
@@ -270,7 +270,7 @@ struct SettingsView: View {
           let stored = connectionManager.connections[id]
         {
           ReauthSheet(stored: stored)
-            .environmentObject(connectionManager)
+            .environment(connectionManager)
             .environmentObject(errorController)
             .environment(networkMonitor)
         }
@@ -291,7 +291,7 @@ struct SettingsView: View {
 #Preview("SettingsView") {
   @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @StateObject var connectionManager = ConnectionManager(
+  @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   VStack {
@@ -299,6 +299,6 @@ struct SettingsView: View {
   .sheet(isPresented: .constant(true)) {
     SettingsView()
       .environment(store)
-      .environmentObject(connectionManager)
+      .environment(connectionManager)
   }
 }

--- a/swift-paperless/Views/Tasks/TaskActivityToolbar.swift
+++ b/swift-paperless/Views/Tasks/TaskActivityToolbar.swift
@@ -12,7 +12,7 @@ import os
 struct TaskActivityToolbar: View {
   @Binding var navState: NavigationState?
 
-  @EnvironmentObject var store: DocumentStore
+  @Environment(DocumentStore.self) var store
 
   @State private var number: Int = 0
 

--- a/swift-paperless/Views/Tasks/TasksView.swift
+++ b/swift-paperless/Views/Tasks/TasksView.swift
@@ -92,7 +92,7 @@ extension TaskStatus {
 struct TaskDetailView: View {
   let task: PaperlessTask
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   private enum DocumentResult {
     case document(_: Document)
@@ -311,7 +311,7 @@ final class TaskListViewModel {
 struct TasksView: View {
   @State var navPath: [NavigationState]
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
 
   init(navPath: [NavigationState] = []) {
     _navPath = State(initialValue: navPath)
@@ -323,7 +323,7 @@ struct TasksView: View {
 
         .navigationTitle(String(localized: .tasks(.title)))
         .navigationBarTitleDisplayMode(.inline)
-        .environmentObject(store)
+        .environment(store)
         .navigationDestination(for: NavigationState.self) { nav in
           switch nav {
           case .detail(let document):
@@ -348,7 +348,7 @@ private struct TaskList: View {
   @State private var errorTask: PaperlessTask? = nil
   @State private var viewModel: TaskListViewModel?
 
-  @EnvironmentObject private var store: DocumentStore
+  @Environment(DocumentStore.self) private var store
   @EnvironmentObject private var errorController: ErrorController
 
   @Environment(\.dismiss) private var dismiss
@@ -525,13 +525,13 @@ private struct TaskList: View {
 // MARK: - Previews
 
 private struct PreviewHelperView<Content: View>: View {
-  @StateObject private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore(repository: PreviewRepository())
 
   @ViewBuilder var content: () -> Content
 
   var body: some View {
     content()
-      .environmentObject(store)
+      .environment(store)
   }
 }
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -317,14 +317,12 @@ struct MainView: View {
       initialDisplay = false
     }
 
-    .task {
-      for await event in manager.events.subscribe() {
-        switch event {
-        case .connectionChange(let animated):
-          Task { await refreshConnection(animated: animated) }
-        case .logout:
-          showLoginScreen = true
-        }
+    .onEvent(from: manager.events) { event in
+      switch event {
+      case .connectionChange(let animated):
+        Task { await refreshConnection(animated: animated) }
+      case .logout:
+        showLoginScreen = true
       }
     }
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -25,7 +25,7 @@ struct MainView: View {
 
   @StateObject private var manager: ConnectionManager
 
-  @State private var friendlyNameSubscription: AnyCancellable?
+  @State private var friendlyNameTask: Task<Void, Never>?
 
   @StateObject private var errorController: ErrorController
 
@@ -161,7 +161,7 @@ struct MainView: View {
         wrapping: api, serverID: conn.serverID, connectionManager: manager)
       if let store {
         await sleep(.seconds(0.1))
-        store.eventPublisher.send(.repositoryWillChange)
+        store.events.emit(.repositoryWillChange)
         await sleep(.seconds(0.3))
         store.set(repository: repository)
         storeReady = true
@@ -189,15 +189,25 @@ struct MainView: View {
 
   private func observeFriendlyName(on store: DocumentStore) {
     // Forwards the server's PAPERLESS_APP_TITLE (settings.appTitle) to the
-    // active connection. compactMap drops nil values so resets from
-    // store.clear() don't wipe out a previously stored friendly name.
-    friendlyNameSubscription =
-      store.$settings
-      .compactMap(\.appTitle)
-      .removeDuplicates()
-      .sink { [manager] title in
-        manager.setFriendlyName(title)
+    // active connection. The nil-guard drops resets from store.clear() so
+    // they don't wipe out a previously stored friendly name. setFriendlyName
+    // is already idempotent, so no explicit dedup is needed.
+    friendlyNameTask?.cancel()
+    friendlyNameTask = Task { @MainActor [manager] in
+      while !Task.isCancelled {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+          _ = store.settings.appTitle
+        } onChange: {
+          continuation.yield()
+          continuation.finish()
+        }
+        if let title = store.settings.appTitle {
+          manager.setFriendlyName(title)
+        }
+        for await _ in stream { break }
       }
+    }
   }
 
   private func setupQuickActions() {
@@ -217,7 +227,7 @@ struct MainView: View {
       ZStack {
         if manager.connection != nil, storeReady {
           DocumentView(showSettings: $showSettings)
-            .environmentObject(store!)
+            .environment(store!)
             .environmentObject(manager)
             .safeAreaInset(edge: .bottom, spacing: 0) {
               NeedsAuthBanner()
@@ -288,7 +298,7 @@ struct MainView: View {
       if let store {
         SettingsView()
           .environmentObject(manager)
-          .environmentObject(store)
+          .environment(store)
           .environmentObject(errorController)
           .environmentObject(biometricLockManager)
       }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -6,7 +6,6 @@
 //
 
 import AppShared
-import Combine
 import Common
 import DataModel
 import Networking
@@ -23,7 +22,7 @@ struct MainView: View {
   @State private var initialDisplay = true
   @State private var showSettings = false
 
-  @StateObject private var manager: ConnectionManager
+  @State private var manager: ConnectionManager
 
   @State private var friendlyNameTask: Task<Void, Never>?
 
@@ -47,7 +46,7 @@ struct MainView: View {
 
   init(database: Database) {
     _ = AppSettings.shared
-    _manager = StateObject(wrappedValue: ConnectionManager(database: database))
+    _manager = State(wrappedValue: ConnectionManager(database: database))
     let errorController = ErrorController()
     let networkMonitor = NetworkMonitor()
     errorController.suppressBannerCoveredErrors(networkMonitor: networkMonitor)
@@ -228,10 +227,10 @@ struct MainView: View {
         if manager.connection != nil, storeReady {
           DocumentView(showSettings: $showSettings)
             .environment(store!)
-            .environmentObject(manager)
+            .environment(manager)
             .safeAreaInset(edge: .bottom, spacing: 0) {
               NeedsAuthBanner()
-                .environmentObject(manager)
+                .environment(manager)
                 .environment(networkMonitor)
             }
             .overlay {
@@ -284,7 +283,7 @@ struct MainView: View {
         let stored = manager.connections[id]
       {
         ReauthSheet(stored: stored)
-          .environmentObject(manager)
+          .environment(manager)
           .environmentObject(errorController)
           .environment(networkMonitor)
       }
@@ -297,7 +296,7 @@ struct MainView: View {
     .sheet(isPresented: $showSettings) {
       if let store {
         SettingsView()
-          .environmentObject(manager)
+          .environment(manager)
           .environment(store)
           .environmentObject(errorController)
           .environmentObject(biometricLockManager)
@@ -318,12 +317,14 @@ struct MainView: View {
       initialDisplay = false
     }
 
-    .onReceive(manager.eventPublisher) { event in
-      switch event {
-      case .connectionChange(let animated):
-        Task { await refreshConnection(animated: animated) }
-      case .logout:
-        showLoginScreen = true
+    .task {
+      for await event in manager.events.subscribe() {
+        switch event {
+        case .connectionChange(let animated):
+          Task { await refreshConnection(animated: animated) }
+        case .logout:
+          showLoginScreen = true
+        }
       }
     }
 


### PR DESCRIPTION


<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)  👈
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->
