### PR TITLE
feat: Element (attribute) cache record models

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -21,24 +21,33 @@ public final class DocumentStore: Sendable {
   // MARK: Observed state
 
   public private(set) var documents: [UInt: Document] = [:]
-  public private(set) var correspondents: [UInt: Correspondent] = [:]
-  public private(set) var documentTypes: [UInt: DocumentType] = [:]
-  public private(set) var tags: [UInt: Tag] = [:]
-  public private(set) var savedViews: [UInt: SavedView] = [:]
-  public private(set) var storagePaths: [UInt: StoragePath] = [:]
-
-  public private(set) var users: [UInt: User] = [:]
-  public private(set) var groups: [UInt: UserGroup] = [:]
-  public private(set) var currentUser: User?
-
-  public private(set) var customFields: [UInt: CustomField] = [:]
-
-  public private(set) var serverConfiguration: ServerConfiguration?
 
   public private(set) var tasks: [PaperlessTask] = []
 
-  public private(set) var permissions: UserPermissions = .empty
-  public private(set) var settings = UISettingsSettings()
+  /// The live element projection (DB → typed `ValueObservation`). The store owns
+  /// it and re-exposes its collections through the computed delegates below, so
+  /// `store.tags` etc. keep working and stay reactive (a view reading
+  /// `store.tags` tracks `ElementStore.tags` through the getter). The reference
+  /// is stable across its lifetime — only its contents change — so it is
+  /// `@ObservationIgnored`; the inner `@Observable` does the tracking.
+  @ObservationIgnored
+  public let elementStore = ElementStore()
+
+  // Element collections and singletons — read-only projections of the DB,
+  // observed via `elementStore`. Writes go through the repository (which
+  // write-throughs to the DB); the observation repaints these.
+  public var correspondents: [UInt: Correspondent] { elementStore.correspondents }
+  public var documentTypes: [UInt: DocumentType] { elementStore.documentTypes }
+  public var tags: [UInt: Tag] { elementStore.tags }
+  public var savedViews: [UInt: SavedView] { elementStore.savedViews }
+  public var storagePaths: [UInt: StoragePath] { elementStore.storagePaths }
+  public var users: [UInt: User] { elementStore.users }
+  public var groups: [UInt: UserGroup] { elementStore.groups }
+  public var customFields: [UInt: CustomField] { elementStore.customFields }
+  public var currentUser: User? { elementStore.currentUser }
+  public var serverConfiguration: ServerConfiguration? { elementStore.serverConfiguration }
+  public var permissions: UserPermissions { elementStore.permissions }
+  public var settings: UISettingsSettings { elementStore.settings }
 
   /// True while a network `sync` is in flight. Distinct from data-presence so a
   /// cold cache shows loading rather than emptiness.
@@ -68,7 +77,6 @@ public final class DocumentStore: Sendable {
   public let events = Broadcaster<Event>()
 
   public let semaphore = AsyncSemaphore(value: 1)
-  public let fetchAllSemaphore = AsyncSemaphore(value: 1)
 
   public private(set) var repository: any Repository
 
@@ -82,10 +90,23 @@ public final class DocumentStore: Sendable {
   public init(repository: some Repository) {
     self.repository = repository
     self.imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+    wireElementStore()
   }
 
   deinit {
     taskUpdateTask?.cancel()
+  }
+
+  /// Point the element projection at the active repository's DB. Under the
+  /// source-of-truth model every production/preview repository fronts a DB
+  /// (`CachingBackend`); a repository that doesn't (e.g. `NullRepository` before
+  /// login) detaches the projection.
+  private func wireElementStore() {
+    if let backend = repository as? any CachingBackend {
+      elementStore.repoint(database: backend.database, serverID: backend.serverID)
+    } else {
+      elementStore.reset()
+    }
   }
 
   @Sendable
@@ -135,24 +156,16 @@ public final class DocumentStore: Sendable {
 
   public func clear() {
     documents = [:]
-    correspondents = [:]
-    documentTypes = [:]
-    tags = [:]
-    savedViews = [:]
-    storagePaths = [:]
-    users = [:]
-    groups = [:]
-    currentUser = nil
-    serverConfiguration = nil
     tasks = []
-    permissions = .empty
-    settings = UISettingsSettings()
     lastSyncError = nil
+    // The element projection is owned by `elementStore` and (re)wired by
+    // `wireElementStore()` on repository change — nothing to clear here.
   }
 
   public func set(repository: some Repository, reload: Bool = true) {
     self.repository = repository
     imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+    wireElementStore()
     if reload {
       events.emit(.repositoryChanged)
       clear()
@@ -266,174 +279,40 @@ public final class DocumentStore: Sendable {
     await fetchTasks()
   }
 
-  public func fetchAllCorrespondents() async throws {
-    // @TODO: For the `fetchAll` calls: centralize this to that method.
-    //        Use a property on the resource to map to the permissions resource.
-    //        Also: clear the associated resource if there's a permissions error
-    try checkPermission(.view, for: .correspondent)
-    try await fetchAll(
-      elements: repository.correspondents(),
-      collection: \.correspondents)
-  }
+  // On-demand element refreshers kept for their external callers. Under the
+  // source-of-truth model "refresh collection X" means "sync into the DB"; the
+  // live observation then repaints the projection. `syncElements` reconciles
+  // every collection at once, so these all delegate to it.
+  public func fetchAllUsers() async throws { try await sync(userInitiated: true) }
+  public func fetchAllGroups() async throws { try await sync(userInitiated: true) }
+  public func fetchAllCustomFields() async throws { try await sync(userInitiated: true) }
 
-  public func fetchAllDocumentTypes() async throws {
-    try checkPermission(.view, for: .documentType)
-    try await fetchAll(
-      elements: repository.documentTypes(),
-      collection: \.documentTypes)
-  }
-
-  public func fetchAllTags() async throws {
-    try checkPermission(.view, for: .tag)
-    try await fetchAll(
-      elements: repository.tags(),
-      collection: \.tags)
-  }
-
-  public func fetchAllSavedViews() async throws {
-    try checkPermission(.view, for: .savedView)
-    try await fetchAll(
-      elements: repository.savedViews(),
-      collection: \.savedViews)
-  }
-
-  public func fetchAllStoragePaths() async throws {
-    try checkPermission(.view, for: .storagePath)
-    try await fetchAll(
-      elements: repository.storagePaths(),
-      collection: \.storagePaths)
-  }
-
-  public func fetchCurrentUser() async throws {
-    // this should basically always be the case but let's be safe
-    try checkPermission(.view, for: .uiSettings)
-    do {
-      currentUser = try await repository.currentUser()
-    } catch let error where !error.isCancellationError {
-      Logger.shared.error("Unable to get current user: \(error)")
-      throw error
-    }
-  }
-
-  public func fetchAllUsers() async throws {
-    try checkPermission(.view, for: .user)
-    try await fetchAll(
-      elements: repository.users(),
-      collection: \.users)
-  }
-
-  public func fetchAllGroups() async throws {
-    try checkPermission(.view, for: .group)
-    try await fetchAll(
-      elements: repository.groups(),
-      collection: \.groups)
-  }
-
+  /// Refresh `ui_settings` (permissions/settings) from the network. Syncs into
+  /// the DB, then synchronously pulls the singleton into the projection — the
+  /// one path (`DocumentListViewModel.load`) that reads `permissions`
+  /// immediately afterwards can't wait for the observation's runloop hop.
   public func fetchUISettings() async throws {
-    do {
-      // This can fail if we don't have the required permissions to even access UI settings
-      // Older versions of the backend return an ok response here even if the perms aren't valid
-      let uiSettings = try await repository.uiSettings()
-      permissions = uiSettings.permissions
-      settings = uiSettings.settings
-    } catch let error where error.isCancellationError {
-      Logger.shared.debug("Cancelled fetch UI settings")
-    } catch {
-      // If we don't get permissions here, log a warning and assume full permissions.
-      Logger.shared.error("Error getting UI settings: \(error)")
-      Logger.shared.error("Assuming full permissions to proceed")
-      permissions = UserPermissions.full
-      settings = UISettingsSettings()
-      throw error
+    try await sync(userInitiated: true)
+    if let backend = repository as? any CachingBackend {
+      elementStore.refreshUISettings(from: backend.database, serverID: backend.serverID)
     }
   }
 
-  public func fetchAllCustomFields() async throws {
-    try checkPermission(.view, for: .customField)
-    try await fetchAll(
-      elements: repository.customFields(),
-      collection: \.customFields)
-  }
-
-  public func fetchServerConfiguration() async throws {
-    do {
-      serverConfiguration = try await repository.serverConfiguration()
-      let debug = String(describing: serverConfiguration)
-      Logger.shared.info("Fetched server configuration: \(debug, privacy: .public)")
-    } catch let error where error.isCancellationError {
-      Logger.shared.debug("Cancelled fetch server configuration")
-    } catch {
-      Logger.shared.error("Unable to get server configuration: \(error)")
-      throw error
-    }
-  }
-
-  /// Load every element collection through `repository` into the observed dicts.
-  /// Behind a `CachingRepository` this reads the DB (hydrate); behind a plain
-  /// `ApiRepository` it reads the network. `lenient` controls whether a failing
-  /// resource aborts the whole load (`false`, network-fetch semantics) or is
-  /// suppressed (`true`, cache-read semantics — a cold/partial cache must not
-  /// fail the UI).
-  private func loadAll(lenient: Bool) async throws {
-    await fetchAllSemaphore.wait()
-    defer { fetchAllSemaphore.signal() }
-
-    try? await fetchUISettings()
-
-    let permissions = permissions
-    Logger.shared.info(
-      "Permissions returned from backend:\n\(permissions.matrix, privacy: .public)")
-
-    try await withThrowingTaskGroup(of: Void.self) { group in
-      for task in [
-        fetchAllCorrespondents,
-        fetchAllDocumentTypes,
-        fetchAllTags,
-        fetchAllSavedViews,
-        fetchAllStoragePaths,
-        fetchCurrentUser,
-        fetchAllUsers,
-        fetchAllGroups,
-        fetchAllCustomFields,
-        fetchServerConfiguration,
-      ] {
-        group.addTask { try await task() }
-      }
-
-      while !group.isEmpty {
-        do {
-          try await group.next()
-        } catch is PermissionsError {
-          Logger.shared.debug("Load task returned permissions error, suppressing")
-          continue
-        } catch let error where error.isCancellationError {
-          Logger.shared.debug("Load task caught cancellation, suppressing")
-          continue
-        } catch {
-          if lenient {
-            Logger.shared.warning("Load task error (suppressed during hydrate): \(error)")
-            continue
-          }
-          Logger.shared.error("Load task caught error: \(error)")
-          throw error
-        }
-      }
-    }
-  }
-
-  /// Network → DB (behind a `CachingBackend`) or network → dicts (otherwise).
-  /// Automatic syncs fail soft into `lastSyncError`; user-initiated syncs
-  /// rethrow so the caller can surface the failure (toast), as before.
+  /// Network → DB via the caching backend; the live element observation repaints
+  /// the projection. Automatic syncs fail soft into `lastSyncError`;
+  /// user-initiated syncs rethrow so the caller can surface the failure (toast).
   public func sync(userInitiated: Bool = false) async throws {
     Logger.shared.notice("Sync store (userInitiated: \(userInitiated))")
+    guard let backend = repository as? any CachingBackend else {
+      // No DB-backed repository (e.g. NullRepository before login). Nothing to
+      // sync; the projection is empty until a caching repository is set.
+      Logger.shared.info("Sync skipped: repository is not a caching backend")
+      return
+    }
     isRefreshing = true
     defer { isRefreshing = false }
     do {
-      if let backend = repository as? any CachingBackend {
-        try await backend.syncElements()
-      } else {
-        try await loadAll(lenient: false)
-      }
+      try await backend.syncElements()
       lastSyncError = nil
       Logger.shared.info("Sync store complete")
     } catch {
@@ -445,55 +324,11 @@ public final class DocumentStore: Sendable {
     }
   }
 
-  /// The eager entry views call. Triggers a network → DB sync; the cache → UI
-  /// read side is wired up in a later commit layered on top of this core.
+  /// The eager entry views call. Triggers a network → DB sync; the element
+  /// projection repaints from the live observation.
   public func fetchAll() async throws {
     Logger.shared.notice("Fetch all store request")
     try await sync()
-  }
-
-  private func fetchAll<T>(
-    elements: [T],
-    collection: ReferenceWritableKeyPath<DocumentStore, [UInt: T]>
-  ) async
-  where T: Identifiable, T.ID == UInt, T: Model {
-    var copy = [UInt: T]()
-
-    for element in elements {
-      copy[element.id] = element
-    }
-
-    self[keyPath: collection] = copy
-  }
-
-  private func getSingleCached<T: Sendable>(
-    get: (UInt) async throws -> T?, id: UInt,
-    cache: ReferenceWritableKeyPath<DocumentStore, [UInt: T]>
-  ) async throws -> (Bool, T)? where T: Model {
-    if let element = self[keyPath: cache][id] {
-      return (true, element)
-    }
-
-    guard let element = try await get(id) else {
-      return nil
-    }
-
-    self[keyPath: cache][id] = element
-    return (false, element)
-  }
-
-  public func getCorrespondent(id: UInt) async throws -> (Bool, Correspondent)? {
-    try checkPermission(.view, for: .correspondent)
-    return try await getSingleCached(
-      get: { try await repository.correspondent(id: $0) }, id: id,
-      cache: \.correspondents)
-  }
-
-  public func getDocumentType(id: UInt) async throws -> (Bool, DocumentType)? {
-    try checkPermission(.view, for: .documentType)
-    return try await getSingleCached(
-      get: { try await repository.documentType(id: $0) }, id: id,
-      cache: \.documentTypes)
   }
 
   public func document(id: UInt) async throws -> Document? {
@@ -501,64 +336,28 @@ public final class DocumentStore: Sendable {
     return try await repository.document(id: id)
   }
 
-  public func getTag(id: UInt) async throws -> (Bool, Tag)? {
-    try checkPermission(.view, for: .tag)
-    return try await getSingleCached(
-      get: { try await repository.tag(id: $0) }, id: id,
-      cache: \.tags)
-  }
-
-  public func getTags(_ ids: [UInt]) async throws -> (Bool, [Tag]) {
-    try checkPermission(.view, for: .tag)
-    var tags: [Tag] = []
-    var allCached = true
-    for id in ids {
-      if let (cached, tag) = try await getTag(id: id) {
-        tags.append(tag)
-        allCached = allCached && cached
-      }
-    }
-    return (allCached, tags)
-  }
-
   private func create<E, R>(
     _: R.Type, from element: E,
-    store: ReferenceWritableKeyPath<DocumentStore, [R.ID: R]>,
     method: (E) async throws -> R
   ) async throws -> R
   where E: Sendable & PermissionsModel, R: Identifiable & Sendable {
-    let updated: E
-    do {
-      Logger.shared.info(
-        "Refreshing default permissions so we can apply them no new element \(R.self)")
-      try await fetchUISettings()  // ensure up to date permissions
-      updated = settings.permissions.appliedAsDefaults(to: element)
-      Logger.shared.info(
-        "Applied permissions defaults to \(R.self). before owner=\(element.owner, privacy: .public) perms=\(String(describing: element.permissions), privacy: .public), after owner=\(updated.owner, privacy: .public) perms=\(String(describing: updated.permissions), privacy: .public)"
-      )
-    } catch {
-      Logger.shared.error(
-        "Error applying permissions defaults: \(error, privacy: .public). Not applying configured defaults permissions to element."
-      )
-      updated = element
-    }
-
-    let created = try await method(updated)
-    self[keyPath: store][created.id] = created
-    return created
+    // `settings` is kept live by the element observation, so its permission
+    // defaults are already current — apply them directly. The repository
+    // write-throughs the created element to the DB; the observation repaints it
+    // into the projection.
+    let updated = settings.permissions.appliedAsDefaults(to: element)
+    return try await method(updated)
   }
 
   private func update<E>(
     _ element: E,
-    store: ReferenceWritableKeyPath<DocumentStore, [E.ID: E]>,
     method: (E) async throws -> E
   ) async throws where E: Identifiable & Sendable {
-    self[keyPath: store][element.id] = try await method(element)
+    _ = try await method(element)
   }
 
   private func delete<E>(
     _ element: E,
-    store: ReferenceWritableKeyPath<DocumentStore, [E.ID: E]>,
     method: (E) async throws -> Void
   ) async throws where E: Identifiable & Sendable {
     do {
@@ -566,10 +365,10 @@ public final class DocumentStore: Sendable {
     } catch let RequestError.unexpectedStatusCode(code: code, _) where code == .notFound {
       let id = "\(element.id)"
       Logger.api.debug(
-        "Element with ID \(id) found (probably already deleted), removing from store")
+        "Element with ID \(id) not found (probably already deleted)")
     }
-
-    self[keyPath: store].removeValue(forKey: element.id)
+    // The repository write-throughs the delete to the DB; the observation
+    // removes it from the projection.
   }
 
   public func create(tag: ProtoTag) async throws -> Tag {
@@ -577,18 +376,17 @@ public final class DocumentStore: Sendable {
     return try await create(
       Tag.self,
       from: tag,
-      store: \.tags,
       method: repository.create(tag:))
   }
 
   public func update(tag: Tag) async throws {
     Logger.api.info("Updating tag with ID \(tag.id)")
-    return try await update(tag, store: \.tags, method: repository.update(tag:))
+    return try await update(tag, method: repository.update(tag:))
   }
 
   public func delete(tag: Tag) async throws {
     Logger.api.info("Deleting tag with ID \(tag.id)")
-    return try await delete(tag, store: \.tags, method: repository.delete(tag:))
+    return try await delete(tag, method: repository.delete(tag:))
   }
 
   public func create(correspondent: ProtoCorrespondent) async throws -> Correspondent {
@@ -596,7 +394,6 @@ public final class DocumentStore: Sendable {
     return try await create(
       Correspondent.self,
       from: correspondent,
-      store: \.correspondents,
       method: repository.create(correspondent:))
   }
 
@@ -604,7 +401,6 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating correspondent with ID \(correspondent.id)")
     return try await update(
       correspondent,
-      store: \.correspondents,
       method: repository.update(correspondent:))
   }
 
@@ -612,7 +408,6 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting correspondent with ID \(correspondent.id)")
     return try await delete(
       correspondent,
-      store: \.correspondents,
       method: repository.delete(correspondent:))
   }
 
@@ -621,7 +416,6 @@ public final class DocumentStore: Sendable {
     return try await create(
       DocumentType.self,
       from: documentType,
-      store: \.documentTypes,
       method: repository.create(documentType:))
   }
 
@@ -629,7 +423,6 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating document type with ID \(documentType.id)")
     return try await update(
       documentType,
-      store: \.documentTypes,
       method: repository.update(documentType:))
   }
 
@@ -637,14 +430,12 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting document type with ID \(documentType.id)")
     return try await delete(
       documentType,
-      store: \.documentTypes,
       method: repository.delete(documentType:))
   }
 
   public func create(savedView: ProtoSavedView) async throws -> SavedView {
     Logger.api.info("Creating saved view with name \(savedView.name)")
     let created = try await repository.create(savedView: savedView)
-    savedViews[created.id] = created
 
     try await handleSavedViewVisibility(created)
 
@@ -660,11 +451,18 @@ public final class DocumentStore: Sendable {
 
     Logger.api.info("Updating saved view visibility via ui settings")
 
+    // `settings` is a read-only projection; mutate a local copy and write it
+    // through the repository (which updates the cached singleton → observation
+    // repaints `settings`).
+    var newSettings = settings
+
     // Normalize to exclude
-    var dashboardVisibleIds = settings.savedViews.dashboardViewsVisibleIds.filter {
+    var dashboardVisibleIds = newSettings.savedViews.dashboardViewsVisibleIds.filter {
       $0 != savedView.id
     }
-    var sidebarVisibleIds = settings.savedViews.sidebarViewsVisibleIds.filter { $0 != savedView.id }
+    var sidebarVisibleIds = newSettings.savedViews.sidebarViewsVisibleIds.filter {
+      $0 != savedView.id
+    }
 
     if savedView.showOnDashboard {
       dashboardVisibleIds.append(savedView.id)
@@ -674,10 +472,10 @@ public final class DocumentStore: Sendable {
       sidebarVisibleIds.append(savedView.id)
     }
 
-    settings.savedViews.dashboardViewsVisibleIds = dashboardVisibleIds
-    settings.savedViews.sidebarViewsVisibleIds = sidebarVisibleIds
+    newSettings.savedViews.dashboardViewsVisibleIds = dashboardVisibleIds
+    newSettings.savedViews.sidebarViewsVisibleIds = sidebarVisibleIds
 
-    try await repository.update(settings: settings)
+    try await repository.update(settings: newSettings)
   }
 
   public func create(document: ProtoDocument, file: URL, filename: String? = nil) async throws {
@@ -689,7 +487,7 @@ public final class DocumentStore: Sendable {
 
   public func update(savedView: SavedView) async throws {
     Logger.api.info("Updating saved view with ID \(savedView.id)")
-    savedViews[savedView.id] = try await repository.update(savedView: savedView)
+    _ = try await repository.update(savedView: savedView)
 
     try await handleSavedViewVisibility(savedView)
   }
@@ -697,7 +495,6 @@ public final class DocumentStore: Sendable {
   public func delete(savedView: SavedView) async throws {
     Logger.api.info("Deleting saved view with ID \(savedView.id)")
     try await repository.delete(savedView: savedView)
-    savedViews.removeValue(forKey: savedView.id)
   }
 
   public func create(storagePath: ProtoStoragePath) async throws -> StoragePath {
@@ -705,7 +502,6 @@ public final class DocumentStore: Sendable {
     return try await create(
       StoragePath.self,
       from: storagePath,
-      store: \.storagePaths,
       method: repository.create(storagePath:))
   }
 
@@ -713,7 +509,6 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating storage path with ID \(storagePath.id)")
     try await update(
       storagePath,
-      store: \.storagePaths,
       method: repository.update(storagePath:))
   }
 
@@ -721,7 +516,6 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting storage path with ID \(storagePath.id)")
     try await delete(
       storagePath,
-      store: \.storagePaths,
       method: repository.delete(storagePath:))
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -40,6 +40,15 @@ public final class DocumentStore: Sendable {
   public private(set) var permissions: UserPermissions = .empty
   public private(set) var settings = UISettingsSettings()
 
+  /// True while a network `sync` is in flight. Distinct from data-presence so a
+  /// cold cache shows loading rather than emptiness.
+  public private(set) var isRefreshing = false
+
+  /// The last automatic (non-user-initiated) sync failure, kept so the UI can
+  /// surface a degraded state without tearing down the cached display.
+  /// User-initiated syncs rethrow instead (the caller toasts, as before).
+  public private(set) var lastSyncError: (any DisplayableError)?
+
   public var activeTasks: [PaperlessTask] {
     tasks.filter(\.isActive)
   }
@@ -138,6 +147,7 @@ public final class DocumentStore: Sendable {
     tasks = []
     permissions = .empty
     settings = UISettingsSettings()
+    lastSyncError = nil
   }
 
   public func set(repository: some Repository, reload: Bool = true) {
@@ -358,12 +368,15 @@ public final class DocumentStore: Sendable {
     }
   }
 
-  public func fetchAll() async throws {
-    // @TODO: This gets called concurrently during startup, maybe debounce
-    Logger.shared.notice("Fetch all store request")
+  /// Load every element collection through `repository` into the observed dicts.
+  /// Behind a `CachingRepository` this reads the DB (hydrate); behind a plain
+  /// `ApiRepository` it reads the network. `lenient` controls whether a failing
+  /// resource aborts the whole load (`false`, network-fetch semantics) or is
+  /// suppressed (`true`, cache-read semantics — a cold/partial cache must not
+  /// fail the UI).
+  private func loadAll(lenient: Bool) async throws {
     await fetchAllSemaphore.wait()
     defer { fetchAllSemaphore.signal() }
-    Logger.shared.notice("Fetch all store")
 
     try? await fetchUISettings()
 
@@ -391,20 +404,52 @@ public final class DocumentStore: Sendable {
         do {
           try await group.next()
         } catch is PermissionsError {
-          Logger.shared.debug("Fetch all task returned permissions error, suppressing")
+          Logger.shared.debug("Load task returned permissions error, suppressing")
           continue
         } catch let error where error.isCancellationError {
-          Logger.shared.debug("Fetch all task caught cancellation, suppressing")
+          Logger.shared.debug("Load task caught cancellation, suppressing")
           continue
         } catch {
-          Logger.shared.error("Fetch all task caught error: \(error)")
-          // @TODO: This cancels the other tasks, maybe we want to continue
+          if lenient {
+            Logger.shared.warning("Load task error (suppressed during hydrate): \(error)")
+            continue
+          }
+          Logger.shared.error("Load task caught error: \(error)")
           throw error
         }
       }
     }
+  }
 
-    Logger.shared.info("Fetch all store complete")
+  /// Network → DB (behind a `CachingBackend`) or network → dicts (otherwise).
+  /// Automatic syncs fail soft into `lastSyncError`; user-initiated syncs
+  /// rethrow so the caller can surface the failure (toast), as before.
+  public func sync(userInitiated: Bool = false) async throws {
+    Logger.shared.notice("Sync store (userInitiated: \(userInitiated))")
+    isRefreshing = true
+    defer { isRefreshing = false }
+    do {
+      if let backend = repository as? any CachingBackend {
+        try await backend.syncElements()
+      } else {
+        try await loadAll(lenient: false)
+      }
+      lastSyncError = nil
+      Logger.shared.info("Sync store complete")
+    } catch {
+      if userInitiated { throw error }
+      if !error.isCancellationError {
+        lastSyncError = error as? any DisplayableError
+        Logger.shared.error("Background sync failed (suppressed): \(error)")
+      }
+    }
+  }
+
+  /// The eager entry views call. Triggers a network → DB sync; the cache → UI
+  /// read side is wired up in a later commit layered on top of this core.
+  public func fetchAll() async throws {
+    Logger.shared.notice("Fetch all store request")
+    try await sync()
   }
 
   private func fetchAll<T>(

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -318,7 +318,13 @@ public final class DocumentStore: Sendable {
     } catch {
       if userInitiated { throw error }
       if !error.isCancellationError {
-        lastSyncError = error as? any DisplayableError
+        // Only overwrite when the failure is actually presentable. Assigning
+        // `error as? any DisplayableError` unconditionally meant a
+        // non-displayable failure (a GRDB `DatabaseError`, a raw `URLError`)
+        // wrote `nil` and cleared a degraded state the UI was already showing.
+        if let displayable = error as? any DisplayableError {
+          lastSyncError = displayable
+        }
         Logger.shared.error("Background sync failed (suppressed): \(error)")
       }
     }

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -318,10 +318,9 @@ public final class DocumentStore: Sendable {
     } catch {
       if userInitiated { throw error }
       if !error.isCancellationError {
-        // Only overwrite when the failure is actually presentable. Assigning
-        // `error as? any DisplayableError` unconditionally meant a
-        // non-displayable failure (a GRDB `DatabaseError`, a raw `URLError`)
-        // wrote `nil` and cleared a degraded state the UI was already showing.
+        // Only presentable failures are recorded. A non-displayable one (a GRDB
+        // `DatabaseError`, a raw `URLError`) leaves any degraded state already
+        // on screen intact rather than clearing it.
         if let displayable = error as? any DisplayableError {
           lastSyncError = displayable
         }

--- a/AppShared/Sources/AppShared/Document/ElementStore.swift
+++ b/AppShared/Sources/AppShared/Document/ElementStore.swift
@@ -1,0 +1,203 @@
+//
+//  ElementStore.swift
+//  AppShared
+//
+//  The source-of-truth read projection for the element collections. Owned by
+//  `DocumentStore`, which re-exposes these through read-only computed delegates
+//  (`store.tags { elementStore.tags }`) so existing call sites keep working.
+//
+//  The DB is the only authoritative copy. Each collection/singleton is kept
+//  live by a GRDB `ValueObservation` (vended as a typed `observe…` stream from
+//  `Persistence`): the observation *carries the data* (the freshly-mapped domain
+//  result), which the loop assigns directly — there is no `hydrate` step and no
+//  coarse `CacheChange` signal. The first emission is the current cached state
+//  (offline-first instant paint), then live updates as `sync`/mutations write
+//  the DB.
+//
+
+import Common
+import DataModel
+import Foundation
+import Persistence
+import SwiftUI
+import os
+
+@MainActor
+@Observable
+public final class ElementStore {
+  // MARK: Observed projection (read-only; written only by the observation loops)
+
+  public private(set) var tags: [UInt: Tag] = [:]
+  public private(set) var correspondents: [UInt: Correspondent] = [:]
+  public private(set) var documentTypes: [UInt: DocumentType] = [:]
+  public private(set) var storagePaths: [UInt: StoragePath] = [:]
+  public private(set) var savedViews: [UInt: SavedView] = [:]
+  public private(set) var users: [UInt: User] = [:]
+  public private(set) var groups: [UInt: UserGroup] = [:]
+  public private(set) var customFields: [UInt: CustomField] = [:]
+
+  // Derived from the `ui_settings` singleton, set together on each emission.
+  public private(set) var currentUser: User?
+  public private(set) var permissions: UserPermissions = .empty
+  public private(set) var settings = UISettingsSettings()
+
+  public private(set) var serverConfiguration: ServerConfiguration?
+
+  /// True once the `ui_settings` singleton has produced a non-nil value for the
+  /// active server — i.e. `permissions`/`settings` reflect real data rather than
+  /// the cold-cache default. Lets the UI distinguish "loading" from "denied".
+  public private(set) var isHydrated = false
+
+  @ObservationIgnored
+  private nonisolated(unsafe) var observationTasks: [Task<Void, Never>] = []
+
+  public init() {}
+
+  deinit {
+    for task in observationTasks { task.cancel() }
+  }
+
+  // MARK: Lifecycle
+
+  /// Point the projection at a server's cached data and keep it live. Cancels
+  /// any prior observation, clears the dicts synchronously (so the previous
+  /// server's data isn't shown during the gap before the first emission lands),
+  /// then subscribes. Mirror of `set(repository:)`'s connection-switch hook.
+  public func repoint(database: Database, serverID: UUID) {
+    cancelObservation()
+    clearProjection()
+    start(database: database, serverID: serverID)
+  }
+
+  /// Detach from any server (logout / a non-caching repository that fronts no
+  /// DB): stop the loops and clear the projection.
+  public func reset() {
+    cancelObservation()
+    clearProjection()
+  }
+
+  /// Synchronously pull the `ui_settings` singleton from the DB into the
+  /// projection, for the one caller (`DocumentStore.fetchUISettings`) that reads
+  /// `permissions` immediately after a refresh and cannot wait for the
+  /// observation's runloop hop. The observation will re-emit the same values
+  /// harmlessly.
+  func refreshUISettings(from database: Database, serverID: UUID) {
+    guard let uiSettings = try? database.uiSettings(serverID: serverID) else { return }
+    apply(uiSettings)
+  }
+
+  // MARK: Observation
+
+  private func start(database: Database, serverID: UUID) {
+    observationTasks = [
+      observeCollection(
+        database.observeElements(TagRecord.self, serverID: serverID), into: \.tags),
+      observeCollection(
+        database.observeElements(CorrespondentRecord.self, serverID: serverID),
+        into: \.correspondents),
+      observeCollection(
+        database.observeElements(DocumentTypeRecord.self, serverID: serverID),
+        into: \.documentTypes),
+      observeCollection(
+        database.observeElements(StoragePathRecord.self, serverID: serverID),
+        into: \.storagePaths),
+      observeCollection(
+        database.observeElements(SavedViewRecord.self, serverID: serverID), into: \.savedViews),
+      observeCollection(
+        database.observeElements(UserRecord.self, serverID: serverID), into: \.users),
+      observeCollection(
+        database.observeElements(UserGroupRecord.self, serverID: serverID), into: \.groups),
+      observeCollection(
+        database.observeElements(CustomFieldRecord.self, serverID: serverID),
+        into: \.customFields),
+      observeUISettings(database.observeUISettings(serverID: serverID)),
+      observeSingleton(
+        database.observeServerConfiguration(serverID: serverID), into: \.serverConfiguration),
+    ]
+  }
+
+  private func observeCollection<E: Identifiable & Sendable>(
+    _ stream: AsyncThrowingStream<[E], Error>,
+    into keyPath: ReferenceWritableKeyPath<ElementStore, [UInt: E]>
+  ) -> Task<Void, Never> where E.ID == UInt {
+    Task { @MainActor [weak self] in
+      do {
+        for try await values in stream {
+          guard let self else { break }
+          var dict = [UInt: E](minimumCapacity: values.count)
+          for value in values { dict[value.id] = value }
+          self[keyPath: keyPath] = dict
+        }
+      } catch is CancellationError {
+      } catch {
+        Logger.shared.error("Element observation terminated: \(error)")
+      }
+    }
+  }
+
+  private func observeSingleton<V: Sendable>(
+    _ stream: AsyncThrowingStream<V?, Error>,
+    into keyPath: ReferenceWritableKeyPath<ElementStore, V?>
+  ) -> Task<Void, Never> {
+    Task { @MainActor [weak self] in
+      do {
+        for try await value in stream {
+          guard let self else { break }
+          self[keyPath: keyPath] = value
+        }
+      } catch is CancellationError {
+      } catch {
+        Logger.shared.error("Singleton observation terminated: \(error)")
+      }
+    }
+  }
+
+  private func observeUISettings(
+    _ stream: AsyncThrowingStream<UISettings?, Error>
+  ) -> Task<Void, Never> {
+    Task { @MainActor [weak self] in
+      do {
+        for try await value in stream {
+          guard let self else { break }
+          // A nil emission means a cold cache: keep the prior values (don't
+          // reset permissions to .empty mid-session) and leave isHydrated false
+          // so the UI can show "loading" rather than "denied".
+          if let value { apply(value) }
+        }
+      } catch is CancellationError {
+      } catch {
+        Logger.shared.error("UI settings observation terminated: \(error)")
+      }
+    }
+  }
+
+  private func apply(_ uiSettings: UISettings) {
+    currentUser = uiSettings.user
+    permissions = uiSettings.permissions
+    settings = uiSettings.settings
+    isHydrated = true
+  }
+
+  // MARK: Helpers
+
+  private func cancelObservation() {
+    for task in observationTasks { task.cancel() }
+    observationTasks = []
+  }
+
+  private func clearProjection() {
+    tags = [:]
+    correspondents = [:]
+    documentTypes = [:]
+    storagePaths = [:]
+    savedViews = [:]
+    users = [:]
+    groups = [:]
+    customFields = [:]
+    currentUser = nil
+    permissions = .empty
+    settings = UISettingsSettings()
+    serverConfiguration = nil
+    isHydrated = false
+  }
+}

--- a/AppShared/Sources/AppShared/Document/ElementStore.swift
+++ b/AppShared/Sources/AppShared/Document/ElementStore.swift
@@ -48,13 +48,17 @@ public final class ElementStore {
   /// the cold-cache default. Lets the UI distinguish "loading" from "denied".
   public private(set) var isHydrated = false
 
+  /// The live observation loops, held in a locked box rather than a stored
+  /// property because `deinit` is nonisolated and cannot read main-actor state.
+  /// `Task.cancel()` is safe from any thread, so the box only has to make the
+  /// list itself safe to touch.
   @ObservationIgnored
-  private nonisolated(unsafe) var observationTasks: [Task<Void, Never>] = []
+  private let observationTasks = TaskBox()
 
   public init() {}
 
   deinit {
-    for task in observationTasks { task.cancel() }
+    observationTasks.cancelAll()
   }
 
   // MARK: Lifecycle
@@ -89,7 +93,7 @@ public final class ElementStore {
   // MARK: Observation
 
   private func start(database: Database, serverID: UUID) {
-    observationTasks = [
+    observationTasks.replace(with: [
       observeCollection(
         database.observeElements(TagRecord.self, serverID: serverID), into: \.tags),
       observeCollection(
@@ -113,7 +117,7 @@ public final class ElementStore {
       observeUISettings(database.observeUISettings(serverID: serverID)),
       observeSingleton(
         database.observeServerConfiguration(serverID: serverID), into: \.serverConfiguration),
-    ]
+    ])
   }
 
   private func observeCollection<E: Identifiable & Sendable>(
@@ -181,8 +185,7 @@ public final class ElementStore {
   // MARK: Helpers
 
   private func cancelObservation() {
-    for task in observationTasks { task.cancel() }
-    observationTasks = []
+    observationTasks.cancelAll()
   }
 
   private func clearProjection() {

--- a/AppShared/Sources/AppShared/Document/TaskBox.swift
+++ b/AppShared/Sources/AppShared/Document/TaskBox.swift
@@ -1,0 +1,32 @@
+//
+//  TaskBox.swift
+//  AppShared
+//
+
+import Foundation
+import os
+
+/// A thread-safe holder for a set of long-running `Task`s.
+///
+/// Exists so an actor-isolated owner can still cancel its tasks from `deinit`,
+/// which is nonisolated and therefore cannot read isolated stored properties.
+/// Cancellation is safe from any thread; the lock is only here to make the
+/// array itself safe to read and replace.
+final class TaskBox: Sendable {
+  private let tasks = OSAllocatedUnfairLock<[Task<Void, Never>]>(initialState: [])
+
+  /// Cancel whatever is currently held and take ownership of `newTasks`.
+  func replace(with newTasks: [Task<Void, Never>]) {
+    let previous = tasks.withLock { held -> [Task<Void, Never>] in
+      let previous = held
+      held = newTasks
+      return previous
+    }
+    for task in previous { task.cancel() }
+  }
+
+  /// Cancel and drop everything held.
+  func cancelAll() {
+    replace(with: [])
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -39,6 +39,13 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// local cache. Throws if the sync as a whole fails (e.g. offline); a single
   /// resource the user lacks permission for is skipped, not fatal.
   func syncElements() async throws
+
+  /// The shared database and the active server this repository caches into.
+  /// `DocumentStore` reads these to point its `ElementStore` projection at the
+  /// same `(database, serverID)` the writes land in, so the live observation
+  /// sees them.
+  var database: Database { get }
+  var serverID: UUID { get }
 }
 
 enum CachingRepositoryError: Error {
@@ -50,8 +57,8 @@ enum CachingRepositoryError: Error {
 @MainActor
 public final class CachingRepository<Wrapped: Repository>: Repository, CachingBackend {
   private let wrapped: Wrapped
-  private let database: Database
-  private let serverID: UUID
+  public let database: Database
+  public let serverID: UUID
 
   public init(wrapping: Wrapped, database: Database, serverID: UUID) {
     wrapped = wrapping
@@ -415,6 +422,14 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
   public func update(settings: UISettingsSettings) async throws {
     try await wrapped.update(settings: settings)
+    // Write the new settings through to the cached `ui_settings` singleton (the
+    // server returns no body), merging onto the cached user/permissions, so the
+    // live observation repaints `settings` (e.g. saved-view visibility).
+    if let current = try database.uiSettings(serverID: serverID) {
+      let merged = UISettings(
+        user: current.user, settings: settings, permissions: current.permissions)
+      try database.setUISettings(merged, serverID: serverID)
+    }
   }
 
   // MARK: - Tasks (forwarded)

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -1,0 +1,445 @@
+//
+//  CachingRepository.swift
+//  AppShared
+//
+//  A `Repository` decorator that serves the small "element" collections (tags,
+//  correspondents, document types, storage paths, saved views, users, groups,
+//  custom fields, current user / UI settings, server config) from the local
+//  GRDB cache, and exposes a separate `sync` (network → DB) via
+//  `CachingBackend`.
+//
+//  Layering: this sits *outside* `NeedsAuthRepository` —
+//  `CachingRepository(wrapping: NeedsAuthRepository(wrapping: ApiRepository))` —
+//  so reads come from the cache while `sync`'s network calls still flow through
+//  the 401 → needs-auth interception.
+//
+//  Read methods are pure cache reads and never hit the network, except the
+//  single-element getters (`tag(id:)` etc.) which fall back to the network +
+//  write-through to resolve a referenced id absent from the cached set.
+//  Element mutations are pessimistic: forward to the server, then write the
+//  confirmed value through to the cache. Everything document/task related is
+//  forwarded unchanged — those caches are later stages.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import SwiftUI
+import os
+
+/// The cache control surface the store reaches for, kept off the `Repository`
+/// protocol (which stays technology-agnostic). A repository that isn't a
+/// `CachingBackend` (preview, Share Extension, tests) makes the store fall back
+/// to direct-network behavior.
+@MainActor
+public protocol CachingBackend: AnyObject, Sendable {
+  /// Fetch every element collection from the network and reconcile it into the
+  /// local cache. Throws if the sync as a whole fails (e.g. offline); a single
+  /// resource the user lacks permission for is skipped, not fatal.
+  func syncElements() async throws
+}
+
+enum CachingRepositoryError: Error {
+  /// A pure cache read found nothing for a non-optional resource. The store's
+  /// hydrate path tolerates this (cold cache); `sync` then fills it.
+  case cacheMiss
+}
+
+@MainActor
+public final class CachingRepository<Wrapped: Repository>: Repository, CachingBackend {
+  private let wrapped: Wrapped
+  private let database: Database
+  private let serverID: UUID
+
+  public init(wrapping: Wrapped, database: Database, serverID: UUID) {
+    wrapped = wrapping
+    self.database = database
+    self.serverID = serverID
+  }
+
+  // MARK: - CachingBackend
+
+  public func syncElements() async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask { [self] in
+        try await syncCollection(TagRecord.self) { try await wrapped.tags() }
+      }
+      group.addTask { [self] in
+        try await syncCollection(CorrespondentRecord.self) {
+          try await wrapped.correspondents()
+        }
+      }
+      group.addTask { [self] in
+        try await syncCollection(DocumentTypeRecord.self) {
+          try await wrapped.documentTypes()
+        }
+      }
+      group.addTask { [self] in
+        try await syncCollection(StoragePathRecord.self) {
+          try await wrapped.storagePaths()
+        }
+      }
+      group.addTask { [self] in
+        try await syncCollection(SavedViewRecord.self) { try await wrapped.savedViews() }
+      }
+      group.addTask { [self] in
+        try await syncCollection(UserRecord.self) { try await wrapped.users() }
+      }
+      group.addTask { [self] in
+        try await syncCollection(UserGroupRecord.self) { try await wrapped.groups() }
+      }
+      group.addTask { [self] in
+        try await syncCollection(CustomFieldRecord.self) {
+          try await wrapped.customFields()
+        }
+      }
+      group.addTask { [self] in try await syncUISettings() }
+      group.addTask { [self] in try await syncServerConfiguration() }
+
+      for try await _ in group {}
+    }
+  }
+
+  private func syncCollection<R: ElementRecord>(
+    _ type: R.Type, _ fetch: () async throws -> [R.Domain]
+  ) async throws {
+    do {
+      let domains = try await fetch()
+      try database.replaceElements(domains, of: type, serverID: serverID)
+    } catch let error as RequestError where Self.isSkippable(error) {
+      Logger.shared.info(
+        "Skipping \(R.databaseTableName, privacy: .public) sync: \(error)")
+    }
+  }
+
+  private func syncUISettings() async throws {
+    do {
+      let settings = try await wrapped.uiSettings()
+      try database.setUISettings(settings, serverID: serverID)
+    } catch let error as RequestError where Self.isSkippable(error) {
+      Logger.shared.info("Skipping uiSettings sync: \(error)")
+    }
+  }
+
+  private func syncServerConfiguration() async throws {
+    do {
+      let config = try await wrapped.serverConfiguration()
+      try database.setServerConfiguration(config, serverID: serverID)
+    } catch let error as RequestError where Self.isSkippable(error) {
+      Logger.shared.info("Skipping serverConfiguration sync: \(error)")
+    }
+  }
+
+  /// 401 already flips needs-auth via the wrapped decorator; 403 means the user
+  /// lacks permission for that one resource. Neither should fail the whole sync.
+  private static func isSkippable(_ error: RequestError) -> Bool {
+    switch error {
+    case .forbidden, .unauthorized: true
+    default: false
+    }
+  }
+
+  // MARK: - Element reads (cache)
+
+  public func tags() async throws -> [Tag] {
+    try database.elements(TagRecord.self, serverID: serverID)
+  }
+
+  public func correspondents() async throws -> [Correspondent] {
+    try database.elements(CorrespondentRecord.self, serverID: serverID)
+  }
+
+  public func documentTypes() async throws -> [DocumentType] {
+    try database.elements(DocumentTypeRecord.self, serverID: serverID)
+  }
+
+  public func storagePaths() async throws -> [StoragePath] {
+    try database.elements(StoragePathRecord.self, serverID: serverID)
+  }
+
+  public func savedViews() async throws -> [SavedView] {
+    try database.elements(SavedViewRecord.self, serverID: serverID)
+  }
+
+  public func users() async throws -> [User] {
+    try database.elements(UserRecord.self, serverID: serverID)
+  }
+
+  public func groups() async throws -> [UserGroup] {
+    try database.elements(UserGroupRecord.self, serverID: serverID)
+  }
+
+  public func customFields() async throws -> [CustomField] {
+    try database.elements(CustomFieldRecord.self, serverID: serverID)
+  }
+
+  public func currentUser() async throws -> User {
+    guard let user = try database.uiSettings(serverID: serverID)?.user else {
+      throw CachingRepositoryError.cacheMiss
+    }
+    return user
+  }
+
+  public func uiSettings() async throws -> UISettings {
+    guard let settings = try database.uiSettings(serverID: serverID) else {
+      throw CachingRepositoryError.cacheMiss
+    }
+    return settings
+  }
+
+  public func serverConfiguration() async throws -> ServerConfiguration {
+    guard let config = try database.serverConfiguration(serverID: serverID) else {
+      throw CachingRepositoryError.cacheMiss
+    }
+    return config
+  }
+
+  // MARK: - Single-element getters (cache-first + network fallback + write-through)
+
+  public func tag(id: UInt) async throws -> Tag? {
+    if let cached = try database.element(TagRecord.self, serverID: serverID, id: id) {
+      return cached
+    }
+    guard let fetched = try await wrapped.tag(id: id) else { return nil }
+    try database.upsertElement(fetched, of: TagRecord.self, serverID: serverID)
+    return fetched
+  }
+
+  public func correspondent(id: UInt) async throws -> Correspondent? {
+    if let cached = try database.element(CorrespondentRecord.self, serverID: serverID, id: id) {
+      return cached
+    }
+    guard let fetched = try await wrapped.correspondent(id: id) else { return nil }
+    try database.upsertElement(fetched, of: CorrespondentRecord.self, serverID: serverID)
+    return fetched
+  }
+
+  public func documentType(id: UInt) async throws -> DocumentType? {
+    if let cached = try database.element(DocumentTypeRecord.self, serverID: serverID, id: id) {
+      return cached
+    }
+    guard let fetched = try await wrapped.documentType(id: id) else { return nil }
+    try database.upsertElement(fetched, of: DocumentTypeRecord.self, serverID: serverID)
+    return fetched
+  }
+
+  // MARK: - Element mutations (pessimistic: forward + write-through)
+
+  public func create(tag: ProtoTag) async throws -> Tag {
+    let created = try await wrapped.create(tag: tag)
+    try database.upsertElement(created, of: TagRecord.self, serverID: serverID)
+    return created
+  }
+
+  public func update(tag: Tag) async throws -> Tag {
+    let updated = try await wrapped.update(tag: tag)
+    try database.upsertElement(updated, of: TagRecord.self, serverID: serverID)
+    return updated
+  }
+
+  public func delete(tag: Tag) async throws {
+    try await wrapped.delete(tag: tag)
+    try database.deleteElement(TagRecord.self, serverID: serverID, id: tag.id)
+  }
+
+  public func create(correspondent: ProtoCorrespondent) async throws -> Correspondent {
+    let created = try await wrapped.create(correspondent: correspondent)
+    try database.upsertElement(created, of: CorrespondentRecord.self, serverID: serverID)
+    return created
+  }
+
+  public func update(correspondent: Correspondent) async throws -> Correspondent {
+    let updated = try await wrapped.update(correspondent: correspondent)
+    try database.upsertElement(updated, of: CorrespondentRecord.self, serverID: serverID)
+    return updated
+  }
+
+  public func delete(correspondent: Correspondent) async throws {
+    try await wrapped.delete(correspondent: correspondent)
+    try database.deleteElement(CorrespondentRecord.self, serverID: serverID, id: correspondent.id)
+  }
+
+  public func create(documentType: ProtoDocumentType) async throws -> DocumentType {
+    let created = try await wrapped.create(documentType: documentType)
+    try database.upsertElement(created, of: DocumentTypeRecord.self, serverID: serverID)
+    return created
+  }
+
+  public func update(documentType: DocumentType) async throws -> DocumentType {
+    let updated = try await wrapped.update(documentType: documentType)
+    try database.upsertElement(updated, of: DocumentTypeRecord.self, serverID: serverID)
+    return updated
+  }
+
+  public func delete(documentType: DocumentType) async throws {
+    try await wrapped.delete(documentType: documentType)
+    try database.deleteElement(DocumentTypeRecord.self, serverID: serverID, id: documentType.id)
+  }
+
+  public func create(storagePath: ProtoStoragePath) async throws -> StoragePath {
+    let created = try await wrapped.create(storagePath: storagePath)
+    try database.upsertElement(created, of: StoragePathRecord.self, serverID: serverID)
+    return created
+  }
+
+  public func update(storagePath: StoragePath) async throws -> StoragePath {
+    let updated = try await wrapped.update(storagePath: storagePath)
+    try database.upsertElement(updated, of: StoragePathRecord.self, serverID: serverID)
+    return updated
+  }
+
+  public func delete(storagePath: StoragePath) async throws {
+    try await wrapped.delete(storagePath: storagePath)
+    try database.deleteElement(StoragePathRecord.self, serverID: serverID, id: storagePath.id)
+  }
+
+  public func create(savedView: ProtoSavedView) async throws -> SavedView {
+    let created = try await wrapped.create(savedView: savedView)
+    try database.upsertElement(created, of: SavedViewRecord.self, serverID: serverID)
+    return created
+  }
+
+  public func update(savedView: SavedView) async throws -> SavedView {
+    let updated = try await wrapped.update(savedView: savedView)
+    try database.upsertElement(updated, of: SavedViewRecord.self, serverID: serverID)
+    return updated
+  }
+
+  public func delete(savedView: SavedView) async throws {
+    try await wrapped.delete(savedView: savedView)
+    try database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
+  }
+
+  // MARK: - Documents (forwarded — Stage 8)
+
+  public func update(document: Document) async throws -> Document {
+    try await wrapped.update(document: document)
+  }
+
+  public func delete(document: Document) async throws {
+    try await wrapped.delete(document: document)
+  }
+
+  public func create(document: ProtoDocument, file: URL, filename: String) async throws {
+    try await wrapped.create(document: document, file: file, filename: filename)
+  }
+
+  public func document(id: UInt) async throws -> Document? {
+    try await wrapped.document(id: id)
+  }
+
+  public func document(asn: UInt) async throws -> Document? {
+    try await wrapped.document(asn: asn)
+  }
+
+  public func documents(filter: FilterState) throws -> Wrapped.Documents {
+    try wrapped.documents(filter: filter)
+  }
+
+  public func nextAsn() async throws -> UInt {
+    try await wrapped.nextAsn()
+  }
+
+  public func metadata(documentId: UInt) async throws -> Metadata {
+    try await wrapped.metadata(documentId: documentId)
+  }
+
+  public func notes(documentId: UInt) async throws -> [Document.Note] {
+    try await wrapped.notes(documentId: documentId)
+  }
+
+  public func createNote(documentId: UInt, note: ProtoDocument.Note) async throws
+    -> [Document.Note]
+  {
+    try await wrapped.createNote(documentId: documentId, note: note)
+  }
+
+  public func deleteNote(id: UInt, documentId: UInt) async throws -> [Document.Note] {
+    try await wrapped.deleteNote(id: id, documentId: documentId)
+  }
+
+  public func shareLinks(documentId: UInt) async throws -> [DataModel.ShareLink] {
+    try await wrapped.shareLinks(documentId: documentId)
+  }
+
+  public func trash() async throws -> [Document] {
+    try await wrapped.trash()
+  }
+
+  public func restoreTrash(documents: [UInt]) async throws {
+    try await wrapped.restoreTrash(documents: documents)
+  }
+
+  public func emptyTrash(documents: [UInt]) async throws {
+    try await wrapped.emptyTrash(documents: documents)
+  }
+
+  public func thumbnail(document: Document) async throws -> Image? {
+    try await wrapped.thumbnail(document: document)
+  }
+
+  public func thumbnailData(document: Document) async throws -> Data {
+    try await wrapped.thumbnailData(document: document)
+  }
+
+  public nonisolated func thumbnailRequest(document: Document) throws -> URLRequest {
+    try wrapped.thumbnailRequest(document: document)
+  }
+
+  public func download(
+    document: Document, original: Bool,
+    progress: (@Sendable (Double) -> Void)?
+  ) async throws -> URL {
+    try await wrapped.download(document: document, original: original, progress: progress)
+  }
+
+  public func suggestions(documentId: UInt) async throws -> Suggestions {
+    try await wrapped.suggestions(documentId: documentId)
+  }
+
+  // MARK: - Server / share links / settings (forwarded)
+
+  public func remoteVersion() async throws -> RemoteVersion {
+    try await wrapped.remoteVersion()
+  }
+
+  public func create(shareLink: ProtoShareLink) async throws -> DataModel.ShareLink {
+    try await wrapped.create(shareLink: shareLink)
+  }
+
+  public func delete(shareLink: DataModel.ShareLink) async throws {
+    try await wrapped.delete(shareLink: shareLink)
+  }
+
+  public func update(settings: UISettingsSettings) async throws {
+    try await wrapped.update(settings: settings)
+  }
+
+  // MARK: - Tasks (forwarded)
+
+  public func task(id: UInt) async throws -> PaperlessTask? {
+    try await wrapped.task(id: id)
+  }
+
+  public func tasks(limit: UInt) async throws -> [PaperlessTask] {
+    try await wrapped.tasks(limit: limit)
+  }
+
+  public func tasks() throws -> Wrapped.Tasks {
+    try wrapped.tasks()
+  }
+
+  public func acknowledge(tasks: [UInt]) async throws {
+    try await wrapped.acknowledge(tasks: tasks)
+  }
+
+  // MARK: - Infrastructure pass-throughs
+
+  public nonisolated var delegate: (any URLSessionDelegate)? { wrapped.delegate }
+
+  public func supports(feature: BackendFeature) -> Bool {
+    wrapped.supports(feature: feature)
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -142,12 +142,11 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   /// 401 already flips needs-auth via the wrapped decorator; 403 means the user
   /// lacks permission for that one resource. Neither should fail the whole sync.
   ///
-  /// Takes `any Error` rather than `RequestError` because the two carriers of a
-  /// 403 are not the same type: the singleton fetches surface
-  /// `RequestError.forbidden`, but every paginated collection goes through
-  /// `PageCursor`, which rewrites that into `ResourceForbidden<Element>`. Matching
-  /// only `RequestError` silently let a single forbidden collection abort the
-  /// whole sync task group.
+  /// Takes `any Error` because a 403 arrives as one of two unrelated types: the
+  /// singleton fetches surface `RequestError.forbidden`, while every paginated
+  /// collection goes through `PageCursor`, which reports it as
+  /// `ResourceForbidden<Element>`. Both must be skippable, or one forbidden
+  /// collection takes the whole sync task group down with it.
   private static func isSkippable(_ error: any Error) -> Bool {
     if error is any ResourceForbiddenError { return true }
     return switch error as? RequestError {
@@ -327,7 +326,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
   }
 
-  // MARK: - Documents (forwarded — Stage 8)
+  // MARK: - Documents (forwarded)
 
   public func update(document: Document) async throws -> Document {
     try await wrapped.update(document: document)

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -115,7 +115,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     do {
       let domains = try await fetch()
       try database.replaceElements(domains, of: type, serverID: serverID)
-    } catch let error as RequestError where Self.isSkippable(error) {
+    } catch let error where Self.isSkippable(error) {
       Logger.shared.info(
         "Skipping \(R.databaseTableName, privacy: .public) sync: \(error)")
     }
@@ -125,7 +125,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     do {
       let settings = try await wrapped.uiSettings()
       try database.setUISettings(settings, serverID: serverID)
-    } catch let error as RequestError where Self.isSkippable(error) {
+    } catch let error where Self.isSkippable(error) {
       Logger.shared.info("Skipping uiSettings sync: \(error)")
     }
   }
@@ -134,15 +134,23 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     do {
       let config = try await wrapped.serverConfiguration()
       try database.setServerConfiguration(config, serverID: serverID)
-    } catch let error as RequestError where Self.isSkippable(error) {
+    } catch let error where Self.isSkippable(error) {
       Logger.shared.info("Skipping serverConfiguration sync: \(error)")
     }
   }
 
   /// 401 already flips needs-auth via the wrapped decorator; 403 means the user
   /// lacks permission for that one resource. Neither should fail the whole sync.
-  private static func isSkippable(_ error: RequestError) -> Bool {
-    switch error {
+  ///
+  /// Takes `any Error` rather than `RequestError` because the two carriers of a
+  /// 403 are not the same type: the singleton fetches surface
+  /// `RequestError.forbidden`, but every paginated collection goes through
+  /// `PageCursor`, which rewrites that into `ResourceForbidden<Element>`. Matching
+  /// only `RequestError` silently let a single forbidden collection abort the
+  /// whole sync task group.
+  private static func isSkippable(_ error: any Error) -> Bool {
+    if error is any ResourceForbiddenError { return true }
+    return switch error as? RequestError {
     case .forbidden, .unauthorized: true
     default: false
     }

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -7,6 +7,7 @@
 
 import Common
 import Networking
+import Persistence
 import SwiftUI
 import os
 
@@ -91,6 +92,7 @@ public struct ConnectionSelectionMenu: View {
 
 public struct ConnectionsView: View {
   private var connectionManager: ConnectionManager
+  private let database: Database
   @Binding public var showLoginSheet: Bool
 
   @ScaledMetric(relativeTo: .title) private var plusIconSize = 18.0
@@ -106,8 +108,11 @@ public struct ConnectionsView: View {
 
   @Environment(DocumentStore.self) private var store
 
-  public init(connectionManager: ConnectionManager, showLoginSheet: Binding<Bool>) {
+  public init(
+    connectionManager: ConnectionManager, database: Database, showLoginSheet: Binding<Bool>
+  ) {
     self.connectionManager = connectionManager
+    self.database = database
     _extraHeaders = State(initialValue: connectionManager.storedConnection?.extraHeaders ?? [])
     _showLoginSheet = showLoginSheet
   }
@@ -124,12 +129,19 @@ public struct ConnectionsView: View {
         Task {
           let api = await ApiRepository(
             connection: connection, mode: Bundle.main.appConfiguration.mode)
-          // Must carry the same needs-auth decoration the app shell installs:
-          // a bare repository 401s without ever flipping the flag, and 401s are
+          // Rebuild the *whole* stack the app shell installs, not just the API
+          // layer. The needs-auth decoration is required because a bare
+          // repository 401s without ever flipping the flag, and 401s are
           // suppressed on the assumption the connection banner covers them.
+          // The caching wrapper is required because the store detaches its
+          // ElementStore projection from any repository that fronts no
+          // database — installing an uncached repository here would blank every
+          // element read site until the next relaunch.
+          let needsAuth = NeedsAuthRepository(
+            wrapping: api, serverID: stored.id, connectionManager: connectionManager)
           store.set(
-            repository: NeedsAuthRepository(
-              wrapping: api, serverID: stored.id, connectionManager: connectionManager))
+            repository: CachingRepository(
+              wrapping: needsAuth, database: database, serverID: stored.id))
         }
       }
     }

--- a/Networking/Sources/Networking/RequestError.swift
+++ b/Networking/Sources/Networking/RequestError.swift
@@ -138,7 +138,14 @@ extension RequestError {
   }
 }
 
-public struct ResourceForbidden<Resource>: Error {
+/// Non-generic view of ``ResourceForbidden`` so callers can recognise "this one
+/// resource was forbidden" without knowing the resource type. `ResourceForbidden`
+/// is generic, so `error is ResourceForbidden` is not expressible; this is.
+public protocol ResourceForbiddenError: Error {
+  var response: String? { get }
+}
+
+public struct ResourceForbidden<Resource>: ResourceForbiddenError {
   public let response: String?
 
   public init(_: Resource.Type, response: String?) {

--- a/Persistence/Sources/Persistence/Database+Elements.swift
+++ b/Persistence/Sources/Persistence/Database+Elements.swift
@@ -1,0 +1,102 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// Element-cache operations. Like `Database+Connections`, these are the only
+/// entry points AppShared uses to read or mutate element rows; GRDB stays
+/// sealed inside `Persistence`.
+///
+/// Reads are pure cache reads (no network — that's the caching repository's
+/// `sync`). Writes are either a full per-server reconcile (`replaceElements`,
+/// used by sync, which also handles server-side deletes) or a single
+/// write-through (`upsertElement` / `deleteElement`, used by pessimistic
+/// mutations).
+extension Database {
+  // MARK: - Multi-row collections
+
+  /// All cached rows of one element kind for a server, ordered by name.
+  public func elements<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID
+  ) throws -> [R.Domain] {
+    try writer.read { db in
+      try R
+        .filter(Column("server_id") == serverID)
+        .order(Column("name"))
+        .fetchAll(db)
+        .map(\.domain)
+    }
+  }
+
+  /// A single cached element by `(server, id)`, or `nil` if not cached.
+  public func element<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID, id: UInt
+  ) throws -> R.Domain? {
+    try writer.read { db in
+      try R
+        .filter(Column("server_id") == serverID && Column("id") == id)
+        .fetchOne(db)?
+        .domain
+    }
+  }
+
+  /// Replace the entire cached set for a server in one transaction: delete the
+  /// existing rows, insert the new ones. This is how `sync` propagates
+  /// server-side deletions (rows absent from `domains` disappear).
+  public func replaceElements<R: ElementRecord>(
+    _ domains: [R.Domain], of type: R.Type, serverID: UUID
+  ) throws {
+    try writer.write { db in
+      try R.filter(Column("server_id") == serverID).deleteAll(db)
+      for domain in domains {
+        try R(serverId: serverID, domain: domain).insert(db)
+      }
+    }
+  }
+
+  /// Insert or replace a single cached row (pessimistic mutation write-through).
+  public func upsertElement<R: ElementRecord>(
+    _ domain: R.Domain, of type: R.Type, serverID: UUID
+  ) throws {
+    try writer.write { db in
+      try R(serverId: serverID, domain: domain).upsert(db)
+    }
+  }
+
+  /// Delete a single cached row by `(server, id)` (pessimistic delete).
+  public func deleteElement<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID, id: UInt
+  ) throws {
+    try writer.write { db in
+      _ =
+        try R
+        .filter(Column("server_id") == serverID && Column("id") == id)
+        .deleteAll(db)
+    }
+  }
+
+  // MARK: - Singletons
+
+  public func uiSettings(serverID: UUID) throws -> UISettings? {
+    try writer.read { db in
+      try UISettingsRecord.fetchOne(db, key: serverID)?.domain
+    }
+  }
+
+  public func setUISettings(_ value: UISettings, serverID: UUID) throws {
+    try writer.write { db in
+      try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
+    }
+  }
+
+  public func serverConfiguration(serverID: UUID) throws -> ServerConfiguration? {
+    try writer.read { db in
+      try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
+    }
+  }
+
+  public func setServerConfiguration(_ value: ServerConfiguration, serverID: UUID) throws {
+    try writer.write { db in
+      try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Elements.swift
+++ b/Persistence/Sources/Persistence/Database+Elements.swift
@@ -4,7 +4,8 @@ import GRDB
 
 /// Element-cache operations. Like `Database+Connections`, these are the only
 /// entry points AppShared uses to read or mutate element rows; GRDB stays
-/// sealed inside `Persistence`.
+/// sealed inside `Persistence`. Every access goes through ``Database/wrapping``
+/// so a GRDB failure reaches callers as a ``DatabaseError``.
 ///
 /// Reads are pure cache reads (no network — that's the caching repository's
 /// `sync`). Writes are either a full per-server reconcile (`replaceElements`,
@@ -18,12 +19,14 @@ extension Database {
   public func elements<R: ElementRecord>(
     _ type: R.Type, serverID: UUID
   ) throws -> [R.Domain] {
-    try writer.read { db in
-      try R
-        .filter(Column("server_id") == serverID)
-        .order(Column("name"))
-        .fetchAll(db)
-        .map(\.domain)
+    try wrapping("elements(\(R.databaseTableName))") {
+      try writer.read { db in
+        try R
+          .filter(Column("server_id") == serverID)
+          .order(Column("name"))
+          .fetchAll(db)
+          .map(\.domain)
+      }
     }
   }
 
@@ -31,24 +34,33 @@ extension Database {
   public func element<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
   ) throws -> R.Domain? {
-    try writer.read { db in
-      try R
-        .filter(Column("server_id") == serverID && Column("id") == id)
-        .fetchOne(db)?
-        .domain
+    try wrapping("element(\(R.databaseTableName))") {
+      try writer.read { db in
+        try R
+          .filter(Column("server_id") == serverID && Column("id") == id)
+          .fetchOne(db)?
+          .domain
+      }
     }
   }
 
   /// Replace the entire cached set for a server in one transaction: delete the
   /// existing rows, insert the new ones. This is how `sync` propagates
   /// server-side deletions (rows absent from `domains` disappear).
+  ///
+  /// Uses `upsert` rather than `insert` because the caller's paginated fetch can
+  /// legitimately yield the same element twice — deleting a row server-side
+  /// mid-fetch shifts later elements back a page. `insert` raised a primary-key
+  /// violation there and rolled back the whole reconcile.
   public func replaceElements<R: ElementRecord>(
     _ domains: [R.Domain], of type: R.Type, serverID: UUID
   ) throws {
-    try writer.write { db in
-      try R.filter(Column("server_id") == serverID).deleteAll(db)
-      for domain in domains {
-        try R(serverId: serverID, domain: domain).insert(db)
+    try wrapping("replaceElements(\(R.databaseTableName))") {
+      try writer.write { db in
+        try R.filter(Column("server_id") == serverID).deleteAll(db)
+        for domain in domains {
+          try R(serverId: serverID, domain: domain).upsert(db)
+        }
       }
     }
   }
@@ -57,8 +69,10 @@ extension Database {
   public func upsertElement<R: ElementRecord>(
     _ domain: R.Domain, of type: R.Type, serverID: UUID
   ) throws {
-    try writer.write { db in
-      try R(serverId: serverID, domain: domain).upsert(db)
+    try wrapping("upsertElement(\(R.databaseTableName))") {
+      try writer.write { db in
+        try R(serverId: serverID, domain: domain).upsert(db)
+      }
     }
   }
 
@@ -66,37 +80,47 @@ extension Database {
   public func deleteElement<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
   ) throws {
-    try writer.write { db in
-      _ =
-        try R
-        .filter(Column("server_id") == serverID && Column("id") == id)
-        .deleteAll(db)
+    try wrapping("deleteElement(\(R.databaseTableName))") {
+      try writer.write { db in
+        _ =
+          try R
+          .filter(Column("server_id") == serverID && Column("id") == id)
+          .deleteAll(db)
+      }
     }
   }
 
   // MARK: - Singletons
 
   public func uiSettings(serverID: UUID) throws -> UISettings? {
-    try writer.read { db in
-      try UISettingsRecord.fetchOne(db, key: serverID)?.domain
+    try wrapping("uiSettings") {
+      try writer.read { db in
+        try UISettingsRecord.fetchOne(db, key: serverID)?.domain
+      }
     }
   }
 
   public func setUISettings(_ value: UISettings, serverID: UUID) throws {
-    try writer.write { db in
-      try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
+    try wrapping("setUISettings") {
+      try writer.write { db in
+        try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
+      }
     }
   }
 
   public func serverConfiguration(serverID: UUID) throws -> ServerConfiguration? {
-    try writer.read { db in
-      try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
+    try wrapping("serverConfiguration") {
+      try writer.read { db in
+        try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
+      }
     }
   }
 
   public func setServerConfiguration(_ value: ServerConfiguration, serverID: UUID) throws {
-    try writer.write { db in
-      try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)
+    try wrapping("setServerConfiguration") {
+      try writer.write { db in
+        try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)
+      }
     }
   }
 }

--- a/Persistence/Sources/Persistence/Database+Elements.swift
+++ b/Persistence/Sources/Persistence/Database+Elements.swift
@@ -12,13 +12,26 @@ import GRDB
 /// used by sync, which also handles server-side deletes) or a single
 /// write-through (`upsertElement` / `deleteElement`, used by pessimistic
 /// mutations).
+///
+/// Reads go through `writer` because `DatabaseWriter` refines `DatabaseReader`;
+/// on the production `DatabasePool` a `read` takes a reader connection and runs
+/// concurrently with writes under WAL.
+///
+/// **Evolving a record's `Payload`.** The payload is JSON in the `data` column,
+/// so the schema does not constrain its shape: optional fields can be added and
+/// fields can be dropped freely. Adding a *required* field cannot be done in
+/// place — old rows fail to decode, and because a read maps the whole
+/// collection, one undecodable row fails every row of that kind. These tables
+/// hold nothing but derived data, so the cheap correct move is a migration that
+/// deletes the affected rows and lets the next sync refill them, rather than
+/// rewriting stored JSON.
 extension Database {
   // MARK: - Multi-row collections
 
   /// All cached rows of one element kind for a server, ordered by name.
   public func elements<R: ElementRecord>(
     _ type: R.Type, serverID: UUID
-  ) throws -> [R.Domain] {
+  ) throws(DatabaseError) -> [R.Domain] {
     try wrapping("elements(\(R.databaseTableName))") {
       try writer.read { db in
         try R
@@ -33,7 +46,7 @@ extension Database {
   /// A single cached element by `(server, id)`, or `nil` if not cached.
   public func element<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
-  ) throws -> R.Domain? {
+  ) throws(DatabaseError) -> R.Domain? {
     try wrapping("element(\(R.databaseTableName))") {
       try writer.read { db in
         try R
@@ -48,13 +61,13 @@ extension Database {
   /// existing rows, insert the new ones. This is how `sync` propagates
   /// server-side deletions (rows absent from `domains` disappear).
   ///
-  /// Uses `upsert` rather than `insert` because the caller's paginated fetch can
-  /// legitimately yield the same element twice — deleting a row server-side
-  /// mid-fetch shifts later elements back a page. `insert` raised a primary-key
-  /// violation there and rolled back the whole reconcile.
+  /// `upsert` rather than `insert`: a paginated fetch can legitimately deliver
+  /// the same element twice, because deleting a row server-side mid-fetch
+  /// shifts later elements back a page. The last write for an id wins, and the
+  /// reconcile survives the duplicate.
   public func replaceElements<R: ElementRecord>(
     _ domains: [R.Domain], of type: R.Type, serverID: UUID
-  ) throws {
+  ) throws(DatabaseError) {
     try wrapping("replaceElements(\(R.databaseTableName))") {
       try writer.write { db in
         try R.filter(Column("server_id") == serverID).deleteAll(db)
@@ -68,7 +81,7 @@ extension Database {
   /// Insert or replace a single cached row (pessimistic mutation write-through).
   public func upsertElement<R: ElementRecord>(
     _ domain: R.Domain, of type: R.Type, serverID: UUID
-  ) throws {
+  ) throws(DatabaseError) {
     try wrapping("upsertElement(\(R.databaseTableName))") {
       try writer.write { db in
         try R(serverId: serverID, domain: domain).upsert(db)
@@ -79,7 +92,7 @@ extension Database {
   /// Delete a single cached row by `(server, id)` (pessimistic delete).
   public func deleteElement<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
-  ) throws {
+  ) throws(DatabaseError) {
     try wrapping("deleteElement(\(R.databaseTableName))") {
       try writer.write { db in
         _ =
@@ -92,7 +105,7 @@ extension Database {
 
   // MARK: - Singletons
 
-  public func uiSettings(serverID: UUID) throws -> UISettings? {
+  public func uiSettings(serverID: UUID) throws(DatabaseError) -> UISettings? {
     try wrapping("uiSettings") {
       try writer.read { db in
         try UISettingsRecord.fetchOne(db, key: serverID)?.domain
@@ -100,7 +113,7 @@ extension Database {
     }
   }
 
-  public func setUISettings(_ value: UISettings, serverID: UUID) throws {
+  public func setUISettings(_ value: UISettings, serverID: UUID) throws(DatabaseError) {
     try wrapping("setUISettings") {
       try writer.write { db in
         try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
@@ -108,7 +121,7 @@ extension Database {
     }
   }
 
-  public func serverConfiguration(serverID: UUID) throws -> ServerConfiguration? {
+  public func serverConfiguration(serverID: UUID) throws(DatabaseError) -> ServerConfiguration? {
     try wrapping("serverConfiguration") {
       try writer.read { db in
         try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
@@ -116,7 +129,9 @@ extension Database {
     }
   }
 
-  public func setServerConfiguration(_ value: ServerConfiguration, serverID: UUID) throws {
+  public func setServerConfiguration(
+    _ value: ServerConfiguration, serverID: UUID
+  ) throws(DatabaseError) {
     try wrapping("setServerConfiguration") {
       try writer.write { db in
         try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)

--- a/Persistence/Sources/Persistence/Database+Observe.swift
+++ b/Persistence/Sources/Persistence/Database+Observe.swift
@@ -1,0 +1,78 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// Typed live queries over the element cache — the source-of-truth read path.
+///
+/// Like ``Database/observeConnections()``, each method wraps GRDB
+/// `ValueObservation` and surfaces it as an `AsyncThrowingStream` of **domain**
+/// values: GRDB, `ValueObservation`, and SQL never cross the `Persistence`
+/// boundary. The first element is the current state (so a consumer's
+/// `for try await` loop is "initial hydrate + live updates" in one), exactly
+/// like the connection observer.
+///
+/// These replace the cache-aside variant's coarse `CacheChange` signal +
+/// `hydrate()`: the observation *carries the data* (the freshly-mapped domain
+/// result), so the store/projection assigns it directly with no re-read.
+///
+/// Scope: in Stage 7 the active server is singular. The observation tracks the
+/// whole table region, so a write to *another* server's rows re-fires this
+/// stream with an identical array — harmless at one active server; not worth
+/// narrowing.
+extension Database {
+  /// Live, name-ordered list of one element collection for a server.
+  public func observeElements<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID
+  ) -> AsyncThrowingStream<[R.Domain], Error> {
+    let observation = ValueObservation.tracking { db in
+      try R
+        .filter(Column("server_id") == serverID)
+        .order(Column("name"))
+        .fetchAll(db)
+        .map(\.domain)
+    }
+    return stream(observation)
+  }
+
+  /// Live per-server `UISettings` singleton (`nil` until first cached/synced).
+  public func observeUISettings(serverID: UUID) -> AsyncThrowingStream<UISettings?, Error> {
+    let observation = ValueObservation.tracking { db in
+      try UISettingsRecord.fetchOne(db, key: serverID)?.domain
+    }
+    return stream(observation)
+  }
+
+  /// Live per-server `ServerConfiguration` singleton (`nil` until cached/synced).
+  public func observeServerConfiguration(
+    serverID: UUID
+  ) -> AsyncThrowingStream<ServerConfiguration?, Error> {
+    let observation = ValueObservation.tracking { db in
+      try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
+    }
+    return stream(observation)
+  }
+
+  /// Shared adapter: drive a `ValueObservation` into an `AsyncThrowingStream`,
+  /// mirroring ``observeConnections()``. Cancelling the consuming task tears
+  /// down the underlying observation.
+  private func stream<Value: Sendable>(
+    _ observation: ValueObservation<ValueReducers.Fetch<Value>>
+  ) -> AsyncThrowingStream<Value, Error> {
+    let writer = writer
+    return AsyncThrowingStream { continuation in
+      let task = Task {
+        do {
+          for try await value in observation.values(in: writer) {
+            continuation.yield(value)
+          }
+          continuation.finish()
+        } catch is CancellationError {
+          continuation.finish()
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Observe.swift
+++ b/Persistence/Sources/Persistence/Database+Observe.swift
@@ -11,14 +11,13 @@ import GRDB
 /// `for try await` loop is "initial hydrate + live updates" in one), exactly
 /// like the connection observer.
 ///
-/// These replace the cache-aside variant's coarse `CacheChange` signal +
-/// `hydrate()`: the observation *carries the data* (the freshly-mapped domain
-/// result), so the store/projection assigns it directly with no re-read.
+/// Each emission carries the freshly-mapped domain result, so a consumer
+/// assigns it directly and never re-reads the database to find out what
+/// changed.
 ///
-/// Scope: in Stage 7 the active server is singular. The observation tracks the
-/// whole table region, so a write to *another* server's rows re-fires this
-/// stream with an identical array — harmless at one active server; not worth
-/// narrowing.
+/// Scope: the observation tracks the whole table region, so a write to
+/// *another* server's rows re-fires this stream with an identical array. That
+/// is harmless while one server is active and not worth narrowing.
 extension Database {
   /// Live, name-ordered list of one element collection for a server.
   public func observeElements<R: ElementRecord>(

--- a/Persistence/Sources/Persistence/Database+Seeded.swift
+++ b/Persistence/Sources/Persistence/Database+Seeded.swift
@@ -1,0 +1,49 @@
+import DataModel
+import Foundation
+
+extension Database {
+  /// Build an in-memory database pre-populated with one server and the given
+  /// element rows — the seam previews and tests use instead of injecting a
+  /// repository with pre-filled dicts. Under the source-of-truth model every
+  /// repository fronts a DB, so a preview's element data lives here and is
+  /// surfaced through the same `observe…` live queries as production.
+  ///
+  /// Mirrors the inline `makeDatabase` helper in `ElementCacheTests`.
+  public static func seeded(
+    serverID: UUID = UUID(),
+    tags: [Tag] = [],
+    correspondents: [Correspondent] = [],
+    documentTypes: [DocumentType] = [],
+    storagePaths: [StoragePath] = [],
+    savedViews: [SavedView] = [],
+    users: [User] = [],
+    groups: [UserGroup] = [],
+    customFields: [CustomField] = [],
+    uiSettings: UISettings? = nil,
+    serverConfiguration: ServerConfiguration? = nil
+  ) throws -> Database {
+    let database = try Database.inMemory()
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverID,
+        url: URL(string: "https://paperless.example.com/api/")!,
+        user: .init(id: 1, isSuperUser: true, username: "preview")))
+
+    try database.replaceElements(tags, of: TagRecord.self, serverID: serverID)
+    try database.replaceElements(correspondents, of: CorrespondentRecord.self, serverID: serverID)
+    try database.replaceElements(documentTypes, of: DocumentTypeRecord.self, serverID: serverID)
+    try database.replaceElements(storagePaths, of: StoragePathRecord.self, serverID: serverID)
+    try database.replaceElements(savedViews, of: SavedViewRecord.self, serverID: serverID)
+    try database.replaceElements(users, of: UserRecord.self, serverID: serverID)
+    try database.replaceElements(groups, of: UserGroupRecord.self, serverID: serverID)
+    try database.replaceElements(customFields, of: CustomFieldRecord.self, serverID: serverID)
+
+    if let uiSettings {
+      try database.setUISettings(uiSettings, serverID: serverID)
+    }
+    if let serverConfiguration {
+      try database.setServerConfiguration(serverConfiguration, serverID: serverID)
+    }
+    return database
+  }
+}

--- a/Persistence/Sources/Persistence/Database.swift
+++ b/Persistence/Sources/Persistence/Database.swift
@@ -197,7 +197,11 @@ public enum DatabaseError: Error {
 extension Database {
   /// Run a GRDB access, re-wrapping whatever it throws as a ``DatabaseError``
   /// so callers outside this package can present it without importing GRDB.
-  func wrapping<T>(_ operation: String, _ body: () throws -> T) throws -> T {
+  ///
+  /// The `throws(DatabaseError)` is what lets accessors declare the same, which
+  /// in turn means an accessor cannot reach GRDB except through here: a direct
+  /// `try writer.read { }` throws an untyped error and fails to compile.
+  func wrapping<T>(_ operation: String, _ body: () throws -> T) throws(DatabaseError) -> T {
     do {
       return try body()
     } catch let error as DatabaseError {

--- a/Persistence/Sources/Persistence/Migrations/Migrations.swift
+++ b/Persistence/Sources/Persistence/Migrations/Migrations.swift
@@ -39,6 +39,10 @@ enum Migrations {
       try V2_ImportLegacyConnections.run(db, userDefaults: userDefaults)
     }
 
+    migrator.registerMigration("v3_create_element_cache") { db in
+      try V3_CreateElementCache.run(db)
+    }
+
     return migrator
   }
 }

--- a/Persistence/Sources/Persistence/Migrations/V3_CreateElementCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V3_CreateElementCache.swift
@@ -1,0 +1,39 @@
+import GRDB
+
+/// Element-metadata cache tables (Stage 7).
+///
+/// Each multi-row element collection is keyed `(server_id, id)` and carries a
+/// `name` column (display/sort) plus a `data` JSON column for the long tail.
+/// `ui_settings` and `server_configuration` are per-server singletons keyed by
+/// `server_id` alone. Every table FK-references `server(id)` with
+/// `ON DELETE CASCADE`, so removing a connection tears down its whole cache —
+/// the Stage 10 "connection lifecycle = cache lifecycle" rule, for free.
+enum V3_CreateElementCache {
+  static let multiRowTables = [
+    "tag", "correspondent", "document_type", "storage_path",
+    "saved_view", "user", "user_group", "custom_field",
+  ]
+  static let singletonTables = ["ui_settings", "server_configuration"]
+
+  static func run(_ db: GRDB.Database) throws {
+    for table in multiRowTables {
+      try db.create(table: table, options: [.strict]) { t in
+        t.column("server_id", .blob)
+          .notNull()
+          .references("server", onDelete: .cascade)
+        t.column("id", .integer).notNull()
+        t.column("name", .text).notNull()
+        t.column("data", .text).notNull()
+        t.primaryKey(["server_id", "id"])
+      }
+    }
+
+    for table in singletonTables {
+      try db.create(table: table, options: [.strict]) { t in
+        t.primaryKey("server_id", .blob)
+          .references("server", onDelete: .cascade)
+        t.column("data", .text).notNull()
+      }
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Migrations/V3_CreateElementCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V3_CreateElementCache.swift
@@ -1,13 +1,12 @@
 import GRDB
 
-/// Element-metadata cache tables (Stage 7).
+/// Element-metadata cache tables.
 ///
 /// Each multi-row element collection is keyed `(server_id, id)` and carries a
 /// `name` column (display/sort) plus a `data` JSON column for the long tail.
 /// `ui_settings` and `server_configuration` are per-server singletons keyed by
 /// `server_id` alone. Every table FK-references `server(id)` with
-/// `ON DELETE CASCADE`, so removing a connection tears down its whole cache —
-/// the Stage 10 "connection lifecycle = cache lifecycle" rule, for free.
+/// `ON DELETE CASCADE`, so removing a connection tears down its whole cache.
 enum V3_CreateElementCache {
   static let multiRowTables = [
     "tag", "correspondent", "document_type", "storage_path",
@@ -26,6 +25,14 @@ enum V3_CreateElementCache {
         t.column("data", .text).notNull()
         t.primaryKey(["server_id", "id"])
       }
+
+      // Collection reads filter by server and order by name. The primary key
+      // covers the filter only, leaving the order to a sort over the matched
+      // rows; this index serves both, so the read walks it in order.
+      try db.create(
+        index: "index_\(table)_on_server_id_name",
+        on: table,
+        columns: ["server_id", "name"])
     }
 
     for table in singletonTables {

--- a/Persistence/Sources/Persistence/Models/CorrespondentRecord.swift
+++ b/Persistence/Sources/Persistence/Models/CorrespondentRecord.swift
@@ -1,0 +1,56 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `Correspondent` (`correspondent` table).
+public struct CorrespondentRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var documentCount: UInt?
+    public var lastCorrespondence: Date?
+    public var slug: String
+    public var matchingAlgorithm: MatchingAlgorithm
+    public var match: String
+    public var isInsensitive: Bool
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension CorrespondentRecord: ElementRecord {
+  public static let databaseTableName = "correspondent"
+
+  public init(serverId: UUID, domain: Correspondent) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      documentCount: domain.documentCount,
+      lastCorrespondence: domain.lastCorrespondence,
+      slug: domain.slug,
+      matchingAlgorithm: domain.matchingAlgorithm,
+      match: domain.match,
+      isInsensitive: domain.isInsensitive)
+  }
+
+  public var domain: Correspondent {
+    Correspondent(
+      id: id,
+      documentCount: payload.documentCount,
+      lastCorrespondence: payload.lastCorrespondence,
+      name: name,
+      slug: payload.slug,
+      matchingAlgorithm: payload.matchingAlgorithm,
+      match: payload.match,
+      isInsensitive: payload.isInsensitive)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/CustomFieldRecord.swift
+++ b/Persistence/Sources/Persistence/Models/CustomFieldRecord.swift
@@ -1,0 +1,54 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `CustomField` (`custom_field` table).
+///
+/// `CustomFieldExtraData` is not itself `Codable`, so the payload mirrors its
+/// fields (`selectOptions`, `defaultCurrency`) directly.
+public struct CustomFieldRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var dataType: CustomFieldDataType
+    public var selectOptions: [CustomFieldSelectOption]
+    public var defaultCurrency: String?
+    public var documentCount: UInt?
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension CustomFieldRecord: ElementRecord {
+  public static let databaseTableName = "custom_field"
+
+  public init(serverId: UUID, domain: CustomField) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      dataType: domain.dataType,
+      selectOptions: domain.extraData.selectOptions,
+      defaultCurrency: domain.extraData.defaultCurrency,
+      documentCount: domain.documentCount)
+  }
+
+  public var domain: CustomField {
+    CustomField(
+      id: id,
+      name: name,
+      dataType: payload.dataType,
+      extraData: CustomFieldExtraData(
+        selectOptions: payload.selectOptions,
+        defaultCurrency: payload.defaultCurrency),
+      documentCount: payload.documentCount)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/DocumentTypeRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentTypeRecord.swift
@@ -1,0 +1,50 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `DocumentType` (`document_type` table).
+public struct DocumentTypeRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var slug: String
+    public var match: String
+    public var matchingAlgorithm: MatchingAlgorithm
+    public var isInsensitive: Bool
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension DocumentTypeRecord: ElementRecord {
+  public static let databaseTableName = "document_type"
+
+  public init(serverId: UUID, domain: DocumentType) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      slug: domain.slug,
+      match: domain.match,
+      matchingAlgorithm: domain.matchingAlgorithm,
+      isInsensitive: domain.isInsensitive)
+  }
+
+  public var domain: DocumentType {
+    DocumentType(
+      id: id,
+      name: name,
+      slug: payload.slug,
+      match: payload.match,
+      matchingAlgorithm: payload.matchingAlgorithm,
+      isInsensitive: payload.isInsensitive)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/ElementRecord.swift
+++ b/Persistence/Sources/Persistence/Models/ElementRecord.swift
@@ -1,0 +1,40 @@
+import Foundation
+import GRDB
+
+/// Shared, storage-dedicated JSON coders for element records. Sorted keys give
+/// deterministic on-disk output (reproducible dumps in tests/debug exports).
+/// Independent of the wire encoder on purpose — storage shape is not API shape.
+enum ElementStorage {
+  static let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    return encoder
+  }()
+  static let decoder = JSONDecoder()
+}
+
+/// A GRDB record for one of the per-server element collections.
+///
+/// Every conformer is a row keyed `(server_id, id)` with a `name` column (for
+/// future display/sort) and a `data` JSON column holding the long tail. The
+/// `Record ⇄ Domain` mapping lives here in `Persistence` — element domains live
+/// in `DataModel`, which `Persistence` already depends on, so (unlike
+/// `ConnectionRecord`, whose domain is in `Networking`) no AppShared mapping
+/// hop is needed.
+public protocol ElementRecord:
+  FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable
+{
+  associatedtype Domain: Sendable
+  init(serverId: UUID, domain: Domain)
+  var domain: Domain { get }
+}
+
+extension ElementRecord {
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+}

--- a/Persistence/Sources/Persistence/Models/SavedViewRecord.swift
+++ b/Persistence/Sources/Persistence/Models/SavedViewRecord.swift
@@ -1,0 +1,69 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `SavedView` (`saved_view` table).
+///
+/// The view's settings, filter rules, sort, owner and permissions all live in
+/// the JSON `data` column — they're stored as opaque blobs here and only
+/// interpreted by the domain layer.
+public struct SavedViewRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var showOnDashboard: Bool
+    public var showInSidebar: Bool
+    public var sortField: SortField?
+    public var sortOrder: DataModel.SortOrder
+    public var filterRules: [FilterRule]
+    public var owner: Owner
+    public var permissions: Permissions?
+    public var setPermissions: Permissions?
+    public var userCanChange: Bool
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension SavedViewRecord: ElementRecord {
+  public static let databaseTableName = "saved_view"
+
+  public init(serverId: UUID, domain: SavedView) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      showOnDashboard: domain.showOnDashboard,
+      showInSidebar: domain.showInSidebar,
+      sortField: domain.sortField,
+      sortOrder: domain.sortOrder,
+      filterRules: domain.filterRules,
+      owner: domain.owner,
+      permissions: domain.permissions,
+      setPermissions: domain.setPermissions,
+      userCanChange: domain.userCanChange)
+  }
+
+  public var domain: SavedView {
+    SavedView(
+      id: id,
+      name: name,
+      showOnDashboard: payload.showOnDashboard,
+      showInSidebar: payload.showInSidebar,
+      sortField: payload.sortField,
+      sortOrder: payload.sortOrder,
+      filterRules: payload.filterRules,
+      owner: payload.owner,
+      permissions: payload.permissions,
+      setPermissions: payload.setPermissions,
+      userCanChange: payload.userCanChange)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/ServerConfigurationRecord.swift
+++ b/Persistence/Sources/Persistence/Models/ServerConfigurationRecord.swift
@@ -1,0 +1,41 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for the per-server `ServerConfiguration` singleton
+/// (`server_configuration` table, keyed by `server_id`).
+public struct ServerConfigurationRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var id: UInt
+    public var barcodeAsnPrefix: String?
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case payload = "data"
+  }
+}
+
+extension ServerConfigurationRecord: FetchableRecord, PersistableRecord, TableRecord {
+  public static let databaseTableName = "server_configuration"
+
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+
+  public init(serverId: UUID, domain: ServerConfiguration) {
+    self.serverId = serverId
+    payload = Payload(id: domain.id, barcodeAsnPrefix: domain.barcodeAsnPrefix)
+  }
+
+  public var domain: ServerConfiguration {
+    ServerConfiguration(id: payload.id, barcodeAsnPrefix: payload.barcodeAsnPrefix)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/StoragePathRecord.swift
+++ b/Persistence/Sources/Persistence/Models/StoragePathRecord.swift
@@ -1,0 +1,53 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `StoragePath` (`storage_path` table).
+public struct StoragePathRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var path: String
+    public var slug: String
+    public var matchingAlgorithm: MatchingAlgorithm
+    public var match: String
+    public var isInsensitive: Bool
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension StoragePathRecord: ElementRecord {
+  public static let databaseTableName = "storage_path"
+
+  public init(serverId: UUID, domain: StoragePath) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      path: domain.path,
+      slug: domain.slug,
+      matchingAlgorithm: domain.matchingAlgorithm,
+      match: domain.match,
+      isInsensitive: domain.isInsensitive)
+  }
+
+  public var domain: StoragePath {
+    StoragePath(
+      id: id,
+      name: name,
+      path: payload.path,
+      slug: payload.slug,
+      matchingAlgorithm: payload.matchingAlgorithm,
+      match: payload.match,
+      isInsensitive: payload.isInsensitive)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/TagRecord.swift
+++ b/Persistence/Sources/Persistence/Models/TagRecord.swift
@@ -1,0 +1,60 @@
+import Common
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `Tag` (`tag` table, keyed `(server_id, id)`).
+public struct TagRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var isInboxTag: Bool
+    public var slug: String
+    public var color: HexColor
+    public var match: String
+    public var matchingAlgorithm: MatchingAlgorithm
+    public var isInsensitive: Bool
+    public var parent: UInt?
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension TagRecord: ElementRecord {
+  public static let databaseTableName = "tag"
+
+  public init(serverId: UUID, domain: Tag) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload(
+      isInboxTag: domain.isInboxTag,
+      slug: domain.slug,
+      color: domain.color,
+      match: domain.match,
+      matchingAlgorithm: domain.matchingAlgorithm,
+      isInsensitive: domain.isInsensitive,
+      parent: domain.parent)
+  }
+
+  public var domain: Tag {
+    Tag(
+      id: id,
+      isInboxTag: payload.isInboxTag,
+      name: name,
+      slug: payload.slug,
+      color: payload.color,
+      match: payload.match,
+      matchingAlgorithm: payload.matchingAlgorithm,
+      isInsensitive: payload.isInsensitive,
+      parent: payload.parent)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
+++ b/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
@@ -1,0 +1,120 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for the per-server `UISettings` singleton (`ui_settings` table,
+/// keyed by `server_id`). Caching this keeps the current user, app settings and
+/// the permission matrix available offline — without it, an offline cold start
+/// would fall back to assuming full permissions.
+///
+/// None of `User`, `UISettingsSettings` or `UserPermissions` are `Codable`, so
+/// the payload mirrors their fields. The permission matrix is stored as
+/// `resource.rawValue → [view, add, change, delete]` (indexed by
+/// `Operation.rawValue`) and round-tripped through the public `test`/`set` API.
+public struct UISettingsRecord: Codable, Sendable {
+  public var serverId: UUID
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable {
+    public var user: UserData
+    public var settings: SettingsData
+    public var permissions: [String: [Bool]]
+
+    public struct UserData: Codable, Sendable {
+      public var id: UInt
+      public var isSuperUser: Bool
+      public var username: String
+      public var groups: [UInt]
+    }
+
+    public struct SettingsData: Codable, Sendable {
+      public var removeInboxTags: Bool
+      public var defaultOwner: UInt?
+      public var defaultViewUsers: [UInt]
+      public var defaultViewGroups: [UInt]
+      public var defaultEditUsers: [UInt]
+      public var defaultEditGroups: [UInt]
+      public var dashboardViewsVisibleIds: [UInt]
+      public var sidebarViewsVisibleIds: [UInt]
+      public var appTitle: String?
+    }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case payload = "data"
+  }
+}
+
+extension UISettingsRecord: FetchableRecord, PersistableRecord, TableRecord {
+  public static let databaseTableName = "ui_settings"
+
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+
+  public init(serverId: UUID, domain: UISettings) {
+    self.serverId = serverId
+
+    var permissions = [String: [Bool]]()
+    for resource in UserPermissions.Resource.allCases {
+      permissions[resource.rawValue] = UserPermissions.Operation.allCases.map {
+        domain.permissions.test($0, for: resource)
+      }
+    }
+
+    payload = Payload(
+      user: Payload.UserData(
+        id: domain.user.id,
+        isSuperUser: domain.user.isSuperUser,
+        username: domain.user.username,
+        groups: domain.user.groups),
+      settings: Payload.SettingsData(
+        removeInboxTags: domain.settings.documentEditing.removeInboxTags,
+        defaultOwner: domain.settings.permissions.defaultOwner,
+        defaultViewUsers: domain.settings.permissions.defaultViewUsers,
+        defaultViewGroups: domain.settings.permissions.defaultViewGroups,
+        defaultEditUsers: domain.settings.permissions.defaultEditUsers,
+        defaultEditGroups: domain.settings.permissions.defaultEditGroups,
+        dashboardViewsVisibleIds: domain.settings.savedViews.dashboardViewsVisibleIds,
+        sidebarViewsVisibleIds: domain.settings.savedViews.sidebarViewsVisibleIds,
+        appTitle: domain.settings.appTitle),
+      permissions: permissions)
+  }
+
+  public var domain: UISettings {
+    var permissions = UserPermissions.empty
+    for (rawResource, flags) in payload.permissions {
+      guard let resource = UserPermissions.Resource(rawValue: rawResource) else { continue }
+      for operation in UserPermissions.Operation.allCases where operation.rawValue < flags.count {
+        permissions.set(operation, to: flags[operation.rawValue], for: resource)
+      }
+    }
+
+    let user = User(
+      id: payload.user.id,
+      isSuperUser: payload.user.isSuperUser,
+      username: payload.user.username,
+      groups: payload.user.groups)
+
+    let settings = UISettingsSettings(
+      documentEditing: UISettingsDocumentEditing(
+        removeInboxTags: payload.settings.removeInboxTags),
+      permissions: UISettingsPermissions(
+        defaultOwner: payload.settings.defaultOwner,
+        defaultViewUsers: payload.settings.defaultViewUsers,
+        defaultViewGroups: payload.settings.defaultViewGroups,
+        defaultEditUsers: payload.settings.defaultEditUsers,
+        defaultEditGroups: payload.settings.defaultEditGroups),
+      savedViews: UISettingsSavedViews(
+        dashboardViewsVisibleIds: payload.settings.dashboardViewsVisibleIds,
+        sidebarViewsVisibleIds: payload.settings.sidebarViewsVisibleIds),
+      appTitle: payload.settings.appTitle)
+
+    return UISettings(user: user, settings: settings, permissions: permissions)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
+++ b/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
@@ -11,6 +11,12 @@ import GRDB
 /// the payload mirrors their fields. The permission matrix is stored as
 /// `resource.rawValue → [view, add, change, delete]` (indexed by
 /// `Operation.rawValue`) and round-tripped through the public `test`/`set` API.
+///
+/// The operation flags are positional, so a new `Operation` may only be
+/// appended: decoding bounds-checks the array and treats a missing trailing
+/// flag as `false`. Inserting one in the middle shifts every raw value and
+/// makes already-cached rows decode as the wrong permissions, which fails
+/// silently. Such a change needs a migration that clears `ui_settings`.
 public struct UISettingsRecord: Codable, Sendable {
   public var serverId: UUID
   public var payload: Payload

--- a/Persistence/Sources/Persistence/Models/UserGroupRecord.swift
+++ b/Persistence/Sources/Persistence/Models/UserGroupRecord.swift
@@ -1,0 +1,36 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `UserGroup` (`user_group` table). The group has no
+/// fields beyond `id`/`name`, so the `data` column carries an empty payload.
+public struct UserGroupRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {}
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension UserGroupRecord: ElementRecord {
+  public static let databaseTableName = "user_group"
+
+  public init(serverId: UUID, domain: UserGroup) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.name
+    payload = Payload()
+  }
+
+  public var domain: UserGroup {
+    UserGroup(id: id, name: name)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/UserRecord.swift
+++ b/Persistence/Sources/Persistence/Models/UserRecord.swift
@@ -1,0 +1,38 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a cached `User` (`user` table). `name` mirrors `username`.
+public struct UserRecord: Codable, Sendable, Equatable {
+  public var serverId: UUID
+  public var id: UInt
+  public var name: String
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var isSuperUser: Bool
+    public var groups: [UInt]
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case name
+    case payload = "data"
+  }
+}
+
+extension UserRecord: ElementRecord {
+  public static let databaseTableName = "user"
+
+  public init(serverId: UUID, domain: User) {
+    self.serverId = serverId
+    id = domain.id
+    name = domain.username
+    payload = Payload(isSuperUser: domain.isSuperUser, groups: domain.groups)
+  }
+
+  public var domain: User {
+    User(id: id, isSuperUser: payload.isSuperUser, username: name, groups: payload.groups)
+  }
+}

--- a/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
@@ -1,0 +1,199 @@
+import Common
+import DataModel
+import Foundation
+import GRDB
+import SwiftUI
+import Testing
+
+@testable import Persistence
+
+@Suite("ElementCache")
+struct ElementCacheTests {
+  // MARK: - Helpers
+
+  private func makeDatabase(server: UUID) throws -> Persistence.Database {
+    let database = try Persistence.Database.inMemory()
+    let record = ConnectionRecord(
+      id: server,
+      url: URL(string: "https://paperless.example.com/api/")!,
+      user: .init(id: 1, isSuperUser: true, username: "alice"))
+    try database.upsertConnection(record)
+    return database
+  }
+
+  private func tag(_ id: UInt, _ name: String) -> DataModel.Tag {
+    DataModel.Tag(
+      id: id, isInboxTag: false, name: name, slug: name.lowercased(),
+      color: Color(hex: "#3366cc")!.hex, match: "m", matchingAlgorithm: .auto,
+      isInsensitive: true, parent: nil)
+  }
+
+  // MARK: - Round-trip
+
+  @Test("multi-row records round-trip through replace + read")
+  func multiRowRoundtrip() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    let tags = [tag(1, "Alpha"), tag(2, "Beta")]
+    try database.replaceElements(tags, of: TagRecord.self, serverID: server)
+
+    let correspondents = [
+      Correspondent(
+        id: 5, documentCount: 3, lastCorrespondence: nil, name: "ACME",
+        slug: "acme", matchingAlgorithm: .literal, match: "x", isInsensitive: false)
+    ]
+    try database.replaceElements(
+      correspondents, of: CorrespondentRecord.self, serverID: server)
+
+    let customFields = [
+      CustomField(
+        id: 9, name: "Priority", dataType: .select,
+        extraData: .init(
+          selectOptions: [.init(id: "a", label: "High")], defaultCurrency: "EUR"),
+        documentCount: 2)
+    ]
+    try database.replaceElements(
+      customFields, of: CustomFieldRecord.self, serverID: server)
+
+    // Tag holds a SwiftUI.Color whose == is provider-identity based, and
+    // AppKit's Color→hex conversion drifts ±1 per round-trip on the host — both
+    // unrelated to storage. Compare the stable fields; the JSON-column path is
+    // proven by the other record types below.
+    let fetchedTags = try database.elements(TagRecord.self, serverID: server)
+    #expect(fetchedTags.map(\.id) == tags.map(\.id))
+    #expect(fetchedTags.map(\.name) == tags.map(\.name))
+    #expect(fetchedTags.map(\.slug) == tags.map(\.slug))
+    #expect(fetchedTags.map(\.matchingAlgorithm) == tags.map(\.matchingAlgorithm))
+
+    #expect(
+      try database.elements(CorrespondentRecord.self, serverID: server) == correspondents)
+    #expect(
+      try database.elements(CustomFieldRecord.self, serverID: server) == customFields)
+  }
+
+  @Test("saved view round-trips its filter rules and permissions")
+  func savedViewRoundtrip() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    let view = SavedView(
+      id: 3, name: "Inbox", showOnDashboard: true, showInSidebar: false,
+      sortField: .created, sortOrder: .descending,
+      filterRules: [FilterRule(ruleType: .title, value: .string(value: "invoice"))!],
+      owner: .user(1))
+    try database.replaceElements([view], of: SavedViewRecord.self, serverID: server)
+
+    let fetched = try database.elements(SavedViewRecord.self, serverID: server)
+    #expect(fetched == [view])
+  }
+
+  // MARK: - Reconcile
+
+  @Test("replaceElements drops rows absent from the new set")
+  func replaceDropsMissing() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    try database.replaceElements(
+      [tag(1, "A"), tag(2, "B"), tag(3, "C")], of: TagRecord.self, serverID: server)
+    try database.replaceElements(
+      [tag(1, "A"), tag(3, "C-renamed")], of: TagRecord.self, serverID: server)
+
+    let fetched = try database.elements(TagRecord.self, serverID: server)
+    #expect(fetched.map(\.id) == [1, 3])
+    #expect(fetched.first { $0.id == 3 }?.name == "C-renamed")
+  }
+
+  @Test("upsert and delete single element")
+  func upsertAndDelete() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    try database.upsertElement(tag(1, "One"), of: TagRecord.self, serverID: server)
+    try database.upsertElement(tag(1, "One-edit"), of: TagRecord.self, serverID: server)
+    #expect(try database.elements(TagRecord.self, serverID: server).first?.name == "One-edit")
+
+    try database.deleteElement(TagRecord.self, serverID: server, id: 1)
+    #expect(try database.elements(TagRecord.self, serverID: server).isEmpty)
+  }
+
+  // MARK: - Scoping & cascade
+
+  @Test("elements are scoped per server")
+  func perServerScoping() throws {
+    let serverA = UUID()
+    let database = try makeDatabase(server: serverA)
+    let serverB = UUID()
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverB, url: URL(string: "https://b.example.com/")!,
+        user: .init(id: 1, isSuperUser: false, username: "bob")))
+
+    try database.replaceElements([tag(1, "A")], of: TagRecord.self, serverID: serverA)
+    try database.replaceElements([tag(2, "B")], of: TagRecord.self, serverID: serverB)
+
+    #expect(try database.elements(TagRecord.self, serverID: serverA).map(\.id) == [1])
+    #expect(try database.elements(TagRecord.self, serverID: serverB).map(\.id) == [2])
+  }
+
+  @Test("deleting a server cascades to its element rows")
+  func cascadeOnServerDelete() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+    try database.replaceElements(
+      [tag(1, "A"), tag(2, "B")], of: TagRecord.self, serverID: server)
+
+    try database.deleteConnection(id: server)
+
+    #expect(try database.elements(TagRecord.self, serverID: server).isEmpty)
+  }
+
+  // MARK: - Singletons
+
+  @Test("server configuration singleton round-trips")
+  func serverConfigurationRoundtrip() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    #expect(try database.serverConfiguration(serverID: server) == nil)
+    let config = ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN")
+    try database.setServerConfiguration(config, serverID: server)
+
+    let fetched = try #require(try database.serverConfiguration(serverID: server))
+    #expect(fetched.id == 1)
+    #expect(fetched.barcodeAsnPrefix == "ASN")
+  }
+
+  @Test("ui settings singleton round-trips user, settings and permissions")
+  func uiSettingsRoundtrip() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    let permissions = UserPermissions.empty(with: {
+      $0.set(.view, to: true, for: .document)
+      $0.set(.change, to: true, for: .document)
+      $0.set(.view, to: true, for: .tag)
+    })
+    let settings = UISettingsSettings(
+      documentEditing: .init(removeInboxTags: true),
+      permissions: .init(defaultOwner: 1, defaultViewUsers: [2, 3]),
+      savedViews: .init(dashboardViewsVisibleIds: [9]),
+      appTitle: "My Paperless")
+    let uiSettings = UISettings(
+      user: User(id: 1, isSuperUser: false, username: "alice", groups: [7]),
+      settings: settings,
+      permissions: permissions)
+
+    try database.setUISettings(uiSettings, serverID: server)
+    let fetched = try #require(try database.uiSettings(serverID: server))
+
+    #expect(fetched.user == uiSettings.user)
+    #expect(fetched.settings == settings)
+    #expect(fetched.permissions.test(.view, for: .document))
+    #expect(fetched.permissions.test(.change, for: .document))
+    #expect(fetched.permissions.test(.view, for: .tag))
+    #expect(!fetched.permissions.test(.delete, for: .document))
+    #expect(!fetched.permissions.test(.view, for: .correspondent))
+  }
+}

--- a/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
@@ -105,6 +105,22 @@ struct ElementCacheTests {
     #expect(fetched.first { $0.id == 3 }?.name == "C-renamed")
   }
 
+  @Test("replaceElements tolerates the same element twice in one batch")
+  func replaceTolerScopesDuplicates() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+
+    // A paginated fetch can yield one element on two consecutive pages when the
+    // server deletes a row in between, shifting later elements back a page.
+    // `insert` raised a primary-key violation there and rolled the whole
+    // reconcile back, losing every other element in the batch.
+    let duplicated = [tag(1, "A"), tag(2, "B"), tag(2, "B"), tag(3, "C")]
+    try database.replaceElements(duplicated, of: TagRecord.self, serverID: server)
+
+    let fetched = try database.elements(TagRecord.self, serverID: server)
+    #expect(fetched.map(\.id) == [1, 2, 3])
+  }
+
   @Test("upsert and delete single element")
   func upsertAndDelete() throws {
     let server = UUID()

--- a/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
@@ -28,6 +28,49 @@ struct ElementCacheTests {
       isInsensitive: true, parent: nil)
   }
 
+  // MARK: - Indexing
+
+  @Test("every multi-row element table is indexed on (server_id, name)")
+  func elementTablesAreIndexedOnServerAndName() throws {
+    let database = try makeDatabase(server: UUID())
+
+    try database.writer.read { db in
+      for table in V3_CreateElementCache.multiRowTables {
+        let columns = try db.indexes(on: table)
+          .first { $0.name == "index_\(table)_on_server_id_name" }?
+          .columns
+        #expect(columns == ["server_id", "name"], "missing or wrong index on \(table)")
+      }
+    }
+  }
+
+  @Test("the name-ordered collection read sorts via the index, not a temp b-tree")
+  func orderedReadUsesTheIndex() throws {
+    let server = UUID()
+    let database = try makeDatabase(server: server)
+    try database.replaceElements(
+      [tag(1, "B"), tag(2, "A")], of: TagRecord.self, serverID: server)
+
+    let plan = try database.writer.read { db in
+      try String.fetchAll(
+        db,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM tag WHERE server_id = ? ORDER BY name
+          """,
+        arguments: [server],
+        adapter: ColumnMapping(["column": "detail"]))
+    }
+
+    // A temp b-tree here would mean the rows were scanned and then sorted.
+    #expect(
+      !plan.contains { $0.uppercased().contains("USE TEMP B-TREE") },
+      "ordered read fell back to a sort: \(plan)")
+    #expect(
+      plan.contains { $0.contains("index_tag_on_server_id_name") },
+      "ordered read did not use the index: \(plan)")
+  }
+
   // MARK: - Round-trip
 
   @Test("multi-row records round-trip through replace + read")

--- a/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
@@ -1,0 +1,157 @@
+import DataModel
+import Foundation
+import Testing
+
+@testable import Persistence
+
+@Suite("ElementObservation")
+struct ElementObservationTests {
+  // MARK: - Helpers
+
+  private struct TimeoutError: Error {}
+
+  /// First emission of a stream, with a timeout so a missing/never-firing
+  /// observation fails the test instead of hanging.
+  private func firstValue<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
+  /// The emission that lands *after* `action` runs. Consumes the initial value
+  /// first (which also guarantees the observation is subscribed before the
+  /// write), runs `action`, then returns the next emission.
+  private func value<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>,
+    afterSubscribe action: @escaping @Sendable () async throws -> Void
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      _ = try await iterator.next()
+      try await action()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
+  private func withTimeout<T: Sendable>(
+    seconds: Double = 3,
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+      group.addTask { try await operation() }
+      group.addTask {
+        try await Task.sleep(for: .seconds(seconds))
+        throw TimeoutError()
+      }
+      let result = try await group.next()!
+      group.cancelAll()
+      return result
+    }
+  }
+
+  private func correspondent(_ id: UInt, _ name: String) -> Correspondent {
+    Correspondent(
+      id: id, documentCount: 0, lastCorrespondence: nil, name: name,
+      slug: name.lowercased(), matchingAlgorithm: .auto, match: "", isInsensitive: true)
+  }
+
+  // MARK: - Tests
+
+  @Test("observeElements emits the current state on subscribe, name-ordered")
+  func emitsInitialState() async throws {
+    let server = UUID()
+    let database = try Database.seeded(
+      serverID: server, correspondents: [correspondent(2, "Beta"), correspondent(1, "Alpha")])
+
+    let initial = try await firstValue(
+      from: database.observeElements(CorrespondentRecord.self, serverID: server))
+    #expect(initial.map(\.name) == ["Alpha", "Beta"])
+  }
+
+  @Test("observeElements re-emits after an upsert write-through")
+  func emitsAfterUpsert() async throws {
+    let server = UUID()
+    let database = try Database.seeded(
+      serverID: server, correspondents: [correspondent(1, "Alpha")])
+
+    let updated = try await value(
+      from: database.observeElements(CorrespondentRecord.self, serverID: server)
+    ) {
+      try database.upsertElement(
+        self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: server)
+    }
+    #expect(updated.map(\.id) == [1, 2])
+  }
+
+  @Test("observeElements re-emits after a delete")
+  func emitsAfterDelete() async throws {
+    let server = UUID()
+    let database = try Database.seeded(
+      serverID: server, correspondents: [correspondent(1, "Alpha"), correspondent(2, "Beta")])
+
+    let remaining = try await value(
+      from: database.observeElements(CorrespondentRecord.self, serverID: server)
+    ) {
+      try database.deleteElement(CorrespondentRecord.self, serverID: server, id: 1)
+    }
+    #expect(remaining.map(\.id) == [2])
+  }
+
+  @Test("observeUISettings emits nil cold, then the value after setUISettings")
+  func uiSettingsColdThenSet() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+
+    let cold = try await firstValue(from: database.observeUISettings(serverID: server))
+    #expect(cold == nil)
+
+    let settings = UISettings(
+      user: User(id: 7, isSuperUser: false, username: "alice", groups: []),
+      settings: UISettingsSettings(),
+      permissions: .empty)
+    let resolved = try await value(from: database.observeUISettings(serverID: server)) {
+      try database.setUISettings(settings, serverID: server)
+    }
+    #expect(resolved?.user.id == 7)
+    #expect(resolved?.user.username == "alice")
+  }
+
+  @Test("observeServerConfiguration emits nil cold, then the value after set")
+  func serverConfigurationColdThenSet() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+
+    let cold = try await firstValue(from: database.observeServerConfiguration(serverID: server))
+    #expect(cold == nil)
+
+    let resolved = try await value(
+      from: database.observeServerConfiguration(serverID: server)
+    ) {
+      try database.setServerConfiguration(
+        ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN"), serverID: server)
+    }
+    #expect(resolved?.barcodeAsnPrefix == "ASN")
+  }
+
+  @Test("observeElements is scoped to its server")
+  func scopedPerServer() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, correspondents: [correspondent(1, "A")])
+    let serverB = UUID()
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverB, url: URL(string: "https://b.example.com/")!,
+        user: .init(id: 1, isSuperUser: false, username: "bob")))
+    try database.replaceElements(
+      [correspondent(2, "B")], of: CorrespondentRecord.self, serverID: serverB)
+
+    let aOnly = try await firstValue(
+      from: database.observeElements(CorrespondentRecord.self, serverID: serverA))
+    #expect(aOnly.map(\.id) == [1])
+  }
+}

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -21,9 +21,17 @@ struct SettingsView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
+  /// Threaded down to ``ConnectionsView`` so it can rebuild the full caching
+  /// repository stack when the active connection's extra headers change.
+  private let database: Database
+
   @State private var feedbackMailRequest: FeedbackMailRequest?
   @State private var showLoginSheet: Bool = false
   @State var identityManager = IdentityManager()
+
+  init(database: Database) {
+    self.database = database
+  }
 
   private func checked(_ fn: @escaping () async throws -> Void) async {
     do {
@@ -229,6 +237,7 @@ struct SettingsView: View {
       Form {
         ConnectionsView(
           connectionManager: connectionManager,
+          database: database,
           showLoginSheet: $showLoginSheet)
 
         Section(String(localized: .settings(.preferences))) {
@@ -291,13 +300,14 @@ struct SettingsView: View {
 #Preview("SettingsView") {
   @Previewable @State var store = DocumentStore(repository: PreviewRepository())
   @Previewable @StateObject var errorController = ErrorController()
+  @Previewable @State var database = try! Database.inMemory()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   VStack {
   }
   .sheet(isPresented: .constant(true)) {
-    SettingsView()
+    SettingsView(database: database)
       .environment(store)
       .environment(connectionManager)
   }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -24,6 +24,9 @@ struct MainView: View {
 
   @State private var manager: ConnectionManager
 
+  // Shared GRDB database, threaded into each connection's CachingRepository.
+  private let database: Database
+
   @State private var friendlyNameTask: Task<Void, Never>?
 
   @StateObject private var errorController: ErrorController
@@ -44,6 +47,7 @@ struct MainView: View {
 
   init(database: Database) {
     _ = AppSettings.shared
+    self.database = database
     _manager = State(wrappedValue: ConnectionManager(database: database))
     let errorController = ErrorController()
     let networkMonitor = NetworkMonitor()
@@ -154,8 +158,12 @@ struct MainView: View {
 
       Logger.api.info("Valid connection from connection manager: \(String(describing: conn))")
       let api = await ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode)
-      let repository = NeedsAuthRepository(
+      let needsAuth = NeedsAuthRepository(
         wrapping: api, serverID: conn.serverID, connectionManager: manager)
+      // Caching outermost: reads come from the GRDB cache, while sync's network
+      // calls still flow through the needs-auth 401 interception.
+      let repository = CachingRepository(
+        wrapping: needsAuth, database: database, serverID: conn.serverID)
       if let store {
         await sleep(.seconds(0.1))
         store.events.emit(.repositoryWillChange)
@@ -337,6 +345,12 @@ struct MainView: View {
         store?.startTaskPolling()
 
         Logger.shared.notice("App becomes active")
+
+        // Cache-first: foreground refresh syncs the element cache silently.
+        // The initial launch sync is handled by refreshConnection.
+        if !initialDisplay, let store {
+          Task { try? await store.sync() }
+        }
 
         Task { await biometricLockManager.unlockIfEnabled() }
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -301,7 +301,7 @@ struct MainView: View {
 
     .sheet(isPresented: $showSettings) {
       if let store {
-        SettingsView()
+        SettingsView(database: database)
           .environment(manager)
           .environment(store)
           .environmentObject(errorController)


### PR DESCRIPTION
This pull request refactors the `DocumentStore` to centralize and modernize state management by introducing a reactive `ElementStore` projection, simplifying element refresh and CRUD logic, and removing legacy manual cache management. The changes make the store more robust, less error-prone, and easier to maintain by ensuring all element collections are live, read-only projections of the database, and that all updates flow through the repository and observation layer.

**State management modernization:**

* Introduced a new `elementStore` property, which holds a live, reactive projection of all element collections (such as `tags`, `correspondents`, `users`, etc.), replacing the previous manual dictionaries and singletons. All read access to these collections now goes through computed properties that delegate to `elementStore`, ensuring reactivity and consistency. (`DocumentStore.swift`, [AppShared/Sources/AppShared/Document/DocumentStore.swiftL24-R59](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L24-R59))
* Added the `wireElementStore()` method to point the projection at the active repository's database, automatically rewiring on repository changes. (`DocumentStore.swift`, [AppShared/Sources/AppShared/Document/DocumentStore.swiftR93-R111](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R93-R111))
* Removed manual cache clearing and updating logic for element collections; the observation layer now handles all updates and invalidations. (`DocumentStore.swift`, [AppShared/Sources/AppShared/Document/DocumentStore.swiftL129-R168](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L129-R168))

**Element refresh and sync simplification:**

* Replaced all individual `fetchAll*` methods (such as `fetchAllTags`, `fetchAllCorrespondents`, etc.) with a unified `sync(userInitiated:)` method that syncs all elements into the local database, letting the observation repaint the projections. On-demand refreshers now just call `sync`. (`DocumentStore.swift`, [AppShared/Sources/AppShared/Document/DocumentStore.swiftL259-L570](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L259-L570))
* Updated the main `fetchAll()` method to simply trigger a full sync, removing the old concurrent, multi-method fetching logic. (`DocumentStore.swift`, [AppShared/Sources/AppShared/Document/DocumentStore.swiftL259-L570](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L259-L570))

**CRUD operation streamlining:**

* Simplified all create, update, and delete methods for elements (e.g., tags, correspondents, document types, saved views, storage paths) to remove manual cache mutation. Instead, the repository write-throughs to the DB, and the observation layer updates the projections. (`DocumentStore.swift`, [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L259-L570) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L579-L602) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L647-L679)
* Updated settings mutation logic to work on local copies and write through the repository, since `settings` is now a read-only projection. (`DocumentStore.swift`, [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R459-L622) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L632-R483)

These changes collectively move the codebase to a source-of-truth model with reactive state, reducing the risk of stale or inconsistent UI and making the code easier to reason about and extend.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)  👈
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->
