### PR TITLE
feat: Element (attribute) cache is source-of-truth

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -1,0 +1,53 @@
+//
+//  DocumentStore+Preview.swift
+//  AppShared
+//
+//  Preview/test convenience for building a `DocumentStore` under the
+//  source-of-truth model, where every repository must front a DB for the
+//  element projection to see anything.
+//
+
+import Foundation
+import Networking
+import Persistence
+
+extension DocumentStore {
+  /// A store backed by an in-memory seeded DB, wrapping `wrapped` in a
+  /// `CachingRepository` so the live `ElementStore` projection and the
+  /// write-through mutations behave exactly as in production.
+  ///
+  /// The wrapped repository's element data is copied into the DB by a one-shot
+  /// `fetchAll()` (previews are live, so it lands a beat after first render);
+  /// `PreviewRepository`'s built-in fixtures appear this way. Previews using a
+  /// `TransientRepository` seed through `store.repository` (writes flow to the
+  /// DB) and recover the underlying repository for its non-`Repository` helpers
+  /// via ``previewRepository(as:)``.
+  @MainActor
+  public static func preview(_ wrapped: some Repository = PreviewRepository()) -> DocumentStore {
+    let serverID = UUID()
+    let database: Database
+    do {
+      database = try Database.seeded(serverID: serverID)
+    } catch {
+      // The in-memory seed (DatabaseQueue + migrations) is infallible in
+      // practice; a preview crash here is loud and immediately actionable.
+      preconditionFailure("Preview database seed failed: \(error)")
+    }
+    let caching = CachingRepository(wrapping: wrapped, database: database, serverID: serverID)
+    let store = DocumentStore(repository: caching)
+    Task { try? await store.fetchAll() }
+    return store
+  }
+
+  /// Recover the underlying repository from a store built by ``preview(_:)`` —
+  /// for previews that need a concrete repository's preview-only helpers (e.g.
+  /// `TransientRepository.addUser`/`login`/`allDocuments`). The protocol
+  /// surface should be used through `store.repository` so writes reach the DB.
+  @MainActor
+  public func previewRepository<R: Repository>(as type: R.Type) -> R {
+    guard let caching = repository as? CachingRepository<R> else {
+      preconditionFailure("previewRepository(as:) called on a store not built by preview(_:)")
+    }
+    return caching.wrapped
+  }
+}

--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -17,7 +17,7 @@ extension DocumentStore {
   /// write-through mutations behave exactly as in production.
   ///
   /// The wrapped repository's element data is copied into the DB by a one-shot
-  /// `fetchAll()` (previews are live, so it lands a beat after first render);
+  /// `sync()` (previews are live, so it lands a beat after first render);
   /// `PreviewRepository`'s built-in fixtures appear this way. Previews using a
   /// `TransientRepository` seed through `store.repository` (writes flow to the
   /// DB) and recover the underlying repository for its non-`Repository` helpers
@@ -35,7 +35,7 @@ extension DocumentStore {
     }
     let caching = CachingRepository(wrapping: wrapped, database: database, serverID: serverID)
     let store = DocumentStore(repository: caching)
-    Task { try? await store.fetchAll() }
+    Task { try? await store.sync() }
     return store
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -7,6 +7,7 @@
 //  element projection to see anything.
 //
 
+import DataModel
 import Foundation
 import Networking
 import Persistence
@@ -22,12 +23,25 @@ extension DocumentStore {
   /// `TransientRepository` seed through `store.repository` (writes flow to the
   /// DB) and recover the underlying repository for its non-`Repository` helpers
   /// via ``previewRepository(as:)``.
+  ///
+  /// The `ui_settings` singleton is seeded with a full permission matrix rather
+  /// than left to that sync: every store mutation is permission-checked, and the
+  /// sync cannot be what supplies the matrix. It is fire-and-forget, and for a
+  /// `TransientRepository` it fails outright — `uiSettings()` rethrows
+  /// `noUserLoggedIn` until the preview logs a user in from its own `.task`,
+  /// which happens after this sync has already run and found no cached row to
+  /// fall back to. A preview that seeds through `store.create(…)` would lose
+  /// every element to `PermissionsError`. The matrix is applied synchronously so
+  /// it holds from the first render, not a runloop hop later; a later sync
+  /// overwrites it with the repository's own settings.
   @MainActor
   public static func preview(_ wrapped: some Repository = PreviewRepository()) -> DocumentStore {
     let serverID = UUID()
     let database: Database
     do {
-      database = try Database.seeded(serverID: serverID)
+      database = try Database.seeded(
+        serverID: serverID,
+        uiSettings: UISettings(user: previewUser, permissions: .full))
     } catch {
       // The in-memory seed (DatabaseQueue + migrations) is infallible in
       // practice; a preview crash here is loud and immediately actionable.
@@ -35,9 +49,14 @@ extension DocumentStore {
     }
     let caching = CachingRepository(wrapping: wrapped, database: database, serverID: serverID)
     let store = DocumentStore(repository: caching)
+    store.elementStore.refreshUISettings(from: database, serverID: serverID)
     Task { try? await store.sync() }
     return store
   }
+
+  /// Stands in for `ui_settings.user` until a sync supplies the real one. Matches
+  /// the user `Database.seeded` puts on the preview connection record.
+  private static let previewUser = User(id: 1, isSuperUser: true, username: "preview")
 
   /// Recover the underlying repository from a store built by ``preview(_:)`` —
   /// for previews that need a concrete repository's preview-only helpers (e.g.

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -298,16 +298,6 @@ public final class DocumentStore: Sendable {
     await fetchTasks()
   }
 
-  // On-demand element refreshers kept for their external callers. Under the
-  // source-of-truth model "refresh collection X" means "sync into the DB"; the
-  // live observation then repaints the projection. `syncElements` reconciles
-  // every collection at once, so these all delegate to it. They are automatic
-  // on-appear refreshers, not user gestures, so `userInitiated: false` — a
-  // failure fails soft (cached data stays on screen) rather than toasting.
-  public func fetchAllUsers() async throws { try await sync() }
-  public func fetchAllGroups() async throws { try await sync() }
-  public func fetchAllCustomFields() async throws { try await sync() }
-
   /// Refresh `ui_settings` (permissions/settings) from the network, then
   /// synchronously pull the singleton into the projection — the one path
   /// (`DocumentListViewModel.load`) that reads `permissions` immediately

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -87,7 +87,7 @@ public final class DocumentStore: Sendable {
 
   // The in-flight element sync, if any. Concurrent `sync` callers join this one
   // task instead of each firing their own `syncElements` (the launch flurry of
-  // fetchAll / fetchUISettings / scenePhase triggers shares a single network
+  // sync / fetchUISettings / scenePhase triggers shares a single network
   // pass). Only ever touched on the main actor.
   @ObservationIgnored
   private var syncTask: Task<Void, Error>?
@@ -317,7 +317,8 @@ public final class DocumentStore: Sendable {
   /// `userInitiated` policy to the shared outcome — automatic syncs fail soft
   /// into `lastSyncError`, user-initiated syncs rethrow so the caller can
   /// surface the failure (toast). So a user-initiated call joining a background
-  /// sync still sees the error.
+  /// sync still sees the error. This is what entry views call eagerly on
+  /// appear, and what pull-to-refresh calls with `userInitiated: true`.
   public func sync(userInitiated: Bool = false) async throws {
     Logger.shared.notice("Sync store (userInitiated: \(userInitiated))")
     do {
@@ -361,16 +362,6 @@ public final class DocumentStore: Sendable {
       isRefreshing = false
     }
     try await task.value
-  }
-
-  /// The eager entry views call. Triggers a network → DB sync; the element
-  /// projection repaints from the live observation. `userInitiated` forwards to
-  /// `sync`: pass `true` for explicit refreshes (pull-to-refresh) so failures
-  /// rethrow and the caller can surface them; automatic triggers (launch,
-  /// foreground) leave it `false` to fail soft into `lastSyncError`.
-  public func fetchAll(userInitiated: Bool = false) async throws {
-    Logger.shared.notice("Fetch all store request (userInitiated: \(userInitiated))")
-    try await sync(userInitiated: userInitiated)
   }
 
   public func document(id: UInt) async throws -> Document? {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -233,50 +233,54 @@ public final class DocumentStore: Sendable {
 
   public func updateDocument(_ document: Document) async throws -> Document {
     Logger.shared.info("Updating document with ID \(document.id, privacy: .public)")
-    try checkPermission(.change, for: .document)
-    events.emit(.changed(document: document))
+    return try await performing(.change, on: .document) {
+      events.emit(.changed(document: document))
 
-    var document = document
+      var document = document
 
-    if settings.documentEditing.removeInboxTags {
-      Logger.shared.debug("Removing inbox tags from document as per setting")
-      let inboxTags = tags.values.filter(\.isInboxTag)
-      for tag in inboxTags {
-        document.tags.removeAll(where: { $0 == tag.id })
+      if settings.documentEditing.removeInboxTags {
+        Logger.shared.debug("Removing inbox tags from document as per setting")
+        let inboxTags = tags.values.filter(\.isInboxTag)
+        for tag in inboxTags {
+          document.tags.removeAll(where: { $0 == tag.id })
+        }
       }
-    }
 
-    let updated = try await repository.update(document: document)
-    documents[updated.id] = updated
-    events.emit(.changeReceived(document: updated))
-    return updated
+      let updated = try await repository.update(document: document)
+      documents[updated.id] = updated
+      events.emit(.changeReceived(document: updated))
+      return updated
+    }
   }
 
   public func deleteDocument(_ document: Document) async throws {
     Logger.shared.info("Deleting document with ID \(document.id, privacy: .public)")
-    try checkPermission(.delete, for: .document)
-    try await repository.delete(document: document)
-    documents.removeValue(forKey: document.id)
-    events.emit(.deleted(document: document))
+    try await performing(.delete, on: .document) {
+      try await repository.delete(document: document)
+      documents.removeValue(forKey: document.id)
+      events.emit(.deleted(document: document))
+    }
   }
 
   public func deleteNote(from document: Document, id: UInt) async throws {
     Logger.shared.info("Deleting note with ID \(id, privacy: .public)")
-    try checkPermission(.delete, for: .note)
-    events.emit(.changed(document: document))
-    _ = try await repository.deleteNote(id: id, documentId: document.id)
+    try await performing(.delete, on: .note) {
+      events.emit(.changed(document: document))
+      _ = try await repository.deleteNote(id: id, documentId: document.id)
 
-    events.emit(.changeReceived(document: document))
+      events.emit(.changeReceived(document: document))
+    }
   }
 
   public func addNote(to document: Document, note: ProtoDocument.Note) async throws {
     Logger.shared.info("Adding note to document \(document.id, privacy: .public)")
-    try checkPermission(.add, for: .note)
-    events.emit(.changed(document: document))
+    try await performing(.add, on: .note) {
+      events.emit(.changed(document: document))
 
-    _ = try await repository.createNote(documentId: document.id, note: note)
+      _ = try await repository.createNote(documentId: document.id, note: note)
 
-    events.emit(.changeReceived(document: document))
+      events.emit(.changeReceived(document: document))
+    }
   }
 
   public func notes(for document: Document) async throws -> [Document.Note] {
@@ -394,13 +398,14 @@ public final class DocumentStore: Sendable {
     method: (E) async throws -> R
   ) async throws -> R
   where E: Sendable & PermissionsModel, R: Identifiable & Sendable {
-    try checkPermission(.add, for: resource)
-    // `settings` is kept live by the element observation, so its permission
-    // defaults are already current — apply them directly. The repository
-    // write-throughs the created element to the DB; the observation repaints it
-    // into the projection.
-    let updated = settings.permissions.appliedAsDefaults(to: element)
-    return try await method(updated)
+    try await performing(.add, on: resource) {
+      // `settings` is kept live by the element observation, so its permission
+      // defaults are already current — apply them directly. The repository
+      // write-throughs the created element to the DB; the observation repaints
+      // it into the projection.
+      let updated = settings.permissions.appliedAsDefaults(to: element)
+      return try await method(updated)
+    }
   }
 
   private func update<E>(
@@ -408,8 +413,9 @@ public final class DocumentStore: Sendable {
     resource: UserPermissions.Resource,
     method: (E) async throws -> E
   ) async throws where E: Identifiable & Sendable {
-    try checkPermission(.change, for: resource)
-    _ = try await method(element)
+    try await performing(.change, on: resource) {
+      _ = try await method(element)
+    }
   }
 
   private func delete<E>(
@@ -417,16 +423,17 @@ public final class DocumentStore: Sendable {
     resource: UserPermissions.Resource,
     method: (E) async throws -> Void
   ) async throws where E: Identifiable & Sendable {
-    try checkPermission(.delete, for: resource)
-    do {
-      try await method(element)
-    } catch let RequestError.unexpectedStatusCode(code: code, _) where code == .notFound {
-      let id = "\(element.id)"
-      Logger.api.debug(
-        "Element with ID \(id) not found (probably already deleted)")
+    try await performing(.delete, on: resource) {
+      do {
+        try await method(element)
+      } catch let RequestError.unexpectedStatusCode(code: code, _) where code == .notFound {
+        let id = "\(element.id)"
+        Logger.api.debug(
+          "Element with ID \(id) not found (probably already deleted)")
+      }
+      // The repository write-throughs the delete to the DB; the observation
+      // removes it from the projection.
     }
-    // The repository write-throughs the delete to the DB; the observation
-    // removes it from the projection.
   }
 
   public func create(tag: ProtoTag) async throws -> Tag {
@@ -588,6 +595,27 @@ public final class DocumentStore: Sendable {
       storagePath,
       resource: .storagePath,
       method: repository.delete(storagePath:))
+  }
+
+  /// Runs `body` behind its permission check and gives whatever comes back the
+  /// operation context the user needs. The local permission matrix and the
+  /// server can disagree (object-level permissions aren't in the matrix, and it
+  /// can be stale), so a refusal arrives either as our own check failing or as a
+  /// 403 from the request — both surface as a `PermissionsError` that names the
+  /// operation that was attempted rather than a bare "request was denied".
+  private func performing<T>(
+    _ operation: UserPermissions.Operation, on resource: UserPermissions.Resource,
+    _ body: () async throws -> T
+  ) async throws -> T {
+    try checkPermission(operation, for: resource)
+    do {
+      return try await body()
+    } catch let RequestError.forbidden(detail) {
+      Logger.api.debug(
+        "Server refused \(operation.description, privacy: .public) on \(resource.rawValue, privacy: .public)"
+      )
+      throw PermissionsError(resource: resource, operation: operation, detail: detail)
+    }
   }
 
   private func checkPermission(

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -330,10 +330,13 @@ public final class DocumentStore: Sendable {
   }
 
   /// The eager entry views call. Triggers a network → DB sync; the element
-  /// projection repaints from the live observation.
-  public func fetchAll() async throws {
-    Logger.shared.notice("Fetch all store request")
-    try await sync()
+  /// projection repaints from the live observation. `userInitiated` forwards to
+  /// `sync`: pass `true` for explicit refreshes (pull-to-refresh) so failures
+  /// rethrow and the caller can surface them; automatic triggers (launch,
+  /// foreground) leave it `false` to fail soft into `lastSyncError`.
+  public func fetchAll(userInitiated: Bool = false) async throws {
+    Logger.shared.notice("Fetch all store request (userInitiated: \(userInitiated))")
+    try await sync(userInitiated: userInitiated)
   }
 
   public func document(id: UInt) async throws -> Document? {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -170,6 +170,18 @@ public final class DocumentStore: Sendable {
   }
 
   public func set(repository: some Repository, reload: Bool = true) {
+    // A repository that doesn't front the DB detaches the element projection
+    // (see `wireElementStore()`), which blanks every element read site until the
+    // next relaunch. That is legitimate before login, but only via `init` —
+    // anything *replacing* a live repository is expected to assemble a caching
+    // stack, so a bare one here is a caller bug. Be loud instead of silently
+    // emptying the UI: this exact mistake shipped once already, from
+    // `ConnectionsView.updateExtraHeaders`.
+    if !(repository is any CachingBackend) {
+      Logger.shared.fault(
+        "Installing non-caching repository \(String(describing: type(of: repository)), privacy: .public) on a live store; element projection will stay detached until relaunch"
+      )
+    }
     self.repository = repository
     imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
     wireElementStore()

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -343,9 +343,11 @@ public final class DocumentStore: Sendable {
 
   private func create<E, R>(
     _: R.Type, from element: E,
+    resource: UserPermissions.Resource,
     method: (E) async throws -> R
   ) async throws -> R
   where E: Sendable & PermissionsModel, R: Identifiable & Sendable {
+    try checkPermission(.add, for: resource)
     // `settings` is kept live by the element observation, so its permission
     // defaults are already current — apply them directly. The repository
     // write-throughs the created element to the DB; the observation repaints it
@@ -356,15 +358,19 @@ public final class DocumentStore: Sendable {
 
   private func update<E>(
     _ element: E,
+    resource: UserPermissions.Resource,
     method: (E) async throws -> E
   ) async throws where E: Identifiable & Sendable {
+    try checkPermission(.change, for: resource)
     _ = try await method(element)
   }
 
   private func delete<E>(
     _ element: E,
+    resource: UserPermissions.Resource,
     method: (E) async throws -> Void
   ) async throws where E: Identifiable & Sendable {
+    try checkPermission(.delete, for: resource)
     do {
       try await method(element)
     } catch let RequestError.unexpectedStatusCode(code: code, _) where code == .notFound {
@@ -381,17 +387,18 @@ public final class DocumentStore: Sendable {
     return try await create(
       Tag.self,
       from: tag,
+      resource: .tag,
       method: repository.create(tag:))
   }
 
   public func update(tag: Tag) async throws {
     Logger.api.info("Updating tag with ID \(tag.id)")
-    return try await update(tag, method: repository.update(tag:))
+    return try await update(tag, resource: .tag, method: repository.update(tag:))
   }
 
   public func delete(tag: Tag) async throws {
     Logger.api.info("Deleting tag with ID \(tag.id)")
-    return try await delete(tag, method: repository.delete(tag:))
+    return try await delete(tag, resource: .tag, method: repository.delete(tag:))
   }
 
   public func create(correspondent: ProtoCorrespondent) async throws -> Correspondent {
@@ -399,6 +406,7 @@ public final class DocumentStore: Sendable {
     return try await create(
       Correspondent.self,
       from: correspondent,
+      resource: .correspondent,
       method: repository.create(correspondent:))
   }
 
@@ -406,6 +414,7 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating correspondent with ID \(correspondent.id)")
     return try await update(
       correspondent,
+      resource: .correspondent,
       method: repository.update(correspondent:))
   }
 
@@ -413,6 +422,7 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting correspondent with ID \(correspondent.id)")
     return try await delete(
       correspondent,
+      resource: .correspondent,
       method: repository.delete(correspondent:))
   }
 
@@ -421,6 +431,7 @@ public final class DocumentStore: Sendable {
     return try await create(
       DocumentType.self,
       from: documentType,
+      resource: .documentType,
       method: repository.create(documentType:))
   }
 
@@ -428,6 +439,7 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating document type with ID \(documentType.id)")
     return try await update(
       documentType,
+      resource: .documentType,
       method: repository.update(documentType:))
   }
 
@@ -435,11 +447,13 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting document type with ID \(documentType.id)")
     return try await delete(
       documentType,
+      resource: .documentType,
       method: repository.delete(documentType:))
   }
 
   public func create(savedView: ProtoSavedView) async throws -> SavedView {
     Logger.api.info("Creating saved view with name \(savedView.name)")
+    try checkPermission(.add, for: .savedView)
     let created = try await repository.create(savedView: savedView)
 
     try await handleSavedViewVisibility(created)
@@ -492,6 +506,7 @@ public final class DocumentStore: Sendable {
 
   public func update(savedView: SavedView) async throws {
     Logger.api.info("Updating saved view with ID \(savedView.id)")
+    try checkPermission(.change, for: .savedView)
     _ = try await repository.update(savedView: savedView)
 
     try await handleSavedViewVisibility(savedView)
@@ -499,6 +514,7 @@ public final class DocumentStore: Sendable {
 
   public func delete(savedView: SavedView) async throws {
     Logger.api.info("Deleting saved view with ID \(savedView.id)")
+    try checkPermission(.delete, for: .savedView)
     try await repository.delete(savedView: savedView)
   }
 
@@ -507,6 +523,7 @@ public final class DocumentStore: Sendable {
     return try await create(
       StoragePath.self,
       from: storagePath,
+      resource: .storagePath,
       method: repository.create(storagePath:))
   }
 
@@ -514,6 +531,7 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Updating storage path with ID \(storagePath.id)")
     try await update(
       storagePath,
+      resource: .storagePath,
       method: repository.update(storagePath:))
   }
 
@@ -521,6 +539,7 @@ public final class DocumentStore: Sendable {
     Logger.api.info("Deleting storage path with ID \(storagePath.id)")
     try await delete(
       storagePath,
+      resource: .storagePath,
       method: repository.delete(storagePath:))
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -182,6 +182,13 @@ public final class DocumentStore: Sendable {
         "Installing non-caching repository \(String(describing: type(of: repository)), privacy: .public) on a live store; element projection will stay detached until relaunch"
       )
     }
+    // An element sync in flight belongs to the *outgoing* backend: it writes the
+    // old server's rows, and `runSyncElements` would let the caller's follow-up
+    // sync join it (both callers do `set(repository:)` → `sync()`) and return
+    // without ever fetching the new server's cache. Nothing here is worth
+    // keeping, so cancel rather than detach.
+    syncTask?.cancel()
+    syncTask = nil
     self.repository = repository
     imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
     wireElementStore()
@@ -326,16 +333,22 @@ public final class DocumentStore: Sendable {
       lastSyncError = nil
       Logger.shared.info("Sync store complete")
     } catch {
-      if userInitiated { throw error }
-      if !error.isCancellationError {
-        // Only presentable failures are recorded. A non-displayable one (a GRDB
-        // `DatabaseError`, a raw `URLError`) leaves any degraded state already
-        // on screen intact rather than clearing it.
-        if let displayable = error as? any DisplayableError {
-          lastSyncError = displayable
-        }
-        Logger.shared.error("Background sync failed (suppressed): \(error)")
+      // A cancellation is never the user's problem to see: either the caller's
+      // own task went away, or `set(repository:)` retired this sync on a
+      // connection switch. Drop it before the userInitiated rethrow so neither
+      // case toasts.
+      if error.isCancellationError {
+        Logger.shared.debug("Element sync cancelled")
+        return
       }
+      if userInitiated { throw error }
+      // Only presentable failures are recorded. A non-displayable one (a GRDB
+      // `DatabaseError`, a raw `URLError`) leaves any degraded state already
+      // on screen intact rather than clearing it.
+      if let displayable = error as? any DisplayableError {
+        lastSyncError = displayable
+      }
+      Logger.shared.error("Background sync failed (suppressed): \(error)")
     }
   }
 
@@ -358,8 +371,14 @@ public final class DocumentStore: Sendable {
     syncTask = task
     isRefreshing = true
     defer {
-      syncTask = nil
-      isRefreshing = false
+      // Retract only what we installed. `set(repository:)` can retire this sync
+      // mid-flight and a replacement can already own `syncTask` by the time we
+      // resume; clearing it blindly would break the replacement's coalescing and
+      // drop `isRefreshing` while it is still running.
+      if syncTask == task {
+        syncTask = nil
+        isRefreshing = false
+      }
     }
     try await task.value
   }

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -85,6 +85,13 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var taskUpdateTask: Task<Void, Never>?
 
+  // The in-flight element sync, if any. Concurrent `sync` callers join this one
+  // task instead of each firing their own `syncElements` (the launch flurry of
+  // fetchAll / fetchUISettings / scenePhase triggers shares a single network
+  // pass). Only ever touched on the main actor.
+  @ObservationIgnored
+  private var syncTask: Task<Void, Error>?
+
   // MARK: Methods
 
   public init(repository: some Repository) {
@@ -282,37 +289,37 @@ public final class DocumentStore: Sendable {
   // On-demand element refreshers kept for their external callers. Under the
   // source-of-truth model "refresh collection X" means "sync into the DB"; the
   // live observation then repaints the projection. `syncElements` reconciles
-  // every collection at once, so these all delegate to it.
-  public func fetchAllUsers() async throws { try await sync(userInitiated: true) }
-  public func fetchAllGroups() async throws { try await sync(userInitiated: true) }
-  public func fetchAllCustomFields() async throws { try await sync(userInitiated: true) }
+  // every collection at once, so these all delegate to it. They are automatic
+  // on-appear refreshers, not user gestures, so `userInitiated: false` — a
+  // failure fails soft (cached data stays on screen) rather than toasting.
+  public func fetchAllUsers() async throws { try await sync() }
+  public func fetchAllGroups() async throws { try await sync() }
+  public func fetchAllCustomFields() async throws { try await sync() }
 
-  /// Refresh `ui_settings` (permissions/settings) from the network. Syncs into
-  /// the DB, then synchronously pulls the singleton into the projection — the
-  /// one path (`DocumentListViewModel.load`) that reads `permissions`
-  /// immediately afterwards can't wait for the observation's runloop hop.
+  /// Refresh `ui_settings` (permissions/settings) from the network, then
+  /// synchronously pull the singleton into the projection — the one path
+  /// (`DocumentListViewModel.load`) that reads `permissions` immediately
+  /// afterwards can't wait for the observation's runloop hop. Automatic (not
+  /// user-initiated): a sync failure fails soft and we proceed with the cached
+  /// permissions (offline-first) instead of aborting the launch load.
   public func fetchUISettings() async throws {
-    try await sync(userInitiated: true)
+    try await sync()
     if let backend = repository as? any CachingBackend {
       elementStore.refreshUISettings(from: backend.database, serverID: backend.serverID)
     }
   }
 
   /// Network → DB via the caching backend; the live element observation repaints
-  /// the projection. Automatic syncs fail soft into `lastSyncError`;
-  /// user-initiated syncs rethrow so the caller can surface the failure (toast).
+  /// the projection. Concurrent calls coalesce onto a single in-flight
+  /// `syncElements` (see `syncTask`); each caller still applies its own
+  /// `userInitiated` policy to the shared outcome — automatic syncs fail soft
+  /// into `lastSyncError`, user-initiated syncs rethrow so the caller can
+  /// surface the failure (toast). So a user-initiated call joining a background
+  /// sync still sees the error.
   public func sync(userInitiated: Bool = false) async throws {
     Logger.shared.notice("Sync store (userInitiated: \(userInitiated))")
-    guard let backend = repository as? any CachingBackend else {
-      // No DB-backed repository (e.g. NullRepository before login). Nothing to
-      // sync; the projection is empty until a caching repository is set.
-      Logger.shared.info("Sync skipped: repository is not a caching backend")
-      return
-    }
-    isRefreshing = true
-    defer { isRefreshing = false }
     do {
-      try await backend.syncElements()
+      try await runSyncElements()
       lastSyncError = nil
       Logger.shared.info("Sync store complete")
     } catch {
@@ -327,6 +334,31 @@ public final class DocumentStore: Sendable {
         Logger.shared.error("Background sync failed (suppressed): \(error)")
       }
     }
+  }
+
+  /// Run (or join) the single in-flight `syncElements`. Returns when it
+  /// completes; throws its error to every joined caller (who each decide what to
+  /// do with it). A no-op without a caching backend.
+  private func runSyncElements() async throws {
+    if let syncTask {
+      Logger.shared.debug("Joining in-flight element sync")
+      return try await syncTask.value
+    }
+    guard let backend = repository as? any CachingBackend else {
+      // No DB-backed repository (e.g. NullRepository before login). Nothing to
+      // sync; the projection is empty until a caching repository is set.
+      Logger.shared.info("Sync skipped: repository is not a caching backend")
+      return
+    }
+    Logger.shared.debug("Starting element sync")
+    let task = Task { try await backend.syncElements() }
+    syncTask = task
+    isRefreshing = true
+    defer {
+      syncTask = nil
+      isRefreshing = false
+    }
+    try await task.value
   }
 
   /// The eager entry views call. Triggers a network → DB sync; the element

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -46,8 +46,31 @@ public final class DocumentStore: Sendable {
   public var customFields: [UInt: CustomField] { elementStore.customFields }
   public var currentUser: User? { elementStore.currentUser }
   public var serverConfiguration: ServerConfiguration? { elementStore.serverConfiguration }
-  public var permissions: UserPermissions { elementStore.permissions }
+  /// The permission matrix to *gate on* — and, until `ui_settings` has landed
+  /// for the active server, a deliberate optimistic lie.
+  ///
+  /// The stored value starts `.empty`, which tests `false` for everything and is
+  /// therefore indistinguishable from a genuine denial: on a cold start (first
+  /// launch, or any launch while offline before the first successful sync) every
+  /// gate in the app read as "you have no permissions". Handing out `.full`
+  /// instead means the UI stays usable and the *server* answers, which is the
+  /// same bet `CachingRepository.syncElements` already makes (its gate is a
+  /// `UserPermissions?`, and `nil` → fetch everything, let the 403 decide).
+  ///
+  /// Anything that *displays* this matrix, rather than gating on it, must check
+  /// ``permissionsKnown`` first — otherwise it reports access the server never
+  /// granted. `PermissionsView` does.
+  public var permissions: UserPermissions {
+    permissionsKnown ? elementStore.permissions : .full
+  }
+
   public var settings: UISettingsSettings { elementStore.settings }
+
+  /// Whether ``permissions`` reflects the server's answer yet, or is the
+  /// optimistic `.full` stand-in. Gates don't need this; anything that shows the
+  /// matrix, or that would otherwise assert *why* something is unavailable,
+  /// does.
+  public var permissionsKnown: Bool { elementStore.isHydrated }
 
   /// True while a network `sync` is in flight. Distinct from data-presence so a
   /// cold cache shows loading rather than emptiness.
@@ -624,6 +647,10 @@ public final class DocumentStore: Sendable {
     Logger.api.info(
       "Checking permission for \(operation.description, privacy: .public) on \(resource.rawValue, privacy: .public)"
     )
+    // No hydration check needed: `permissions` is `.full` until the real matrix
+    // lands, so a cold start falls through to the request and lets the server
+    // answer instead of refusing with a permission error the user can do
+    // nothing about.
     if !permissions.test(operation, for: resource) {
       Logger.api.debug("No permissions for \(operation.description) on \(resource.rawValue)")
       throw PermissionsError(resource: resource, operation: operation)
@@ -633,7 +660,14 @@ public final class DocumentStore: Sendable {
 
 //// Permissions checking for resources
 extension DocumentStore {
+  /// The optimistic ``permissions`` default isn't enough for these three: they
+  /// also consult `currentUser`, which is nil until `ui_settings` lands, so
+  /// `currentUser?.canView(document) ?? false` would still deny every document
+  /// on a cold start. Answer optimistically until we know — the server still
+  /// refuses anything the user may not do, and a wrong "you don't have
+  /// permission" banner is worse than an edit that fails.
   public func userCanView(document: Document) -> Bool {
+    guard permissionsKnown else { return true }
     if !permissions.test(.view, for: .document) {
       return false
     }
@@ -642,6 +676,7 @@ extension DocumentStore {
   }
 
   public func userCanChange(document: Document) -> Bool {
+    guard permissionsKnown else { return true }
     if !permissions.test(.change, for: .document) {
       return false
     }
@@ -650,6 +685,7 @@ extension DocumentStore {
   }
 
   public func userCanDelete(document: Document) -> Bool {
+    guard permissionsKnown else { return true }
     if !permissions.test(.delete, for: .document) {
       return false
     }

--- a/AppShared/Sources/AppShared/Model/Localization/UserPermissionsResource+localizedName.swift
+++ b/AppShared/Sources/AppShared/Model/Localization/UserPermissionsResource+localizedName.swift
@@ -26,7 +26,30 @@ extension UserPermissions.Resource {
     case .mailRule: String(localized: .permissions(.resourceMailRule))
     case .shareLink: String(localized: .permissions(.resourceShareLink))
     case .workflow: String(localized: .permissions(.resourceWorkflow))
-    case .customField: String(localized: .permissions(.resourceCustomField))
+    case .customField: CustomField.localizedName
+    }
+  }
+
+  /// Permissions are granted per resource *type*, so prose about them reads as a
+  /// class ("not allowed to delete Storage paths"), not as one instance.
+  public var localizedNamePlural: String {
+    switch self {
+    case .document: Document.localizedNamePlural
+    case .note: Document.Note.localizedNamePlural
+    case .tag: Tag.localizedNamePlural
+    case .correspondent: Correspondent.localizedNamePlural
+    case .documentType: DocumentType.localizedNamePlural
+    case .storagePath: StoragePath.localizedNamePlural
+    case .savedView: SavedView.localizedNamePlural
+    case .paperlessTask: PaperlessTask.localizedNamePlural
+    case .uiSettings: UISettings.localizedNamePlural
+    case .user: User.localizedNamePlural
+    case .group: UserGroup.localizedNamePlural
+    case .mailAccount: String(localized: .permissions(.resourceMailAccounts))
+    case .mailRule: String(localized: .permissions(.resourceMailRules))
+    case .shareLink: String(localized: .permissions(.resourceShareLinks))
+    case .workflow: String(localized: .permissions(.resourceWorkflows))
+    case .customField: CustomField.localizedNamePlural
     }
   }
 }

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -56,7 +56,7 @@ enum CachingRepositoryError: Error {
 
 @MainActor
 public final class CachingRepository<Wrapped: Repository>: Repository, CachingBackend {
-  private let wrapped: Wrapped
+  let wrapped: Wrapped
   public let database: Database
   public let serverID: UUID
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -69,40 +69,65 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   // MARK: - CachingBackend
 
   public func syncElements() async throws {
+    // Sync UI settings *first*: its permission matrix gates the rest, so we
+    // don't ask the server for collections the user can't view (doomed 403s).
+    // When the matrix is unavailable (uiSettings failed and nothing is cached),
+    // `gate` is nil and we fetch everything, relying on the per-resource
+    // 403/401-skip in `syncCollection` as a fallback.
+    let gate = await syncUISettings()
+    func canView(_ resource: UserPermissions.Resource) -> Bool {
+      gate?.test(.view, for: resource) ?? true
+    }
+
     try await withThrowingTaskGroup(of: Void.self) { group in
-      group.addTask { [self] in
-        try await syncCollection(TagRecord.self) { try await wrapped.tags() }
-      }
-      group.addTask { [self] in
-        try await syncCollection(CorrespondentRecord.self) {
-          try await wrapped.correspondents()
+      if canView(.tag) {
+        group.addTask { [self] in
+          try await syncCollection(TagRecord.self) { try await wrapped.tags() }
         }
       }
-      group.addTask { [self] in
-        try await syncCollection(DocumentTypeRecord.self) {
-          try await wrapped.documentTypes()
+      if canView(.correspondent) {
+        group.addTask { [self] in
+          try await syncCollection(CorrespondentRecord.self) {
+            try await wrapped.correspondents()
+          }
         }
       }
-      group.addTask { [self] in
-        try await syncCollection(StoragePathRecord.self) {
-          try await wrapped.storagePaths()
+      if canView(.documentType) {
+        group.addTask { [self] in
+          try await syncCollection(DocumentTypeRecord.self) {
+            try await wrapped.documentTypes()
+          }
         }
       }
-      group.addTask { [self] in
-        try await syncCollection(SavedViewRecord.self) { try await wrapped.savedViews() }
-      }
-      group.addTask { [self] in
-        try await syncCollection(UserRecord.self) { try await wrapped.users() }
-      }
-      group.addTask { [self] in
-        try await syncCollection(UserGroupRecord.self) { try await wrapped.groups() }
-      }
-      group.addTask { [self] in
-        try await syncCollection(CustomFieldRecord.self) {
-          try await wrapped.customFields()
+      if canView(.storagePath) {
+        group.addTask { [self] in
+          try await syncCollection(StoragePathRecord.self) {
+            try await wrapped.storagePaths()
+          }
         }
       }
-      group.addTask { [self] in try await syncUISettings() }
+      if canView(.savedView) {
+        group.addTask { [self] in
+          try await syncCollection(SavedViewRecord.self) { try await wrapped.savedViews() }
+        }
+      }
+      if canView(.user) {
+        group.addTask { [self] in
+          try await syncCollection(UserRecord.self) { try await wrapped.users() }
+        }
+      }
+      if canView(.group) {
+        group.addTask { [self] in
+          try await syncCollection(UserGroupRecord.self) { try await wrapped.groups() }
+        }
+      }
+      if canView(.customField) {
+        group.addTask { [self] in
+          try await syncCollection(CustomFieldRecord.self) {
+            try await wrapped.customFields()
+          }
+        }
+      }
       group.addTask { [self] in try await syncServerConfiguration() }
 
       for try await _ in group {}
@@ -121,12 +146,20 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     }
   }
 
-  private func syncUISettings() async throws {
+  /// Fetch the UI settings singleton and return its permission matrix to gate
+  /// the rest of the sync. Never throws: on any failure it falls back to the
+  /// last cached matrix, or `nil` if none exists (caller then fetches every
+  /// collection and relies on per-resource 403/401-skip, as before). A
+  /// uiSettings failure therefore degrades gating without aborting the sync.
+  private func syncUISettings() async -> UserPermissions? {
     do {
       let settings = try await wrapped.uiSettings()
       try database.setUISettings(settings, serverID: serverID)
-    } catch let error where Self.isSkippable(error) {
-      Logger.shared.info("Skipping uiSettings sync: \(error)")
+      return settings.permissions
+    } catch {
+      Logger.shared.info(
+        "uiSettings sync failed (\(error)); gating sync on cached permissions")
+      return try? database.uiSettings(serverID: serverID)?.permissions
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -56,6 +56,10 @@ enum CachingRepositoryError: Error {
 
 @MainActor
 public final class CachingRepository<Wrapped: Repository>: Repository, CachingBackend {
+  /// Module-internal rather than `private` only so
+  /// ``DocumentStore/previewRepository(as:)`` can recover the underlying
+  /// repository for its preview-only helpers. It stays read-only to everyone
+  /// (including this module) by being a `let`.
   let wrapped: Wrapped
   public let database: Database
   public let serverID: UUID

--- a/AppShared/Sources/AppShared/Networking/Error/PermissionsError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/PermissionsError.swift
@@ -12,17 +12,45 @@ public struct PermissionsError: Error, DisplayableError {
   public let resource: UserPermissions.Resource
   public let operation: UserPermissions.Operation
 
-  public init(resource: UserPermissions.Resource, operation: UserPermissions.Operation) {
+  /// What the backend said when it rejected the request. `nil` when the
+  /// client-side permission check refused the operation before it went out.
+  public let detail: String?
+
+  public init(
+    resource: UserPermissions.Resource, operation: UserPermissions.Operation,
+    detail: String? = nil
+  ) {
     self.resource = resource
     self.operation = operation
+    self.detail = detail
   }
 
+  /// Names the operation, not the resource: "no access to storage paths" is
+  /// confusing when the user is looking at a list of them and only the delete
+  /// was refused. The resource goes in `details` — this is the toast message,
+  /// which is one line with tail truncation, so it has to stay short.
   public var message: String {
-    String(localized: .app(.apiForbiddenErrorMessage(resource.localizedName)))
+    switch operation {
+    case .view: String(localized: .app(.apiForbiddenViewErrorMessage))
+    case .add: String(localized: .app(.apiForbiddenAddErrorMessage))
+    case .change: String(localized: .app(.apiForbiddenChangeErrorMessage))
+    case .delete: String(localized: .app(.apiForbiddenDeleteErrorMessage))
+    }
   }
 
   public var details: String? {
-    String(localized: .app(.apiForbiddenDetails(resource.localizedName)))
+    let name = resource.localizedNamePlural
+    var msg =
+      switch operation {
+      case .view: String(localized: .app(.apiForbiddenViewDetails(name)))
+      case .add: String(localized: .app(.apiForbiddenAddDetails(name)))
+      case .change: String(localized: .app(.apiForbiddenChangeDetails(name)))
+      case .delete: String(localized: .app(.apiForbiddenDeleteDetails(name)))
+      }
+    if let detail {
+      msg += "\n\n\(detail)"
+    }
+    return msg
   }
 
   public var documentationLink: URL? { DocumentationLinks.forbidden }

--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -11903,6 +11903,30 @@
         }
       }
     },
+    "shareSheetNeedsAuthMessage" : {
+      "comment" : "Alert body in the Share Extension when the server rejected the login (401). The extension cannot run the re-authentication flow itself.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+          }
+        }
+      }
+    },
+    "shareSheetNeedsAuthTitle" : {
+      "comment" : "Alert title in the Share Extension when the server rejected the login (401)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in again"
+          }
+        }
+      }
+    },
     "shareSheetNotLoggedIn" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -161,6 +161,78 @@
         }
       }
     },
+    "apiForbiddenAddDetails" : {
+      "comment" : "Argument is the localized resource name (e.g. User, Document type)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+          }
+        }
+      }
+    },
+    "apiForbiddenAddErrorMessage" : {
+      "comment" : "Toast title, truncated to one line: keep it short. The resource name goes in the detail string instead",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create not permitted"
+          }
+        }
+      }
+    },
+    "apiForbiddenChangeDetails" : {
+      "comment" : "Argument is the localized resource name (e.g. User, Document type)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+          }
+        }
+      }
+    },
+    "apiForbiddenChangeErrorMessage" : {
+      "comment" : "Toast title, truncated to one line: keep it short. The resource name goes in the detail string instead",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit not permitted"
+          }
+        }
+      }
+    },
+    "apiForbiddenDeleteDetails" : {
+      "comment" : "Argument is the localized resource name (e.g. User, Document type)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+          }
+        }
+      }
+    },
+    "apiForbiddenDeleteErrorMessage" : {
+      "comment" : "Toast title, truncated to one line: keep it short. The resource name goes in the detail string instead",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete not permitted"
+          }
+        }
+      }
+    },
     "apiForbiddenDetails" : {
       "comment" : "Argument 1 is the localized resource name (e.g. User, Document type), argument 2 is the detail error string reported by the backend",
       "extractionState" : "manual",
@@ -265,6 +337,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erişim yok: %@"
+          }
+        }
+      }
+    },
+    "apiForbiddenViewDetails" : {
+      "comment" : "Argument is the localized resource name (e.g. User, Document type)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+          }
+        }
+      }
+    },
+    "apiForbiddenViewErrorMessage" : {
+      "comment" : "Toast title, truncated to one line: keep it short. The resource name goes in the detail string instead",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View not permitted"
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -6495,49 +6495,49 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tryk for detaljer!"
+            "value" : "Detaljer"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Für Details antippen!"
+            "value" : "Details"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tap for details!"
+            "value" : "Details"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appuyez pour en savoir plus!"
+            "value" : "Détails"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tocca per maggiori dettagli!"
+            "value" : "Dettagli"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tik voor meer informatie!"
+            "value" : "Details"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dotknij, aby zobaczyć szczegóły!"
+            "value" : "Szczegóły"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Detaylar için dokun!"
+            "value" : "Ayrıntılar"
           }
         }
       }
@@ -6548,49 +6548,49 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der opstod en fejl"
+            "value" : "Uventet fejl"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ein Fehler ist aufgetreten"
+            "value" : "Unerwarteter Fehler"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "An unexpected error occurred"
+            "value" : "Unexpected error"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Une erreur est survenue"
+            "value" : "Erreur inattendue"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Si è verificato un errore imprevisto"
+            "value" : "Errore imprevisto"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Er is een fout opgetreden"
+            "value" : "Onverwachte fout"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wystąpił błąd"
+            "value" : "Nieoczekiwany błąd"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Beklenmedik bir hata oluştu"
+            "value" : "Beklenmedik hata"
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
@@ -1647,6 +1647,18 @@
         }
       }
     },
+    "resourceMailAccounts" : {
+      "comment" : "Plural resource name, used in permission error details",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mail accounts"
+          }
+        }
+      }
+    },
     "resourceMailRule" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1696,6 +1708,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "E-posta kuralı"
+          }
+        }
+      }
+    },
+    "resourceMailRules" : {
+      "comment" : "Plural resource name, used in permission error details",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mail rules"
           }
         }
       }
@@ -1753,6 +1777,18 @@
         }
       }
     },
+    "resourceShareLinks" : {
+      "comment" : "Plural resource name, used in permission error details",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share links"
+          }
+        }
+      }
+    },
     "resourceWorkflow" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1802,6 +1838,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "İş akışı"
+          }
+        }
+      }
+    },
+    "resourceWorkflows" : {
+      "comment" : "Plural resource name, used in permission error details",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Workflows"
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
@@ -1276,6 +1276,18 @@
         }
       }
     },
+    "permissionsNotLoaded" : {
+      "comment" : "Shown on the permissions matrix screen when ui_settings hasn't been fetched yet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+          }
+        }
+      }
+    },
     "private" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/AppShared/Sources/AppShared/Views/AppOverlays.swift
+++ b/AppShared/Sources/AppShared/Views/AppOverlays.swift
@@ -10,6 +10,10 @@
 //    into toasts — no persistent UI for the offline state, just a brief
 //    announcement when the state flips.
 //
+//  None of this reaches the Share Extension: a toast renders into a
+//  screen-level window, which the extension's sheet doesn't own. Its
+//  counterpart is `ShareErrorBanner`.
+//
 //  The interactive `NeedsAuthBanner` is intentionally NOT installed here —
 //  it lives in a `safeAreaInset` on the home document screen so existing
 //  sheets visually hide it, preventing the user from triggering a SwiftUI

--- a/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
@@ -364,7 +364,7 @@ private let instances = [
 
 @MainActor
 private func getDocument(store: DocumentStore) async throws -> Document? {
-  let repository = store.repository as! TransientRepository
+  let repository = store.previewRepository(as: TransientRepository.self)
   repository.addUser(
     User(id: 1, isSuperUser: false, username: "user", groups: [1]))
   try? repository.login(userId: 1)
@@ -383,7 +383,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
 
 #Preview("Fully equipped") {
   @Previewable
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()
@@ -410,7 +410,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
 
 #Preview("Empty") {
   @Previewable
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()
@@ -428,7 +428,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
 
     Button("Toggle perms") {
       Task {
-        let repository = store.repository as! TransientRepository
+        let repository = store.previewRepository(as: TransientRepository.self)
         repository.set(
           permissions: .full {
             $0.set(.view, to: !store.permissions.test(.view, for: .customField), for: .customField)

--- a/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
@@ -142,7 +142,7 @@ private struct AddCustomFieldView: View {
 
     .task {
       do {
-        try await store.fetchAllCustomFields()
+        try await store.sync()
       } catch {
         //                Logger.shared.error("Error fetching custom fields: \(error, privacy: .public)")
         errorController.push(error: error)

--- a/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
@@ -371,7 +371,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
   for field in customFields {
     _ = try await repository.add(customField: field)
   }
-  try await store.fetchAll()
+  try await store.sync()
   try await store.repository.create(
     document: ProtoDocument(title: "blubb"),
     file: #URL("http://example.com"), filename: "blubb.pdf"
@@ -433,7 +433,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
           permissions: .full {
             $0.set(.view, to: !store.permissions.test(.view, for: .customField), for: .customField)
           })
-        try? await store.fetchAll()
+        try? await store.sync()
       }
     }
   }

--- a/AppShared/Sources/AppShared/Views/CustomFields/DocumentLinkView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/DocumentLinkView.swift
@@ -233,7 +233,7 @@ private let field = CustomField(id: 9, name: "Custom doc link", dataType: .docum
 #Preview {
   @Previewable @State var instance = CustomFieldInstance(field: field, value: .documentLink([2]))
   @Previewable
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
   @Previewable @State var document: Document? = nil
 
   NavigationStack {

--- a/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
+++ b/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
@@ -238,7 +238,7 @@ private struct PreviewHelper: View {
     .environmentObject(errorController)
 
     .task {
-      try? await store.fetchAll()
+      try? await store.sync()
     }
   }
 }

--- a/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
+++ b/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
@@ -214,7 +214,7 @@ public struct DocumentNoteView: View {
 // - MARK: Preview
 
 private struct PreviewHelper: View {
-  @State public var store = DocumentStore(repository: PreviewRepository(downloadDelay: 3.0))
+  @State public var store = DocumentStore.preview(PreviewRepository(downloadDelay: 3.0))
   @StateObject public var errorController = ErrorController()
 
   @State public var document: Document?

--- a/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
+++ b/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
@@ -197,7 +197,7 @@ public struct DocumentCell: View {
 }
 
 #Preview {
-  @Previewable @State var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore.preview(TransientRepository())
   @Previewable @State var documents = [Document]()
 
   List {
@@ -207,7 +207,7 @@ public struct DocumentCell: View {
   }
   .task {
     do {
-      let repository = store.repository as! TransientRepository
+      let repository = store.previewRepository(as: TransientRepository.self)
       repository.addUser(User(id: 1, isSuperUser: false, username: "user1", groups: []))
       try? repository.login(userId: 1)
 

--- a/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
+++ b/AppShared/Sources/AppShared/Views/Document/DocumentCell.swift
@@ -241,7 +241,7 @@ public struct DocumentCell: View {
 
       documents = try await store.repository.documents(filter: .default).fetch(limit: 100_000)
 
-      try await store.fetchAll()
+      try await store.sync()
     } catch { print(error) }
   }
 }

--- a/AppShared/Sources/AppShared/Views/Error/ErrorDisplay.swift
+++ b/AppShared/Sources/AppShared/Views/Error/ErrorDisplay.swift
@@ -9,6 +9,7 @@
 import Common
 import SwiftUI
 import Toasts
+import WindowOverlay
 
 public struct ErrorDisplay: ViewModifier {
   @ObservedObject public var errorController: ErrorController
@@ -41,28 +42,35 @@ public struct ErrorDisplay: ViewModifier {
           )
         )
       }
-      .alert(
-        unwrapping: $detail,
-        title: { detail in
-          Text(detail.message)
-        },
-        actions: { detail in
-          Button(String(localized: .app(.copyToClipboard))) {
-            Pasteboard.general.string = detail.details
-          }
+      // Host the detail alert in a dedicated window (the same mechanism the
+      // toast itself uses) so it presents above whatever sheet is currently
+      // open. A plain `.alert` here attaches to the root view controller, and
+      // presenting it tears down any active sheet (e.g. Settings).
+      .windowOverlay(isPresented: detail != nil) {
+        Color.clear
+          .alert(
+            unwrapping: $detail,
+            title: { detail in
+              Text(detail.message)
+            },
+            actions: { detail in
+              Button(String(localized: .app(.copyToClipboard))) {
+                Pasteboard.general.string = detail.details
+              }
 
-          if let link = detail.documentationLink {
-            Link(String(localized: .app(.errorMoreInfo)), destination: link)
-          }
+              if let link = detail.documentationLink {
+                Link(String(localized: .app(.errorMoreInfo)), destination: link)
+              }
 
-          Button(String(localized: .app(.ok)), role: .cancel) {}
-        },
-        message: { detail in
-          if let details = detail.details {
-            Text(details)
-          }
-        }
-      )
+              Button(String(localized: .app(.ok)), role: .cancel) {}
+            },
+            message: { detail in
+              if let details = detail.details {
+                Text(details)
+              }
+            }
+          )
+      }
   }
 }
 

--- a/AppShared/Sources/AppShared/Views/Error/ErrorDisplay.swift
+++ b/AppShared/Sources/AppShared/Views/Error/ErrorDisplay.swift
@@ -53,17 +53,7 @@ public struct ErrorDisplay: ViewModifier {
             title: { detail in
               Text(detail.message)
             },
-            actions: { detail in
-              Button(String(localized: .app(.copyToClipboard))) {
-                Pasteboard.general.string = detail.details
-              }
-
-              if let link = detail.documentationLink {
-                Link(String(localized: .app(.errorMoreInfo)), destination: link)
-              }
-
-              Button(String(localized: .app(.ok)), role: .cancel) {}
-            },
+            actions: { ErrorAlertActions(for: $0) },
             message: { detail in
               if let details = detail.details {
                 Text(details)
@@ -77,5 +67,32 @@ public struct ErrorDisplay: ViewModifier {
 extension View {
   @MainActor public func errorOverlay(errorController: ErrorController) -> some View {
     modifier(ErrorDisplay(errorController: errorController))
+  }
+}
+
+/// The buttons an error alert offers: copy the details, follow the
+/// documentation link, dismiss. Shared with the Share Extension's alert so the
+/// two stay in the same vocabulary.
+public struct ErrorAlertActions: View {
+  private let error: any DisplayableError
+
+  public init(for error: any DisplayableError) {
+    self.error = error
+  }
+
+  public var body: some View {
+    // The app only reaches this alert when there are details to show; the
+    // extension alerts on every error, so the button is conditional.
+    if error.details != nil {
+      Button(String(localized: .app(.copyToClipboard))) {
+        Pasteboard.general.string = error.details
+      }
+    }
+
+    if let link = error.documentationLink {
+      Link(String(localized: .app(.errorMoreInfo)), destination: link)
+    }
+
+    Button(String(localized: .app(.ok)), role: .cancel) {}
   }
 }

--- a/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
@@ -425,7 +425,7 @@ where
     .refreshable {
       await Task {
         do {
-          try await store.fetchAll()
+          try await store.fetchAll(userInitiated: true)
         } catch {
           errorController.push(error: error)
         }

--- a/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
@@ -449,7 +449,7 @@ where
 }
 
 private struct FilterViewPreviewHelper<T: Pickable>: View {
-  @State public var store = DocumentStore(repository: PreviewRepository())
+  @State public var store = DocumentStore.preview()
   @State public var filterState = FilterState.Filter.any
   @State public var elements: [(UInt, String)] = []
 

--- a/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
@@ -425,7 +425,7 @@ where
     .refreshable {
       await Task {
         do {
-          try await store.fetchAll(userInitiated: true)
+          try await store.sync(userInitiated: true)
         } catch {
           errorController.push(error: error)
         }

--- a/AppShared/Sources/AppShared/Views/Filter/TagFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/TagFilterView.swift
@@ -253,7 +253,7 @@ public struct TagFilterView: View {
 }
 
 #Preview {
-  @Previewable @State var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore.preview(TransientRepository())
 
   @Previewable @State var filterState = FilterState.default
 

--- a/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
+++ b/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
@@ -466,7 +466,7 @@ public struct CreateDocumentView: View {
 // - MARK: Previews
 
 private struct PreviewHelperView: View {
-  @State private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore.preview()
   @StateObject private var errorController = ErrorController()
   @State private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)

--- a/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
+++ b/AppShared/Sources/AppShared/Views/Import/CreateDocumentView.swift
@@ -440,7 +440,7 @@ public struct CreateDocumentView: View {
       }
       .task {
         do {
-          try await store.fetchAll()
+          try await store.sync()
         } catch {
           errorController.push(error: error)
         }

--- a/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
+++ b/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
@@ -437,7 +437,7 @@ private struct PreviewHelper: View {
             $0.set(.view, to: true, for: .user)
             $0.set(.view, to: true, for: .group)
           })
-        try await store.fetchAll()
+        try await store.sync()
         print(store.users)
         try await store.repository.create(
           document: ProtoDocument(title: "blubb"),

--- a/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
+++ b/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
@@ -213,11 +213,9 @@ public struct PermissionsEditView<Object>: View where Object: PermissionsModel {
   }
 
   private func initialize() async {
-    // update users and groups just in case
-    let users = Task { await fetch { try await store.fetchAllUsers() } }
-    let groups = Task { await fetch { try await store.fetchAllGroups() } }
-    await users.value
-    await groups.value
+    // Refresh users and groups just in case. One sync reconciles every
+    // collection, so this is a single call rather than one per collection.
+    await fetch { try await store.sync() }
   }
 
   private func fetch(_ operation: () async throws -> Void) async {

--- a/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
+++ b/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
@@ -428,7 +428,7 @@ private struct PreviewHelper: View {
     }
     .task {
       do {
-        let repository = store.repository as! TransientRepository
+        let repository = store.previewRepository(as: TransientRepository.self)
         repository.addUser(User(id: 1, isSuperUser: false, username: "user", groups: [1]))
         repository.addUser(User(id: 2, isSuperUser: false, username: "user 2"))
         repository.addGroup(UserGroup(id: 1, name: "group 1"))
@@ -463,7 +463,7 @@ private struct PreviewHelper: View {
 
 #Preview {
   @Previewable
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
   @Previewable
   @StateObject var errorController = ErrorController()
 

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -200,7 +200,7 @@ public struct ConnectionsView: View {
           value: stored.identity ?? String(localized: .login(.noIdentity)))
 
         NavigationLink {
-          PermissionsView(userPermissions: store.permissions)
+          PermissionsView(userPermissions: store.permissions, isKnown: store.permissionsKnown)
         } label: {
           Label(localized: .permissions(.title), systemImage: "lock.fill")
         }

--- a/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
@@ -155,7 +155,7 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
 
   private func refresh() async {
     do {
-      try await store.fetchAll(userInitiated: true)
+      try await store.sync(userInitiated: true)
       if let model {
         withAnimation {
           elements = model.load()
@@ -338,7 +338,7 @@ private struct Container<M: ManagerProtocol>: View {
     }
     .environment(store)
     .task {
-      try? await store.fetchAll()
+      try? await store.sync()
     }
   }
 }

--- a/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
@@ -155,7 +155,7 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
 
   private func refresh() async {
     do {
-      try await store.fetchAll()
+      try await store.fetchAll(userInitiated: true)
       if let model {
         withAnimation {
           elements = model.load()

--- a/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
@@ -328,7 +328,7 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
 }
 
 private struct Container<M: ManagerProtocol>: View {
-  @State public var store = DocumentStore(repository: PreviewRepository())
+  @State public var store = DocumentStore.preview()
   @StateObject public var errorController = ErrorController()
 
   public var body: some View {

--- a/AppShared/Sources/AppShared/Views/Settings/PermissionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/PermissionsView.swift
@@ -23,6 +23,18 @@ extension UserPermissions.Operation {
 public struct PermissionsView: View {
   public let userPermissions: UserPermissions
 
+  /// False while `ui_settings` hasn't landed for the active server. The store
+  /// hands out `.full` in that state so the rest of the app stays usable (see
+  /// `DocumentStore.permissions`), but rendering that as a green matrix would
+  /// report access the server never granted — so this screen, which *displays*
+  /// the matrix rather than gating on it, shows every cell as unknown instead.
+  public let isKnown: Bool
+
+  public init(userPermissions: UserPermissions, isKnown: Bool = true) {
+    self.userPermissions = userPermissions
+    self.isKnown = isKnown
+  }
+
   private struct Row: Identifiable {
     var id: String { name }
 
@@ -39,19 +51,38 @@ public struct PermissionsView: View {
 
   private struct Value: View {
     let value: Bool
+    var known: Bool = true
 
     public var body: some View {
-      Label(
-        localized: value ? .app(.yes) : .app(.no),
-        systemImage: value ? "checkmark.circle.fill" : "xmark.circle.fill"
-      )
-      .labelStyle(.iconOnly)
-      .foregroundStyle(value ? .green : .gray)
+      if known {
+        Label(
+          localized: value ? .app(.yes) : .app(.no),
+          systemImage: value ? "checkmark.circle.fill" : "xmark.circle.fill"
+        )
+        .labelStyle(.iconOnly)
+        .foregroundStyle(value ? .green : .gray)
+      } else {
+        Image(systemName: "questionmark.circle.fill")
+          .foregroundStyle(.secondary)
+          .accessibilityLabel(String(localized: .permissions(.permissionsNotLoaded)))
+      }
     }
   }
 
   public var body: some View {
     Form {
+      if !isKnown {
+        Section {
+          Label {
+            Text(.permissions(.permissionsNotLoaded))
+          } icon: {
+            Image(systemName: "questionmark.circle.fill")
+          }
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+        }
+      }
+
       Grid {
         GridRow {
           Text(.permissions(.resource))
@@ -69,16 +100,21 @@ public struct PermissionsView: View {
           GridRow {
             Text(resource.localizedName)
               .frame(maxWidth: .infinity, alignment: .leading)
-            Value(value: userPermissions.test(.view, for: resource))
-            Value(value: userPermissions.test(.add, for: resource))
-            Value(value: userPermissions.test(.change, for: resource))
-            Value(value: userPermissions.test(.delete, for: resource))
+            Value(value: userPermissions.test(.view, for: resource), known: isKnown)
+            Value(value: userPermissions.test(.add, for: resource), known: isKnown)
+            Value(value: userPermissions.test(.change, for: resource), known: isKnown)
+            Value(value: userPermissions.test(.delete, for: resource), known: isKnown)
           }
         }
       }
 
       Button(String(localized: .permissions(.copySummary))) {
-        Pasteboard.general.string = userPermissions.matrix
+        // Mark an unloaded matrix in the copied text too — this lands in bug
+        // reports, where an all-green `.full` stand-in would be read as fact.
+        Pasteboard.general.string =
+          isKnown
+          ? userPermissions.matrix
+          : "(not loaded from server; assuming full access)\n\(userPermissions.matrix)"
       }
     }
     .navigationTitle(String(localized: .permissions(.title)))
@@ -94,5 +130,11 @@ public struct PermissionsView: View {
 
   NavigationStack {
     PermissionsView(userPermissions: perms)
+  }
+}
+
+#Preview("Permissions view (not loaded)") {
+  NavigationStack {
+    PermissionsView(userPermissions: .full, isKnown: false)
   }
 }

--- a/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
@@ -138,7 +138,7 @@ public struct TrashView: View {
 }
 
 #Preview {
-  @Previewable @State var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore.preview(TransientRepository())
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var ready = false
 
@@ -151,7 +151,7 @@ public struct TrashView: View {
   }
   .task {
     do {
-      let repository = store.repository as! TransientRepository
+      let repository = store.previewRepository(as: TransientRepository.self)
       repository.addUser(User(id: 1, isSuperUser: false, username: "user", groups: []))
       try repository.login(userId: 1)
 

--- a/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/TrashView.swift
@@ -178,7 +178,7 @@ public struct TrashView: View {
         )
       }
 
-      try await store.fetchAll()
+      try await store.sync()
       let seq = try store.repository.documents(filter: .default)
       let allDocuments = try await seq.fetch(limit: 1000)
 

--- a/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
@@ -209,7 +209,7 @@ public struct DocumentTagEditView<D>: View where D: DocumentProtocol {
     .refreshable {
       Task {
         do {
-          try await store.fetchAll()
+          try await store.fetchAll(userInitiated: true)
         } catch {
           errorController.push(error: error)
         }

--- a/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
@@ -209,7 +209,7 @@ public struct DocumentTagEditView<D>: View where D: DocumentProtocol {
     .refreshable {
       Task {
         do {
-          try await store.fetchAll(userInitiated: true)
+          try await store.sync(userInitiated: true)
         } catch {
           errorController.push(error: error)
         }

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -14,34 +14,15 @@ import os
 struct ShareView: View {
   @ObservedObject var attachmentManager: AttachmentManager
 
-  // Build a Database for the extension process. WAL allows concurrent
-  // readers across processes, so opening the same app-group SQLite file
-  // alongside the main app is supported. Cross-process live notification
-  // is not — the extension sees whatever was committed at launch.
-  // If the bootstrap fails (corrupt file, missing app-group), fall back to
-  // an in-memory database so the extension still renders the disabled
-  // "no active server" state cleanly instead of crashing.
-  @State private var connectionManager: ConnectionManager = {
-    let database: Database
-    do {
-      database = try Database()
-    } catch {
-      Logger.shared.fault(
-        "Share Extension database bootstrap failed (\(error)); falling back to in-memory")
-      database =
-        (try? Database.inMemory())
-        ?? {
-          // The in-memory path opens a DatabaseQueue and runs migrations,
-          // both of which are infallible in practice. Force-unwrap so the
-          // closure has a non-optional return; if this ever throws we want
-          // to know immediately, not silently render a broken share sheet.
-          preconditionFailure(
-            "In-memory database fallback also failed; cannot construct ConnectionManager")
-        }()
-    }
-    return ConnectionManager(database: database)
-  }()
+  // The extension process's own Database (app-group SQLite, WAL). The same DB
+  // backs the `ConnectionManager` and — wrapped in a `CachingRepository` in
+  // `refreshConnection` — the element cache, so the store's `ElementStore`
+  // projection observes the extension's own writes. Cross-process live
+  // notification isn't delivered (the extension syncs at launch), but the
+  // extension's in-process writes drive its own observation normally.
+  private let database: Database
 
+  @State private var connectionManager: ConnectionManager
   @State private var store = DocumentStore(repository: NullRepository())
   @State private var storeReady = false
 
@@ -54,6 +35,28 @@ struct ShareView: View {
   init(attachmentManager: AttachmentManager, callback: @escaping () -> Void) {
     self.attachmentManager = attachmentManager
     self.callback = callback
+    let database = Self.bootstrapDatabase()
+    self.database = database
+    _connectionManager = State(initialValue: ConnectionManager(database: database))
+  }
+
+  // Open the app-group SQLite file. If the bootstrap fails (corrupt file,
+  // missing app-group), fall back to an in-memory database so the extension
+  // still renders the disabled "no active server" state cleanly instead of
+  // crashing. The in-memory path (DatabaseQueue + migrations) is infallible in
+  // practice; if it ever throws we want to know immediately.
+  private static func bootstrapDatabase() -> Database {
+    do {
+      return try Database()
+    } catch {
+      Logger.shared.fault(
+        "Share Extension database bootstrap failed (\(error)); falling back to in-memory")
+      if let inMemory = try? Database.inMemory() {
+        return inMemory
+      }
+      preconditionFailure(
+        "In-memory database fallback also failed; cannot construct ConnectionManager")
+    }
   }
 
   private func internalCallback() {
@@ -73,8 +76,14 @@ struct ShareView: View {
       Logger.api.trace("Valid connection from connection manager: \(String(describing: conn))")
       Task {
         store.events.emit(.repositoryWillChange)
-        await store.set(
-          repository: ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode))
+        // Caching outermost, over the extension's own DB, so the store's
+        // ElementStore projection observes the writes its sync performs.
+        let api = await ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode)
+        let needsAuth = NeedsAuthRepository(
+          wrapping: api, serverID: conn.serverID, connectionManager: connectionManager)
+        let repository = CachingRepository(
+          wrapping: needsAuth, database: database, serverID: conn.serverID)
+        store.set(repository: repository)
         storeReady = true
         try? await store.fetchAll()
       }

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -85,7 +85,7 @@ struct ShareView: View {
           wrapping: needsAuth, database: database, serverID: conn.serverID)
         store.set(repository: repository)
         storeReady = true
-        try? await store.fetchAll()
+        try? await store.sync()
       }
     } else {
       Logger.shared.trace("App does not have any active connection")

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -28,7 +28,7 @@ struct ShareView: View {
 
   @StateObject private var errorController = ErrorController()
 
-  @State private var error: String = ""
+  @State private var presentedError: (any DisplayableError)?
 
   var callback: () -> Void
 
@@ -63,6 +63,16 @@ struct ShareView: View {
           "In-memory database fallback also failed (\(error)); cannot construct ConnectionManager")
       }
     }
+  }
+
+  // Matched on the error rather than `ConnectionManager`'s `needsAuth` flag:
+  // that flag is set through a database write, and this has to be right on the
+  // frame the alert is built.
+  private func isUnauthorized(_ error: any Error) -> Bool {
+    if let request = error as? RequestError, case .unauthorized = request {
+      return true
+    }
+    return false
   }
 
   private func internalCallback() {
@@ -191,5 +201,43 @@ struct ShareView: View {
 
     .onChange(of: connectionManager.activeConnectionId) { refreshConnection() }
     .onChange(of: connectionManager.connections) { refreshConnection() }
+
+    // Without this the `errorController` above has no subscriber at all and
+    // every push — an upload rejected for a 401 included — is dropped by the
+    // PassthroughSubject, leaving only the toolbar's three-second warning
+    // triangle.
+    //
+    // The app's toast surface can't be reused: `installToast` renders into a
+    // full-screen window inset by the safe area of its *host* view, which is
+    // ~0 inside the share sheet, so the toast lands under the Dynamic Island.
+    // An alert is positioned by the system, and the extension is a single
+    // screen with no competing presentation to conflict with.
+    .onReceive(errorController.presentations) { presentedError = $0 }
+    .alert(
+      unwrapping: $presentedError,
+      // Resolved with `String(localized:)` rather than handed to `Text` as a
+      // `LocalizedStringResource`: in the alert title slot the resource is
+      // stringified with its attributes still attached, rendering as
+      // `Sign in again{ NSLanguage = en; }`.
+      title: { error in
+        if isUnauthorized(error) {
+          Text(String(localized: .app(.shareSheetNeedsAuthTitle)))
+        } else {
+          Text(error.message)
+        }
+      },
+      actions: { ErrorAlertActions(for: $0) },
+      // An expired login is the one failure the user can act on — but not from
+      // here. `NeedsAuthRepository` flips the connection's flag, but the
+      // recovery UI lives in the app target, and `NSExtensionContext.open`
+      // does nothing from a share extension, so refer them to the app.
+      message: { error in
+        if isUnauthorized(error) {
+          Text(String(localized: .app(.shareSheetNeedsAuthMessage)))
+        } else if let details = error.details {
+          Text(details)
+        }
+      }
+    )
   }
 }

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -44,18 +44,24 @@ struct ShareView: View {
   // missing app-group), fall back to an in-memory database so the extension
   // still renders the disabled "no active server" state cleanly instead of
   // crashing. The in-memory path (DatabaseQueue + migrations) is infallible in
-  // practice; if it ever throws we want to know immediately.
+  // practice; if it ever throws we want to know immediately — but log the
+  // fallback's own error first, since `preconditionFailure` only carries its
+  // message into the crash report and the underlying error is the only thing
+  // that would make such a report diagnosable.
   private static func bootstrapDatabase() -> Database {
     do {
       return try Database()
     } catch {
       Logger.shared.fault(
         "Share Extension database bootstrap failed (\(error)); falling back to in-memory")
-      if let inMemory = try? Database.inMemory() {
-        return inMemory
+      do {
+        return try Database.inMemory()
+      } catch {
+        Logger.shared.fault(
+          "Share Extension in-memory database fallback also failed: \(error)")
+        preconditionFailure(
+          "In-memory database fallback also failed (\(error)); cannot construct ConnectionManager")
       }
-      preconditionFailure(
-        "In-memory database fallback also failed; cannot construct ConnectionManager")
     }
   }
 

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -5,3 +5,4 @@
 - OIDC logins now support TOTP (two-factor authentication) codes from Paperless-ngx
 - Sharing a document link now shares the web interface URL, which opens in a browser, instead of the API URL that did not
 - Permission errors now say which operation was refused, e.g. "Delete not permitted" instead of a generic access error, and name the affected item in the error details
+- Pulling to refresh on a document now also refreshes permissions, so a permission change on the server takes effect without restarting the app

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -4,6 +4,7 @@
 - The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.
 - OIDC logins now support TOTP (two-factor authentication) codes from Paperless-ngx
 - Sharing a document link now shares the web interface URL, which opens in a browser, instead of the API URL that did not
+- The share extension now reports errors when saving a document fails, instead of only briefly flashing a warning icon. If your login has expired it says so and tells you to sign in again in the app
 - Permission errors now say which operation was refused, e.g. "Delete not permitted" instead of a generic access error, and name the affected item in the error details
 - Pulling to refresh on a document now also refreshes permissions, so a permission change on the server takes effect without restarting the app
 - Starting the app before your permissions have loaded, for example while offline, no longer looks like you have no permissions: lists and documents stay usable instead of showing "Insufficient permissions"

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -6,3 +6,4 @@
 - Sharing a document link now shares the web interface URL, which opens in a browser, instead of the API URL that did not
 - Permission errors now say which operation was refused, e.g. "Delete not permitted" instead of a generic access error, and name the affected item in the error details
 - Pulling to refresh on a document now also refreshes permissions, so a permission change on the server takes effect without restarting the app
+- Starting the app before your permissions have loaded, for example while offline, no longer looks like you have no permissions: lists and documents stay usable instead of showing "Insufficient permissions"

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -4,3 +4,4 @@
 - The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.
 - OIDC logins now support TOTP (two-factor authentication) codes from Paperless-ngx
 - Sharing a document link now shares the web interface URL, which opens in a browser, instead of the API URL that did not
+- Permission errors now say which operation was refused, e.g. "Delete not permitted" instead of a generic access error, and name the affected item in the error details

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -64,6 +64,20 @@ class DocumentDetailModel {
     self.document = document
   }
 
+  /// Permissions live in `ui_settings`, which the detail view never fetches on
+  /// its own: without this, a permission change on the server doesn't reach the
+  /// edit/delete affordances on this screen until the next launch or list
+  /// refresh. Pulled in on refresh alongside the document itself. Fails soft
+  /// like the other loads here — a stale permission set is better than a toast
+  /// over the document.
+  func refreshPermissions() async {
+    do {
+      try await store.fetchUISettings()
+    } catch {
+      Logger.shared.error("Error refreshing UI settings from document detail: \(error)")
+    }
+  }
+
   func loadMetadata() async {
     do {
       metadata = try await store.repository.metadata(documentId: document.id)

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -208,10 +208,12 @@ class DocumentListViewModel {
     }
   }
 
-  func refresh(filter: FilterState? = nil, retain: Bool = false) async throws -> [Document] {
+  func refresh(filter: FilterState? = nil, retain: Bool = false, userInitiated: Bool = false)
+    async throws -> [Document]
+  {
     inFlight += 1
     defer { inFlight -= 1 }
-    try await store.fetchAll()
+    try await store.fetchAll(userInitiated: userInitiated)
 
     if let filter {
       filterState = filter

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -213,7 +213,7 @@ class DocumentListViewModel {
   {
     inFlight += 1
     defer { inFlight -= 1 }
-    try await store.fetchAll(userInitiated: userInitiated)
+    try await store.sync(userInitiated: userInitiated)
 
     if let filter {
       filterState = filter

--- a/swift-paperless/ViewModel/LoginViewModel.swift
+++ b/swift-paperless/ViewModel/LoginViewModel.swift
@@ -722,7 +722,7 @@ class LoginViewModel {
     // failure here (server too old, transient error, missing scope) just
     // leaves friendlyName nil and the existing subscription path will fill
     // it in later. The server settings are already fetched once during
-    // refreshConnection -> store.fetchAll(); this just front-loads the
+    // refreshConnection -> store.sync(); this just front-loads the
     // request so the DB sees the value immediately.
     let friendlyName: String? = await {
       do {

--- a/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
@@ -129,7 +129,7 @@ struct DocumentMetadataView: View {
       }
     }
     .task {
-      try? await store.fetchAll()
+      try? await store.sync()
       document = try? await store.document(id: 1)
       if let document {
         metadata = try? await store.repository.metadata(documentId: document.id)

--- a/swift-paperless/Views/Document/Detail/ShareLinkView.swift
+++ b/swift-paperless/Views/Document/Detail/ShareLinkView.swift
@@ -248,7 +248,7 @@ private struct CreateShareLinkView: View {
 
 #Preview {
   @Previewable
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
 
   @Previewable
   @StateObject var errorController = ErrorController()

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -1034,7 +1034,7 @@ private struct DocumentDetailViewV4PreviewHelper: View {
           )
         )
 
-        try await store.fetchAll()
+        try await store.sync()
         let documents = try await store.repository.documents(filter: .default).fetch(limit: 100_000)
         let firstDocument = documents.first
         if var firstDocument {

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -667,7 +667,8 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       let model = viewModel
       async let document: () = model.loadDocument()
       async let metadata: () = model.loadMetadata()
-      _ = await (document, metadata)
+      async let permissions: () = model.refreshPermissions()
+      _ = await (document, metadata, permissions)
     }
     .safeAreaInset(edge: .bottom) {
       metadataBar

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -946,7 +946,7 @@ extension Tag {
 }
 
 private struct DocumentDetailViewV4PreviewHelper: View {
-  @State private var store = DocumentStore(repository: TransientRepository())
+  @State private var store = DocumentStore.preview(TransientRepository())
   @StateObject private var errorController = ErrorController()
   @State private var connectionManager = ConnectionManager(
     database: try! Database.inMemory(), previewMode: true)
@@ -978,9 +978,7 @@ private struct DocumentDetailViewV4PreviewHelper: View {
     .environment(RouteManager())
     .task {
       do {
-        guard let repository = store.repository as? TransientRepository else {
-          return
-        }
+        let repository = store.previewRepository(as: TransientRepository.self)
         repository.addUser(User(id: 1, isSuperUser: true, username: "preview", groups: []))
         try repository.login(userId: 1)
 

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -229,12 +229,13 @@ struct DocumentList: View {
 
   func refresh() async {
     do {
-      let documents = try await viewModel.refresh()
+      let documents = try await viewModel.refresh(userInitiated: true)
       withAnimation {
         viewModel.replace(documents: documents)
       }
     } catch {
       Logger.shared.error("Error refreshing documents: \(error)")
+      errorController.push(error: error)
     }
   }
 

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -15,7 +15,7 @@ import os
 
 struct LoadingDocumentList: View {
   @State private var documents: [Document] = []
-  @State private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore.preview()
 
   var body: some View {
     List {

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -765,7 +765,7 @@ struct DocumentView: View {
 // - MARK: Previews
 
 #Preview("DocumentView") {
-  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -731,7 +731,7 @@ struct DocumentView: View {
 
     .task {
       do {
-        async let fetch: Void = store.fetchAll()
+        async let fetch: Void = store.sync()
 
         (isDataScannerAvailable, isDocumentScannerAvailable) = await (
           DataScannerView.isAvailable, DocumentScannerView.isAvailable

--- a/swift-paperless/Views/Document/FilterAssembly.swift
+++ b/swift-paperless/Views/Document/FilterAssembly.swift
@@ -117,7 +117,7 @@ struct FilterAssembly: View {
 @available(iOS 26.0, *)
 #Preview {
   @Previewable @State var filterModel = FilterModel()
-  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())

--- a/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
+++ b/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
@@ -98,7 +98,7 @@ struct FilterAssemblyiOS18: View {
 
 #Preview {
   @Previewable @State var filterModel = FilterModel()
-  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())

--- a/swift-paperless/Views/Filter/CustomFieldFilterView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldFilterView.swift
@@ -974,7 +974,7 @@ private let customFields = [
 ]
 
 private struct PreviewHelper<C: View>: View {
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
 
   @State var show = false
 
@@ -1014,7 +1014,7 @@ private struct PreviewHelper<C: View>: View {
     }
     .task {
       do {
-        let repository = store.repository as! TransientRepository
+        let repository = store.previewRepository(as: TransientRepository.self)
         repository.addUser(
           User(id: 1, isSuperUser: false, username: "user", groups: [1]))
         try? repository.login(userId: 1)

--- a/swift-paperless/Views/Filter/CustomFieldFilterView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldFilterView.swift
@@ -1021,7 +1021,7 @@ private struct PreviewHelper<C: View>: View {
         for field in customFields {
           _ = try await repository.add(customField: field)
         }
-        try await store.fetchAll()
+        try await store.sync()
         await addDocuments()
 
         show = true

--- a/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
@@ -247,7 +247,7 @@ private struct PreviewHelper<C: View>: View {
         for field in customFields {
           _ = try await repository.add(customField: field)
         }
-        try await store.fetchAll()
+        try await store.sync()
         await addDocuments()
 
         show = true

--- a/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
@@ -198,7 +198,7 @@ private let customFields = [
 ]
 
 private struct PreviewHelper<C: View>: View {
-  @State var store = DocumentStore(repository: TransientRepository())
+  @State var store = DocumentStore.preview(TransientRepository())
 
   @State var show = false
 
@@ -240,7 +240,7 @@ private struct PreviewHelper<C: View>: View {
     }
     .task {
       do {
-        let repository = store.repository as! TransientRepository
+        let repository = store.previewRepository(as: TransientRepository.self)
         repository.addUser(
           User(id: 1, isSuperUser: false, username: "user", groups: [1]))
         try? repository.login(userId: 1)

--- a/swift-paperless/Views/Filter/FilterBar.swift
+++ b/swift-paperless/Views/Filter/FilterBar.swift
@@ -959,7 +959,7 @@ private let customFields = [
 ]
 
 #Preview {
-  @Previewable @State var store = DocumentStore(repository: TransientRepository())
+  @Previewable @State var store = DocumentStore.preview(TransientRepository())
   @Previewable @State var filterModel = FilterModel()
   @Previewable @StateObject var errorController = ErrorController()
 
@@ -978,7 +978,7 @@ private let customFields = [
   }
   .task {
     do {
-      let repository = store.repository as! TransientRepository
+      let repository = store.previewRepository(as: TransientRepository.self)
       repository.addUser(
         User(id: 1, isSuperUser: false, username: "user", groups: [1]))
       try? repository.login(userId: 1)

--- a/swift-paperless/Views/Filter/FilterBar.swift
+++ b/swift-paperless/Views/Filter/FilterBar.swift
@@ -991,7 +991,7 @@ private let customFields = [
       _ = try await store.create(documentType: ProtoDocumentType(name: "Test Document Type"))
       _ = try await store.create(storagePath: ProtoStoragePath(name: "Test Storage Path"))
 
-      try await store.fetchAll()
+      try await store.sync()
       try await store.repository.create(
         document: ProtoDocument(title: "blubb"),
         file: #URL("http://example.com"), filename: "blubb.pdf"

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -110,7 +110,7 @@ struct SettingsView: View {
       }
     }
     .task {
-      await checked { try await store.fetchAll() }
+      await checked { try await store.sync() }
     }
   }
 

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -110,7 +110,7 @@ struct SettingsView: View {
       }
     }
     .task {
-      await checked(store.fetchAll)
+      await checked { try await store.fetchAll() }
     }
   }
 

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -298,7 +298,7 @@ struct SettingsView: View {
 }
 
 #Preview("SettingsView") {
-  @Previewable @State var store = DocumentStore(repository: PreviewRepository())
+  @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
   @Previewable @State var database = try! Database.inMemory()
   @Previewable @State var connectionManager = ConnectionManager(

--- a/swift-paperless/Views/Tasks/TasksView.swift
+++ b/swift-paperless/Views/Tasks/TasksView.swift
@@ -525,7 +525,7 @@ private struct TaskList: View {
 // MARK: - Previews
 
 private struct PreviewHelperView<Content: View>: View {
-  @State private var store = DocumentStore(repository: PreviewRepository())
+  @State private var store = DocumentStore.preview()
 
   @ViewBuilder var content: () -> Content
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -170,7 +170,7 @@ struct MainView: View {
         await sleep(.seconds(0.3))
         store.set(repository: repository)
         storeReady = true
-        try? await store.fetchAll()
+        try? await store.sync()
         store.startTaskPolling()
         await sleep(.seconds(0.3))
         showLoadingScreen = false
@@ -179,7 +179,7 @@ struct MainView: View {
         store = newStore
         observeFriendlyName(on: newStore)
         storeReady = true
-        try? await newStore.fetchAll()
+        try? await newStore.sync()
         newStore.startTaskPolling()
         showLoadingScreen = false
       }


### PR DESCRIPTION
This pull request introduces several improvements to the `DocumentStore` and `CachingRepository` to enhance data synchronization, permission enforcement, and preview/testability. The main changes ensure that network syncs are coalesced, permission checks are enforced for all mutations, and preview stores can be more easily constructed for testing. Additionally, the UI settings now gate which collections are fetched during sync, and localization strings for "Tap for details!" have been simplified.

### Data Synchronization and Performance

* Added a `syncTask` to `DocumentStore` to ensure that concurrent sync requests join a single in-flight network sync, preventing redundant network calls and improving efficiency (`DocumentStore.swift`) [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R88-R94) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L282-R324) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R341-R373).
* The UI settings permission matrix is now fetched first in `CachingRepository.syncElements()`, gating which collections are fetched based on user permissions. If fetching UI settings fails, the sync falls back to cached permissions or fetches all collections as before (`CachingRepository.swift`) [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR72-R130) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL124-R162).

### Permission Enforcement

* All create, update, and delete operations in `DocumentStore` now require explicit permission checks for the relevant resource before proceeding, ensuring that only authorized actions are performed (`DocumentStore.swift`) [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R383-R387) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R398-R410) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R427-R462) [[4]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R471-R493) [[5]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R546-R554) [[6]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R563-R579).

### Preview/Testability

* Added a `preview(_:)` static method and `previewRepository(as:)` instance method to `DocumentStore`, allowing for easy construction of a preview store with an in-memory seeded database for UI previews and testing (`DocumentStore+Preview.swift`).
* Exposed the wrapped repository in `CachingRepository` for better testability (`CachingRepository.swift`).

### Logging and Safety

* Improved logging and added a safety check in `DocumentStore.set(repository:)` to warn if a non-caching repository is installed while the app is live, preventing UI from silently emptying due to detachment from the database (`DocumentStore.swift`).

### Localization

* Simplified the "Tap for details!" localization string to just "Details" (and equivalents in other languages), making the UI more concise (`App.xcstrings`).

---

## Manual test checklist

Derived from a pass over all 17 commits in this PR. Nothing here has been driven in a
simulator or on device; `AppShared` has no test target, so none of it has automated
coverage either.

### Element mutations under restricted permissions — *new in this PR*

Document and note mutations were already permission-checked on `main`; this PR extends
that to the five element types, so any mistake shows up as a previously-working action
that now refuses.

- [x] On a **non-superuser account with mixed permissions**, create / rename / delete a **tag** — permitted operations still work, denied ones fail with a permission message rather than a generic error
- [x] Same for **correspondent**, **document type**, **storage path**
- [x] Same for **saved view** (create, update, delete — including the visibility handling on create)
- [x] The inline-creation paths specifically: "+" in the tag picker, and the correspondent / document-type / storage-path edit sheets on a document

### Permission errors name the operation — *added after the first test pass*

A refusal used to read "No access: Storage path" whichever operation was attempted, and a
server-side 403 didn't even say that much ("The request was denied due to missing
permissions"). Both now surface as a `PermissionsError` naming the operation. The toast
message is one line with tail truncation, so the operation is the *title* and the resource
moved into the details.

- [x] A refused **delete** of a storage path toasts **"Delete not permitted"**, and **Details** names the resource ("… not allowed to delete Storage path"); check a refused **create** and **edit** too
- [x] The title **fits on one line** without truncation — including one longer non-English locale if you have one handy
- [x] The same wording appears for a **server-side 403** — an element the account can list but not modify (object-level permissions), where the client-side matrix says the operation is allowed. The backend's own message is appended under **Details**
- [x] **Document** and **note** mutations (delete document, add / delete note) still surface their failures, now with the operation named
- [x] Spot-check one non-English locale: the eight new strings are English-only until Crowdin runs, so they should fall back rather than show a key
- [x] *Known, not fixed here:* after a **failed** delete in a manage list the row stays hidden until you refresh — [#665](https://github.com/paulgessinger/swift-paperless/issues/665)

### Permissions refresh on document detail — *added after the first test pass*

The detail view's pull-to-refresh reloaded the document and its metadata but never
`ui_settings`, so a permission change on the server didn't reach that screen until the next
launch or list refresh.

- [x] Open a document, change the account's permissions server-side, **pull to refresh** on the document — the edit / delete affordances follow the new permissions without restarting the app
- [x] The refresh still loads document and metadata as before, and a failed `ui_settings` fetch logs without toasting over the document

### Cold start and offline permission hydration — *highest risk, fixed after the first test pass*

Confirmed during testing: an offline cold start read as **"no permissions"** everywhere,
because `permissions` was `.empty` until `ui_settings` landed and `.empty` tests false for
everything. `ElementStore.isHydrated` existed to tell "loading" from "denied" and had no
readers (ledger [#664](https://github.com/paulgessinger/swift-paperless/issues/664)).

Now `DocumentStore.permissions` hands out **`.full`** until `permissionsKnown`, so gates
fall through to the request and the server decides. Two places still consult the flag:
`userCan*(document:)` (which also depend on `currentUser`, nil while unhydrated) and
`PermissionsView`, which *displays* the matrix and must not report access the server never
granted.

- [x] **First-ever launch against a server while offline** (use the debug **Clear Cached Data** action from #600 to reproduce, which keeps servers and wipes the caches): lists and documents stay usable, nothing reads as "Insufficient permissions"
- [x] **Relaunch offline with a warm cache**: elements still populate from the DB and mutations are still permitted per the cached matrix
- [x] **Settings → server → Permissions during a cold start**: every cell shows **?**, with the "not loaded" note — *not* an all-green matrix. Copy summary is prefixed with `(not loaded from server; assuming full access)`
- [x] Once `ui_settings` arrives the matrix flips to the real values, and a genuinely denied screen shows its lock again
- [x] *Behaviour change:* create / edit / delete affordances are now **enabled** during a cold start instead of greyed out. Offline, using one should fail with a **connectivity** error, not a permission error
- [x] The document detail no longer claims "you don't have global change permission" while permissions are still loading

### Permission-gated sync

`syncElements()` now fetches `ui_settings` first and skips collections the matrix says the
user can't view.

- [x] Log in as an account **without `view` on users/groups** and confirm tags, correspondents, document types, storage paths and saved views still populate (this is ledger #656 item 4's check — the gating it depends on is added here)
- [x] Confirm the permissions editor's owner / view / edit pickers still list users and groups on an account that *is* allowed to see them

### Share Extension — *now DB-cached and needs-auth wrapped*

It previously ran on a bare `ApiRepository`; it's now `CachingRepository(NeedsAuthRepository(ApiRepository))`, so element data comes from its own cache and 401s are intercepted.

- [x] Share a file from another app: tag / correspondent / document type / storage path pickers populate
- [x] Create a **new tag** from inside the extension and confirm the document saves with it
- [x] With an **expired or invalid token**, confirm the extension surfaces re-auth instead of failing opaquely — this interception didn't exist here before
- [x] *Expected, not a bug:* an element created in the extension does **not** reach an already-running app until the next **successful** foreground sync (ledger #656 item 13)

### Error presentation

- [x] Open **Settings**, trigger an error, tap **Details** on the toast — the alert appears **above** the sheet and the sheet stays open. Previously presenting it tore the sheet down
- [x] The toast action now reads **"Details"** (was "Tap for details!") and the generic title **"Unexpected error"** (was "An unexpected error occurred") — spot-check one non-English locale

### Sync behaviour

- [x] **Pull-to-refresh while offline** on the document list now raises an error toast; it was silently swallowed before
- [x] Opening the **users/groups pickers** or the **custom fields** screen while offline no longer toasts — these were mislabeled as user-initiated and now fail soft
- [x] Launch fires **one** element sync rather than several — `Joining in-flight element sync` should appear in the log for the callers that piggy-back
- [x] **Connection switch mid-sync:** with two servers configured, start a sync against a slow or unreachable one and switch while it's still running. The new server's elements should populate on the switch, not only after a later foreground or pull-to-refresh
- [x] Interrupt a **pull-to-refresh** with a connection switch — no error toast should appear

### Extra headers on a live connection

- [x] Edit extra headers on the active connection and confirm tags/correspondents/etc. survive (ledger #656 item 6, never verified; this PR adds the fault log that would catch a regression)

### Xcode previews

- [x] `FilterBar` preview shows the Inbox tag, correspondent, document type and storage path
- [x] Spot-check one or two other `TransientRepository`-backed previews (e.g. `TagFilterView`, `TrashView`)

### Baseline smoke

- [x] Fresh install → login → every element collection populates
- [x] Force-quit and relaunch **offline** → elements still shown from the cache


<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)  👈
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->



