### PR TITLE
feat: Document cache source-of-truth

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -113,6 +113,14 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var syncTask: Task<Void, Error>?
 
+  // Last successful (or attempted) remote-delete reconcile. The sweep fetches
+  // the server's whole id set, so it is throttled — `sync()` kicks it
+  // fire-and-forget on launch/foreground/refresh, but it only runs at most once
+  // per `reconcileThrottle` unless user-initiated.
+  @ObservationIgnored
+  private var lastDocumentReconcile: Date?
+  private let reconcileThrottle: TimeInterval = 300
+
   // MARK: Methods
 
   public init(repository: some Repository) {
@@ -356,6 +364,10 @@ public final class DocumentStore: Sendable {
       try await runSyncElements()
       lastSyncError = nil
       Logger.shared.info("Sync store complete")
+      // Reconcile remote deletes alongside the element sync (throttled,
+      // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
+      let userInitiated = userInitiated
+      Task { [weak self] in await self?.reconcileDocuments(userInitiated: userInitiated) }
     } catch {
       // A cancellation is never the user's problem to see: either the caller's
       // own task went away, or `set(repository:)` retired this sync on a
@@ -695,6 +707,24 @@ extension DocumentStore {
   ) -> AsyncThrowingStream<QueryStatus, Error> {
     guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
     return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
+  }
+
+  /// Throttled remote-delete reconcile: drop cached documents that no longer
+  /// exist on the server (so they disappear from every offline list). Soft-fail
+  /// (background); kicked from `sync()`. `userInitiated` bypasses the throttle.
+  public func reconcileDocuments(userInitiated: Bool = false) async {
+    guard let backend = repository as? any CachingBackend else { return }
+    if !userInitiated, let last = lastDocumentReconcile,
+      Date().timeIntervalSince(last) < reconcileThrottle
+    {
+      return
+    }
+    lastDocumentReconcile = Date()
+    do {
+      try await backend.reconcileDocumentDeletions()
+    } catch {
+      Logger.shared.info("Document reconcile failed (suppressed): \(error)")
+    }
   }
 
   /// Live single document by id, for detail/preview surfaces that must repaint on

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -663,6 +663,14 @@ public final class DocumentStore: Sendable {
 /// `NullRepository` before login) the observations are empty, finished streams
 /// and `fillDocumentQuery` throws.
 extension DocumentStore {
+  /// The stable key for a list query, computed without touching the network, so
+  /// the list can subscribe to whatever is already cached (offline-first) before
+  /// — or independently of — the network fill. `nil` without a caching backend.
+  public func documentQueryKey(filter: FilterState) -> QueryKey? {
+    guard let backend = repository as? any CachingBackend else { return nil }
+    return QueryKey(serverID: backend.serverID, filter: filter)
+  }
+
   /// Eager full-fill of a list: await page 1 + count, then background-page the
   /// rest. The returned handle carries the `QueryKey` the list then observes.
   public func fillDocumentQuery(filter: FilterState) async throws -> QueryFillHandle {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -20,8 +20,6 @@ import os
 public final class DocumentStore: Sendable {
   // MARK: Observed state
 
-  public private(set) var documents: [UInt: Document] = [:]
-
   public private(set) var tasks: [PaperlessTask] = []
 
   /// The live element projection (DB → typed `ValueObservation`). The store owns
@@ -180,16 +178,13 @@ public final class DocumentStore: Sendable {
     taskUpdateTask = Task(operation: taskPoller)
   }
 
-  public func clearDocuments() {
-    documents = [:]
-  }
-
   public func clear() {
-    documents = [:]
     tasks = []
     lastSyncError = nil
-    // The element projection is owned by `elementStore` and (re)wired by
-    // `wireElementStore()` on repository change — nothing to clear here.
+    // Documents are not held in memory under source-of-truth — the list observes
+    // the DB directly (see the document-cache surface below). The element
+    // projection is owned by `elementStore` and (re)wired by `wireElementStore()`
+    // on repository change — nothing to clear here.
   }
 
   public func set(repository: some Repository, reload: Bool = true) {
@@ -269,8 +264,9 @@ public final class DocumentStore: Sendable {
         }
       }
 
+      // The repository write-throughs the confirmed value to the DB; the list/detail
+      // observations repaint it in place (no in-memory dict to update).
       let updated = try await repository.update(document: document)
-      documents[updated.id] = updated
       events.emit(.changeReceived(document: updated))
       return updated
     }
@@ -279,8 +275,9 @@ public final class DocumentStore: Sendable {
   public func deleteDocument(_ document: Document) async throws {
     Logger.shared.info("Deleting document with ID \(document.id, privacy: .public)")
     try await performing(.delete, on: .document) {
+      // The repository write-throughs the delete to the DB; the FK cascade removes
+      // it from every cached query_order and the observations repaint.
       try await repository.delete(document: document)
-      documents.removeValue(forKey: document.id)
       events.emit(.deleted(document: document))
     }
   }
@@ -655,6 +652,52 @@ public final class DocumentStore: Sendable {
       Logger.api.debug("No permissions for \(operation.description) on \(resource.rawValue)")
       throw PermissionsError(resource: resource, operation: operation)
     }
+  }
+}
+
+// MARK: - Document cache surface (Stage 8)
+
+/// The GRDB-free surface the document list and detail views reach for. Each
+/// method resolves the active `CachingBackend` (the production/preview stack) and
+/// forwards to its `(database, serverID)`; without a caching backend (e.g.
+/// `NullRepository` before login) the observations are empty, finished streams
+/// and `fillDocumentQuery` throws.
+extension DocumentStore {
+  /// Eager full-fill of a list: await page 1 + count, then background-page the
+  /// rest. The returned handle carries the `QueryKey` the list then observes.
+  public func fillDocumentQuery(filter: FilterState) async throws -> QueryFillHandle {
+    guard let backend = repository as? any CachingBackend else {
+      throw CachingRepositoryError.cacheMiss
+    }
+    return try await backend.fillQuery(filter: filter)
+  }
+
+  /// Live growing-prefix of a cached query's ordered answer (the list's data).
+  public func observeDocumentPrefix(
+    queryKey: QueryKey, limit: Int
+  ) -> AsyncThrowingStream<[Document], Error> {
+    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    return backend.database.observeDocumentPrefix(
+      queryKey: queryKey, serverID: backend.serverID, limit: limit)
+  }
+
+  /// Live status of a cached query (scrollbar count, order-stale flag).
+  public func observeQueryStatus(
+    queryKey: QueryKey
+  ) -> AsyncThrowingStream<QueryStatus, Error> {
+    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
+  }
+
+  /// Live single document by id, for detail/preview surfaces that must repaint on
+  /// mutation/sync.
+  public func observeDocument(id: UInt) -> AsyncThrowingStream<Document?, Error> {
+    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    return backend.database.observeDocument(serverID: backend.serverID, id: id)
+  }
+
+  private static func emptyStream<T: Sendable>() -> AsyncThrowingStream<T, Error> {
+    AsyncThrowingStream { $0.finish() }
   }
 }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -186,13 +186,15 @@ public final class DocumentStore: Sendable {
     taskUpdateTask = Task(operation: taskPoller)
   }
 
-  public func clear() {
+  /// Drop the per-server state this store still holds in memory, on a repository
+  /// swap. That is only the task list and the last sync error now: documents
+  /// aren't held in memory under source-of-truth (the list observes the DB
+  /// directly), and the element projection is owned by `elementStore` and
+  /// re-pointed by `wireElementStore()`. `private` because `set(repository:)` is
+  /// the one caller — a swap is the only moment this is the right thing to do.
+  private func clear() {
     tasks = []
     lastSyncError = nil
-    // Documents are not held in memory under source-of-truth — the list observes
-    // the DB directly (see the document-cache surface below). The element
-    // projection is owned by `elementStore` and (re)wired by `wireElementStore()`
-    // on repository change — nothing to clear here.
   }
 
   public func set(repository: some Repository, reload: Bool = true) {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -739,6 +739,28 @@ extension DocumentStore {
   private static func emptyStream<T: Sendable>() -> AsyncThrowingStream<T, Error> {
     AsyncThrowingStream { $0.finish() }
   }
+
+  /// Debug / maintenance: wipe *all* locally cached data — the GRDB element +
+  /// document caches, the downloaded PDF/thumbnail blobs, the in-memory and
+  /// on-disk image caches, and the per-server delta watermarks — while keeping
+  /// the configured server connections. The live observations repaint empty
+  /// immediately; the next sync / list open refills from the network.
+  public func wipeLocalCache() throws {
+    if let backend = repository as? any CachingBackend {
+      try backend.database.clearCache()
+    }
+    // Downloaded originals/archives/thumbnails (app-group blob store). Rooted at
+    // the app group, so a fresh handle addresses the same files the repository
+    // wrote — no need to reach into the active repository.
+    if let contentStore = try? ContentStore() {
+      try? contentStore.purge()
+    }
+    // Nuke memory + disk image cache.
+    imagePipeline.cache.removeAll()
+    // Per-server changed-metadata delta watermarks (regenerable sync state):
+    // clear them so the reconcile re-baselines over the now-empty cache.
+    DocumentDeltaWatermark.clearAll()
+  }
 }
 
 //// Permissions checking for resources

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -721,7 +721,9 @@ extension DocumentStore {
     }
     lastDocumentReconcile = Date()
     do {
+      // Deletes first (correctness), then the changed-metadata delta (freshness).
       try await backend.reconcileDocumentDeletions()
+      try await backend.reconcileDocumentChanges()
     } catch {
       Logger.shared.info("Document reconcile failed (suppressed): \(error)")
     }

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -703,7 +703,7 @@ extension DocumentStore {
       queryKey: queryKey, serverID: backend.serverID, limit: limit)
   }
 
-  /// Live status of a cached query (scrollbar count, order-stale flag).
+  /// Live status of a cached query (server total, order-stale flag).
   public func observeQueryStatus(
     queryKey: QueryKey
   ) -> AsyncThrowingStream<QueryStatus, Error> {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -48,6 +48,13 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// falls back to whatever is already cached).
   func fillQuery(filter: FilterState) async throws -> QueryFillHandle
 
+  /// Remote-delete reconcile (R2): fetch the server's authoritative live id set
+  /// and drop every cached document absent from it — the FK cascade removes them
+  /// from every cached query_order. No-op when nothing is cached. Paperless has
+  /// no deletion feed, so this periodic sweep is how deletes (and trashings)
+  /// disappear locally.
+  func reconcileDocumentDeletions() async throws
+
   /// The shared database and the active server this repository caches into.
   /// `DocumentStore` reads these to point its `ElementStore` projection at the
   /// same `(database, serverID)` the writes land in, so the live observation
@@ -470,6 +477,25 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
   public func documents(filter: FilterState) throws -> Wrapped.Documents {
     try wrapped.documents(filter: filter)
+  }
+
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    try await wrapped.documentIDs(filter: filter)
+  }
+
+  public func reconcileDocumentDeletions() async throws {
+    let localIDs = try database.allDocumentIDs(serverID: serverID)
+    // Nothing cached yet → nothing to reconcile (skip the id fetch entirely).
+    guard !localIDs.isEmpty else { return }
+
+    // The unfiltered list is the complete live id set for the server.
+    let serverIDs = Set(try await wrapped.documentIDs(filter: .empty))
+    let removed = localIDs.subtracting(serverIDs)
+    guard !removed.isEmpty else { return }
+
+    Logger.shared.info(
+      "Reconcile: dropping \(removed.count, privacy: .public) remotely-deleted documents")
+    try database.deleteDocuments(serverID: serverID, removedIDs: Array(removed))
   }
 
   public func nextAsn() async throws -> UInt {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -594,14 +594,19 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try await wrapped.nextAsn()
   }
 
+  /// The version id a document's file-metadata caches under. Both fallbacks
+  /// land on the document id, which equals the root version id server-side: the
+  /// cached row may be absent (nothing fetched it yet) and the read itself may
+  /// fail. In practice the detail view fetches the document first, so the
+  /// versions are usually known by the time this is called.
+  private func fileMetadataVersionID(documentId: UInt) -> UInt {
+    (try? database.document(serverID: serverID, id: documentId))?.currentVersionID ?? documentId
+  }
+
   public func metadata(documentId: UInt) async throws -> Metadata {
     // File-metadata is immutable per file version, so it caches under the
-    // document's current version id (fallback: the document id, which equals the
-    // root version id server-side). The detail view fetches the document first,
-    // so the cached row's versions are usually known by the time we get here.
-    let versionID =
-      (try? database.document(serverID: serverID, id: documentId))?.currentVersionID
-      ?? documentId
+    // document's current version id.
+    let versionID = fileMetadataVersionID(documentId: documentId)
     do {
       let fetched = try await wrapped.metadata(documentId: documentId)
       try database.setFileMetadata(fetched, serverID: serverID, versionID: versionID)

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -595,21 +595,56 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   }
 
   public func metadata(documentId: UInt) async throws -> Metadata {
-    try await wrapped.metadata(documentId: documentId)
+    // File-metadata is immutable per file version, so it caches under the
+    // document's current version id (fallback: the document id, which equals the
+    // root version id server-side). The detail view fetches the document first,
+    // so the cached row's versions are usually known by the time we get here.
+    let versionID =
+      (try? database.document(serverID: serverID, id: documentId))?.currentVersionID
+      ?? documentId
+    do {
+      let fetched = try await wrapped.metadata(documentId: documentId)
+      try database.setFileMetadata(fetched, serverID: serverID, versionID: versionID)
+      return fetched
+    } catch {
+      if let cached = try database.fileMetadata(serverID: serverID, versionID: versionID) {
+        Logger.shared.info("metadata(documentId:) network failed (\(error)); serving cached")
+        return cached
+      }
+      throw error
+    }
   }
 
   public func notes(documentId: UInt) async throws -> [Document.Note] {
-    try await wrapped.notes(documentId: documentId)
+    do {
+      let fetched = try await wrapped.notes(documentId: documentId)
+      try database.setNotes(fetched, serverID: serverID, documentID: documentId)
+      return fetched
+    } catch {
+      // `nil` (never cached) is distinct from `[]` (cached, no notes): only the
+      // former propagates the network error.
+      if let cached = try database.notes(serverID: serverID, documentID: documentId) {
+        Logger.shared.info("notes(documentId:) network failed (\(error)); serving cached")
+        return cached
+      }
+      throw error
+    }
   }
 
   public func createNote(documentId: UInt, note: ProtoDocument.Note) async throws
     -> [Document.Note]
   {
-    try await wrapped.createNote(documentId: documentId, note: note)
+    // Pessimistic: the server returns the updated full list, which we write
+    // through so the cached notes stay consistent without a re-fetch.
+    let updated = try await wrapped.createNote(documentId: documentId, note: note)
+    try database.setNotes(updated, serverID: serverID, documentID: documentId)
+    return updated
   }
 
   public func deleteNote(id: UInt, documentId: UInt) async throws -> [Document.Note] {
-    try await wrapped.deleteNote(id: id, documentId: documentId)
+    let updated = try await wrapped.deleteNote(id: id, documentId: documentId)
+    try database.setNotes(updated, serverID: serverID, documentID: documentId)
+    return updated
   }
 
   public func shareLinks(documentId: UInt) async throws -> [DataModel.ShareLink] {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -184,7 +184,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     let source = try wrapped.documents(filter: filter)
     let pageSize = Endpoint.defaultDocumentPageSize
 
-    // Page 1 awaited: first window on screen + exact scrollbar count.
+    // Page 1 awaited: first window on screen + the exact total for the count pill.
     let firstPage = try await source.fetch(limit: pageSize)
     let total = await source.totalCount
     try database.writeQueryPage(

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -409,14 +409,24 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
   }
 
-  // MARK: - Documents (forwarded)
+  // MARK: - Documents (pessimistic write-through + cache fallback)
 
   public func update(document: Document) async throws -> Document {
-    try await wrapped.update(document: document)
+    let updated = try await wrapped.update(document: document)
+    // Write the confirmed metadata through; the join observation repaints the row
+    // in place. Written at `.metadata` so the non-downgrade guard preserves an
+    // existing Tier-2 row's detail/permissions (a metadata edit doesn't change
+    // them; permissions edits reconcile on the next detail fetch). Ordering under
+    // the active sort isn't recomputed offline — mark affected queries stale.
+    try database.upsertDocument(updated, serverID: serverID, projectionLevel: .metadata)
+    try database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
+    return updated
   }
 
   public func delete(document: Document) async throws {
     try await wrapped.delete(document: document)
+    // FK cascade removes it from every cached query_order.
+    try database.deleteDocuments(serverID: serverID, removedIDs: [document.id])
   }
 
   public func create(document: ProtoDocument, file: URL, filename: String) async throws {
@@ -424,11 +434,38 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   }
 
   public func document(id: UInt) async throws -> Document? {
-    try await wrapped.document(id: id)
+    do {
+      guard let fetched = try await wrapped.document(id: id) else {
+        // Gone on the server — drop from cache (cascade clears its query_order).
+        try database.deleteDocuments(serverID: serverID, removedIDs: [id])
+        return nil
+      }
+      // A full-detail fetch — upgrade the row to Tier-2.
+      try database.upsertDocument(fetched, serverID: serverID, projectionLevel: .detail)
+      return fetched
+    } catch {
+      // Offline/transient: serve the last-known cached row (Tier-1 or Tier-2)
+      // rather than failing the open. Mirrors the element offline-first policy.
+      if let cached = try database.document(serverID: serverID, id: id) {
+        Logger.shared.info("document(id:) network failed (\(error)); serving cached")
+        return cached
+      }
+      throw error
+    }
   }
 
   public func document(asn: UInt) async throws -> Document? {
-    try await wrapped.document(asn: asn)
+    do {
+      guard let fetched = try await wrapped.document(asn: asn) else { return nil }
+      try database.upsertDocument(fetched, serverID: serverID, projectionLevel: .detail)
+      return fetched
+    } catch {
+      if let cached = try database.document(serverID: serverID, asn: asn) {
+        Logger.shared.info("document(asn:) network failed (\(error)); serving cached")
+        return cached
+      }
+      throw error
+    }
   }
 
   public func documents(filter: FilterState) throws -> Wrapped.Documents {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -40,6 +40,14 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// resource the user lacks permission for is skipped, not fatal.
   func syncElements() async throws
 
+  /// Eager full-fill of a document list (Stage 8 v1): await page 1 (so the first
+  /// window + an exact count land synchronously), write it as the query's order,
+  /// then background-page the rest of the query to the cache. The returned
+  /// ``QueryFillHandle`` carries the `QueryKey` the list observes and a cancel
+  /// handle for the in-flight fill. Throws if page 1 fails (offline → the list
+  /// falls back to whatever is already cached).
+  func fillQuery(filter: FilterState) async throws -> QueryFillHandle
+
   /// The shared database and the active server this repository caches into.
   /// `DocumentStore` reads these to point its `ElementStore` projection at the
   /// same `(database, serverID)` the writes land in, so the live observation
@@ -136,6 +144,44 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
       for try await _ in group {}
     }
+  }
+
+  public func fillQuery(filter: FilterState) async throws -> QueryFillHandle {
+    let key = QueryKey(serverID: serverID, filter: filter)
+    let source = try wrapped.documents(filter: filter)
+    let pageSize = Endpoint.defaultDocumentPageSize
+
+    // Page 1 awaited: first window on screen + exact scrollbar count.
+    let firstPage = try await source.fetch(limit: pageSize)
+    let total = await source.totalCount
+    try database.writeQueryPage(
+      queryKey: key, serverID: serverID, documents: firstPage,
+      startPosition: 0, totalCount: total, replaceAll: true, projectionLevel: .metadata)
+
+    // Background-page the rest to disk (append). When this completes the whole
+    // view is local; scrolling then needs no network (v1).
+    let database = database
+    let serverID = serverID
+    let firstCount = firstPage.count
+    let task = Task.detached(priority: .utility) {
+      var position = firstCount
+      do {
+        while !Task.isCancelled {
+          if await source.isExhausted { break }
+          let batch = try await source.fetch(limit: pageSize)
+          if batch.isEmpty { break }
+          try database.writeQueryPage(
+            queryKey: key, serverID: serverID, documents: batch,
+            startPosition: position, totalCount: await source.totalCount,
+            replaceAll: false, projectionLevel: .metadata)
+          position += batch.count
+        }
+      } catch is CancellationError {
+      } catch {
+        Logger.shared.error("Background query fill failed: \(error)")
+      }
+    }
+    return QueryFillHandle(queryKey: key, totalCount: total, fillTask: task)
   }
 
   private func syncCollection<R: ElementRecord>(

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -55,6 +55,11 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// disappear locally.
   func reconcileDocumentDeletions() async throws
 
+  /// Changed-metadata delta (R3δ): page `ordering=-modified` until older than the
+  /// per-server watermark and refresh the cached rows that changed. Keeps
+  /// already-cached documents fresh without re-opening their list.
+  func reconcileDocumentChanges() async throws
+
   /// The shared database and the active server this repository caches into.
   /// `DocumentStore` reads these to point its `ElementStore` projection at the
   /// same `(database, serverID)` the writes land in, so the live observation
@@ -496,6 +501,72 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     Logger.shared.info(
       "Reconcile: dropping \(removed.count, privacy: .public) remotely-deleted documents")
     try database.deleteDocuments(serverID: serverID, removedIDs: Array(removed))
+  }
+
+  // The number of changed documents one delta pass will apply before stopping
+  // (a runaway guard; the next pass continues from the advanced watermark).
+  private let deltaCap = 1000
+
+  public func reconcileDocumentChanges() async throws {
+    // Delta only refreshes already-cached metadata; new docs surface via list
+    // fills, not here. Nothing cached ⇒ nothing to refresh.
+    let localIDs = try database.allDocumentIDs(serverID: serverID)
+    guard !localIDs.isEmpty else { return }
+
+    var filter = FilterState.empty
+    filter.sortField = .modified
+    filter.sortOrder = .descending
+    let source = try wrapped.documents(filter: filter)
+
+    guard let watermark = deltaWatermark() else {
+      // First run: establish the baseline from the newest doc; subsequent passes
+      // delta against it. (Avoids re-paging the whole library on cold start.)
+      if let newest = try await source.fetch(limit: 1).first?.modified {
+        setDeltaWatermark(newest)
+      }
+      return
+    }
+
+    var changed: [Document] = []
+    var advanced = watermark
+    pageLoop: while changed.count < deltaCap {
+      let batch = try await source.fetch(limit: Endpoint.defaultDocumentPageSize)
+      if batch.isEmpty { break }
+      for document in batch {
+        guard let modified = document.modified else { continue }
+        // Sorted newest-first: once we reach the watermark, the rest is known.
+        if modified <= watermark { break pageLoop }
+        changed.append(document)
+        if modified > advanced { advanced = modified }
+      }
+      if await source.isExhausted { break }
+    }
+
+    let tracked = changed.filter { localIDs.contains($0.id) }
+    if !tracked.isEmpty {
+      Logger.shared.info(
+        "Reconcile: refreshing \(tracked.count, privacy: .public) changed documents")
+      try database.upsertDocuments(tracked, serverID: serverID, projectionLevel: .metadata)
+    }
+    if advanced > watermark {
+      setDeltaWatermark(advanced)
+    }
+  }
+
+  // Per-server delta watermark (newest `modified` applied). Kept in the app-group
+  // UserDefaults rather than the DB: it is regenerable sync state, not view
+  // state — losing it just re-baselines on the next pass.
+  private var deltaWatermarkKey: String { "documentDeltaWatermark.\(serverID.uuidString)" }
+
+  private func deltaWatermark() -> Date? {
+    let defaults = UserDefaults(suiteName: ContentStore.appGroup) ?? .standard
+    let stamp = defaults.double(forKey: deltaWatermarkKey)
+    return stamp > 0 ? Date(timeIntervalSinceReferenceDate: stamp) : nil
+  }
+
+  private func setDeltaWatermark(_ date: Date) {
+    let defaults = UserDefaults(suiteName: ContentStore.appGroup) ?? .standard
+    defaults.set(date.timeIntervalSinceReferenceDate, forKey: deltaWatermarkKey)
   }
 
   public func nextAsn() async throws -> UInt {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -29,6 +29,27 @@ import Persistence
 import SwiftUI
 import os
 
+/// Storage and clearing of the per-server changed-metadata delta watermark.
+///
+/// Non-generic so the keys (and the bulk clear used by "clear local storage")
+/// don't depend on `CachingRepository`'s `Wrapped` type — and so a `static`
+/// constant is even legal (it isn't on the generic type itself).
+enum DocumentDeltaWatermark {
+  static let keyPrefix = "documentDeltaWatermark."
+
+  static func key(serverID: UUID) -> String { "\(keyPrefix)\(serverID.uuidString)" }
+
+  /// Drop every server's watermark so the next reconcile re-baselines. Paired
+  /// with a cache wipe (a stale watermark over an empty cache would skip
+  /// re-fetching the rows the wipe removed).
+  static func clearAll() {
+    let defaults = UserDefaults(suiteName: ContentStore.appGroup) ?? .standard
+    for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(keyPrefix) {
+      defaults.removeObject(forKey: key)
+    }
+  }
+}
+
 /// The cache control surface the store reaches for, kept off the `Repository`
 /// protocol (which stays technology-agnostic). A repository that isn't a
 /// `CachingBackend` (preview, Share Extension, tests) makes the store fall back
@@ -556,7 +577,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   // Per-server delta watermark (newest `modified` applied). Kept in the app-group
   // UserDefaults rather than the DB: it is regenerable sync state, not view
   // state — losing it just re-baselines on the next pass.
-  private var deltaWatermarkKey: String { "documentDeltaWatermark.\(serverID.uuidString)" }
+  private var deltaWatermarkKey: String { DocumentDeltaWatermark.key(serverID: serverID) }
 
   private func deltaWatermark() -> Date? {
     let defaults = UserDefaults(suiteName: ContentStore.appGroup) ?? .standard

--- a/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
@@ -102,6 +102,10 @@ public final class NeedsAuthRepository<Wrapped: Repository>: Repository {
     return InterceptingDocumentSource(wrapping: source, onUnauthorized: sourceCallback)
   }
 
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    try await intercept { try await wrapped.documentIDs(filter: filter) }
+  }
+
   public func nextAsn() async throws -> UInt {
     try await intercept { try await wrapped.nextAsn() }
   }

--- a/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
+++ b/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
@@ -1,0 +1,38 @@
+//
+//  QueryFillHandle.swift
+//  AppShared
+//
+//  Opaque result of kicking off a document-list fill (`CachingBackend.fillQuery`).
+//  Carries the `QueryKey` the list observes, the server-reported total for an
+//  exact scrollbar, and a handle to the background paging task so a refresh /
+//  teardown can cancel the in-flight fill. No GRDB crosses this boundary.
+//
+
+import Foundation
+import Persistence
+
+public struct QueryFillHandle: Sendable {
+  /// The key the list view-model subscribes `observeDocumentPrefix` to.
+  public let queryKey: QueryKey
+  /// Server-reported total from page 1 (exact scrollbar extent), if known.
+  public let totalCount: UInt?
+
+  private let fillTask: Task<Void, Never>
+
+  public init(queryKey: QueryKey, totalCount: UInt?, fillTask: Task<Void, Never>) {
+    self.queryKey = queryKey
+    self.totalCount = totalCount
+    self.fillTask = fillTask
+  }
+
+  /// Cancel the background page-the-rest fill (e.g. on filter change / teardown).
+  public func cancel() {
+    fillTask.cancel()
+  }
+
+  /// Await the background fill completing — primarily for tests and callers that
+  /// want the whole view local before proceeding.
+  public func awaitCompletion() async {
+    await fillTask.value
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
+++ b/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
@@ -3,8 +3,8 @@
 //  AppShared
 //
 //  Opaque result of kicking off a document-list fill (`CachingBackend.fillQuery`).
-//  Carries the `QueryKey` the list observes, the server-reported total for an
-//  exact scrollbar, and a handle to the background paging task so a refresh /
+//  Carries the `QueryKey` the list observes, the server-reported total behind
+//  the count pill, and a handle to the background paging task so a refresh /
 //  teardown can cancel the in-flight fill. No GRDB crosses this boundary.
 //
 
@@ -14,7 +14,7 @@ import Persistence
 public struct QueryFillHandle: Sendable {
   /// The key the list view-model subscribes `observeDocumentPrefix` to.
   public let queryKey: QueryKey
-  /// Server-reported total from page 1 (exact scrollbar extent), if known.
+  /// Server-reported total from page 1 (the count pill's number), if known.
   public let totalCount: UInt?
 
   private let fillTask: Task<Void, Never>

--- a/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
@@ -748,6 +748,17 @@
         }
       }
     },
+    "cacheCleared" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached data cleared"
+          }
+        }
+      }
+    },
     "certificateLoadError" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1009,6 +1020,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sunucu seç"
+          }
+        }
+      }
+    },
+    "clearCache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Cached Data"
+          }
+        }
+      }
+    },
+    "clearCacheConfirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+          }
+        }
+      }
+    },
+    "clearCacheConfirmationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear all cached data?"
           }
         }
       }
@@ -2069,6 +2113,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kimlikler, sizi kriptografik olarak doğrulamak için kullanılabilecek sertifika ve özel anahtarlar çiftleridir. Kimlikler, korunan kaynaklara erişmek için [*mTLS*](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/) yapılandırmalarında kullanılır.\n\nBu **gelişmiş bir özelliktir**!"
+          }
+        }
+      }
+    },
+    "localStorage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local Storage"
+          }
+        }
+      }
+    },
+    "localStorageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
           }
         }
       }

--- a/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
+++ b/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
@@ -111,12 +111,18 @@ public struct DocumentNoteView: View {
     }
   }
 
-  private func loadNotes() async {
+  /// Load the document's notes. `userInitiated` controls whether a failure is
+  /// surfaced: a pull-to-refresh (`true`) toasts; the on-appear `.task` (`false`)
+  /// stays silent — it isn't user-initiated, and an offline open falls back to
+  /// whatever the cache holds.
+  private func loadNotes(userInitiated: Bool) async {
     do {
       notes = try await store.notes(for: document)
     } catch let error where error.isCancellationError {} catch {
       Logger.shared.error("Error loading notes for document: \(error)")
-      errorController.push(error: error)
+      if userInitiated {
+        errorController.push(error: error)
+      }
     }
   }
 
@@ -196,7 +202,7 @@ public struct DocumentNoteView: View {
       }
 
       .refreshable {
-        Task { await loadNotes() }
+        await loadNotes(userInitiated: true)
       }
 
       .sheet(isPresented: $adding) {
@@ -206,7 +212,7 @@ public struct DocumentNoteView: View {
 
     .task {
       guard canViewNotes else { return }
-      await loadNotes()
+      await loadNotes(userInitiated: false)
     }
   }
 }

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -145,6 +145,14 @@ public struct ContentStore: Sendable {
     try? FileManager.default.removeItem(at: sidecarURL(for: key))
   }
 
+  /// Remove every cached blob (all servers, all kinds) by tearing down the
+  /// store root, then recreate the empty directory. Used by the debug
+  /// "clear local storage" action.
+  public func purge() throws {
+    try? FileManager.default.removeItem(at: canonicalRoot)
+    try createDirectory(canonicalRoot)
+  }
+
   // MARK: - Sidecar
 
   private struct Sidecar: Codable {

--- a/Common/Sources/Common/ContentStore.swift
+++ b/Common/Sources/Common/ContentStore.swift
@@ -149,7 +149,17 @@ public struct ContentStore: Sendable {
   /// store root, then recreate the empty directory. Used by the debug
   /// "clear local storage" action.
   public func purge() throws {
-    try? FileManager.default.removeItem(at: canonicalRoot)
+    // Propagate a failed removal rather than swallowing it: recreating the
+    // directory succeeds trivially when it is still there, so a `try?` here
+    // would report a clean wipe while every blob was still on disk — and the
+    // caller tells the user the cache is cleared.
+    do {
+      try FileManager.default.removeItem(at: canonicalRoot)
+    } catch let error as NSError
+      where error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError
+    {
+      // Nothing cached yet; an absent root is already the desired end state.
+    }
     try createDirectory(canonicalRoot)
   }
 

--- a/DataModel/Sources/DataModel/Model/MetadataModel.swift
+++ b/DataModel/Sources/DataModel/Model/MetadataModel.swift
@@ -14,7 +14,7 @@ public struct Metadata: Sendable {
 
   // Wire-symmetric value type — round-tripped by `ApiMetadata` and storage
   // alike. Stays `Codable` per the Stage 3 principle.
-  public struct Item: Codable, Sendable {
+  public struct Item: Codable, Sendable, Equatable {
     public var namespace: String
     public var prefix: String
     public var key: String

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -550,6 +550,16 @@ extension ApiRepository: Repository {
     return ApiPagedSource<ApiDocument, Document>(cursor: cursor, map: { $0.domain })
   }
 
+  /// Cheap id-only projection (`fields=id`) in a few very large pages — the
+  /// authoritative ordered id set for the remote-delete reconcile.
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    Logger.networking.notice("Getting document id set for filter")
+    let cursor = try PageCursor<ApiDocumentID>(
+      repository: self,
+      initialURL: url(.documents(page: 1, filter: filter, pageSize: 25000, fields: ["id"])))
+    return try await cursor.collectAll().map(\.id)
+  }
+
   public func download(
     document: Document, original: Bool = false,
     progress: (@Sendable (Double) -> Void)? = nil

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -554,6 +554,15 @@ extension ApiRepository: Repository {
   /// authoritative ordered id set for the remote-delete reconcile.
   public func documentIDs(filter: FilterState) async throws -> [UInt] {
     Logger.networking.notice("Getting document id set for filter")
+    // Page over a *unique* ordering. The caller's sort carries no meaning here
+    // (the result is consumed as a set), and paging a non-unique one is not
+    // stable — `FilterState.empty` sorts by archive serial number, which is NULL
+    // for most documents, so nearly every row lands in one tie group. Any id
+    // dropped across a page boundary reads as a remote deletion to the
+    // reconcile, which then evicts that document from the cache.
+    var filter = filter
+    filter.sortField = .other("id")
+    filter.sortOrder = .ascending
     let cursor = try PageCursor<ApiDocumentID>(
       repository: self,
       initialURL: url(.documents(page: 1, filter: filter, pageSize: 25000, fields: ["id"])))

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -565,7 +565,9 @@ extension ApiRepository: Repository {
     filter.sortOrder = .ascending
     let cursor = try PageCursor<ApiDocumentID>(
       repository: self,
-      initialURL: url(.documents(page: 1, filter: filter, pageSize: 25000, fields: ["id"])))
+      initialURL: url(
+        .documents(
+          page: 1, filter: filter, pageSize: 25000, searchApi: searchApi, fields: ["id"])))
     return try await cursor.collectAll().map(\.id)
   }
 

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -554,12 +554,9 @@ extension ApiRepository: Repository {
   /// authoritative ordered id set for the remote-delete reconcile.
   public func documentIDs(filter: FilterState) async throws -> [UInt] {
     Logger.networking.notice("Getting document id set for filter")
-    // Page over a *unique* ordering. The caller's sort carries no meaning here
-    // (the result is consumed as a set), and paging a non-unique one is not
-    // stable — `FilterState.empty` sorts by archive serial number, which is NULL
-    // for most documents, so nearly every row lands in one tie group. Any id
-    // dropped across a page boundary reads as a remote deletion to the
-    // reconcile, which then evicts that document from the cache.
+    // Page over a *unique* ordering: the result is consumed as a set, and paging
+    // a non-unique one drops ids across page boundaries — which the reconcile
+    // then reads as remote deletions and evicts from the cache.
     var filter = filter
     filter.sortField = .other("id")
     filter.sortOrder = .ascending

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -87,10 +87,11 @@ extension Endpoint {
 extension Endpoint {
   public static func documents(
     page: UInt, filter: FilterState, pageSize: UInt = Self.defaultDocumentPageSize,
-    searchApi: FilterState.SearchApi = .legacy
+    searchApi: FilterState.SearchApi = .legacy,
+    fields: [String]? = nil
   ) -> Endpoint {
     let endpoint = documents(
-      page: page, rules: filter.rules(for: searchApi), pageSize: pageSize)
+      page: page, rules: filter.rules(for: searchApi), pageSize: pageSize, fields: fields)
 
     var ordering: String = filter.sortField.rawValue
     if filter.sortOrder.reverse {
@@ -102,14 +103,22 @@ extension Endpoint {
     return Endpoint(path: endpoint.path, queryItems: queryItems)
   }
 
+  /// - Parameter fields: optional field projection (paperless-ngx `?fields=`).
+  ///   `["id"]` yields the cheap id-only (Tier-0) response used by the
+  ///   deletion-reconcile sweep; `nil` returns the full list shape.
   public static func documents(
-    page: UInt, rules: [FilterRule] = [], pageSize: UInt = Self.defaultDocumentPageSize
+    page: UInt, rules: [FilterRule] = [], pageSize: UInt = Self.defaultDocumentPageSize,
+    fields: [String]? = nil
   ) -> Endpoint {
     var queryItems = [
       URLQueryItem(name: "page", value: String(page)),
       URLQueryItem(name: "truncate_content", value: "true"),
       URLQueryItem(name: "page_size", value: String(pageSize)),
     ]
+
+    if let fields, !fields.isEmpty {
+      queryItems.append(URLQueryItem(name: "fields", value: fields.joined(separator: ",")))
+    }
 
     queryItems += FilterRule.queryItems(for: rules)
 

--- a/Networking/Sources/Networking/Api/PreviewRepository.swift
+++ b/Networking/Sources/Networking/Api/PreviewRepository.swift
@@ -385,6 +385,11 @@ public class PreviewRepository: Repository {
     PreviewDocumentSource(sequence: documents.map(\.value).sorted(by: { a, b in a.id < b.id }))
   }
 
+  // In-memory fixture: paging the full list is the cheap path here.
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    try await pagedDocumentIDs(filter: filter)
+  }
+
   public func trash() async -> [Document] {
     []
   }

--- a/Networking/Sources/Networking/Api/TransientRepository.swift
+++ b/Networking/Sources/Networking/Api/TransientRepository.swift
@@ -163,6 +163,11 @@ extension TransientRepository: Repository {
     return TransientDocumentSource(sequence: filteredDocs)
   }
 
+  // In-memory fixture: paging the full list is the cheap path here.
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    try await pagedDocumentIDs(filter: filter)
+  }
+
   public func trash() async throws -> [Document] {
     trashedDocuments.values.sorted { $0.id < $1.id }
   }

--- a/Networking/Sources/Networking/Api/Wire/ApiDocumentID.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiDocumentID.swift
@@ -1,0 +1,15 @@
+//
+//  ApiDocumentID.swift
+//  Networking
+//
+//  The id-only (Tier-0) projection of the documents list (`?fields=id`). A
+//  dedicated lightweight wire type rather than making every `ApiDocument` field
+//  optional — that would gut the full-document decode contract. Used by the
+//  remote-delete reconcile to fetch the authoritative live id set cheaply.
+//
+
+import Foundation
+
+struct ApiDocumentID: Decodable, Sendable {
+  let id: UInt
+}

--- a/Networking/Sources/Networking/NullRepository.swift
+++ b/Networking/Sources/Networking/NullRepository.swift
@@ -76,6 +76,11 @@ public class NullRepository: Repository {
     NullDocumentSource()
   }
 
+  // No server-side projection to reach for; the source is empty anyway.
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    try await pagedDocumentIDs(filter: filter)
+  }
+
   public func trash() async -> [Document] { [] }
   public func restoreTrash(documents _: [UInt]) async throws {}
   public func emptyTrash(documents _: [UInt]) async throws {}

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -64,11 +64,13 @@ public protocol Repository<Documents, Tasks>: Sendable {
 
   func documents(filter: FilterState) throws -> Documents
 
-  /// The complete ordered list of document IDs matching a query — the cheap
-  /// `fields=id` projection that backs the remote-delete reconcile. A default
-  /// implementation pages the full list and maps ids; `ApiRepository` overrides
-  /// it with the id-only projection. (Has a default, so existing conformers
-  /// need no change.)
+  /// The complete ordered list of document IDs matching a query — backs the
+  /// remote-delete reconcile and the saved-view membership sweep.
+  ///
+  /// Deliberately has no default: only the API layer can express the cheap
+  /// `fields=id` projection, and a default would let a conformer silently
+  /// inherit the expensive full-list paging instead. Conformers that can't do
+  /// better spell that out by calling `pagedDocumentIDs(filter:)`.
   func documentIDs(filter: FilterState) async throws -> [UInt]
 
   func nextAsn() async throws -> UInt
@@ -194,15 +196,20 @@ extension Repository {
     supports(feature: .tantivySimpleSearch) ? .tantivy : .legacy
   }
 
-  /// Default: page the full (Tier-1) list and map ids. Correct everywhere;
-  /// `ApiRepository` overrides it with the cheaper `fields=id` projection.
+  /// Fallback for `documentIDs(filter:)`: page the full (Tier-1) list and map
+  /// ids. Correct everywhere, but pulls whole `Document` payloads to read one
+  /// field — backends that can project server-side should do that instead.
   ///
-  /// Pages over a *unique* ordering for the same reason the override does: the
-  /// result is consumed as a set, and paging a non-unique one drops ids across
-  /// page boundaries — which the remote-delete reconcile then reads as
+  /// Not a default implementation on purpose. It is a helper conformers opt
+  /// into by name, so that inheriting the expensive path is a visible choice
+  /// rather than the consequence of not writing anything.
+  ///
+  /// Pages over a *unique* ordering for the same reason `ApiRepository` does:
+  /// the result is consumed as a set, and paging a non-unique one drops ids
+  /// across page boundaries — which the remote-delete reconcile then reads as
   /// deletions. The `fields=id` projection is what can't be expressed here; the
   /// ordering can.
-  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+  public func pagedDocumentIDs(filter: FilterState) async throws -> [UInt] {
     var filter = filter
     filter.sortField = .other("id")
     filter.sortOrder = .ascending

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -64,6 +64,13 @@ public protocol Repository<Documents, Tasks>: Sendable {
 
   func documents(filter: FilterState) throws -> Documents
 
+  /// The complete ordered list of document IDs matching a query — the cheap
+  /// `fields=id` projection that backs the remote-delete reconcile. A default
+  /// implementation pages the full list and maps ids; `ApiRepository` overrides
+  /// it with the id-only projection. (Has a default, so existing conformers
+  /// need no change.)
+  func documentIDs(filter: FilterState) async throws -> [UInt]
+
   func nextAsn() async throws -> UInt
 
   func metadata(documentId: UInt) async throws -> Metadata
@@ -185,6 +192,20 @@ extension Repository {
   /// store rule types the backend has deprecated.
   public var searchApi: FilterState.SearchApi {
     supports(feature: .tantivySimpleSearch) ? .tantivy : .legacy
+  }
+
+  /// Default: page the full (Tier-1) list and map ids. Correct everywhere;
+  /// `ApiRepository` overrides it with the cheaper `fields=id` projection.
+  public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    let source = try documents(filter: filter)
+    var ids: [UInt] = []
+    while true {
+      let batch = try await source.fetch(limit: 1000)
+      if batch.isEmpty { break }
+      ids.append(contentsOf: batch.map(\.id))
+      if await source.isExhausted { break }
+    }
+    return ids
   }
 }
 

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -196,7 +196,16 @@ extension Repository {
 
   /// Default: page the full (Tier-1) list and map ids. Correct everywhere;
   /// `ApiRepository` overrides it with the cheaper `fields=id` projection.
+  ///
+  /// Pages over a *unique* ordering for the same reason the override does: the
+  /// result is consumed as a set, and paging a non-unique one drops ids across
+  /// page boundaries — which the remote-delete reconcile then reads as
+  /// deletions. The `fields=id` projection is what can't be expressed here; the
+  /// ordering can.
   public func documentIDs(filter: FilterState) async throws -> [UInt] {
+    var filter = filter
+    filter.sortField = .other("id")
+    filter.sortOrder = .ascending
     let source = try documents(filter: filter)
     var ids: [UInt] = []
     while true {

--- a/Persistence/Sources/Persistence/Database+DocumentDetail.swift
+++ b/Persistence/Sources/Persistence/Database+DocumentDetail.swift
@@ -1,0 +1,58 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// Per-document detail-cache operations (notes + file-metadata) — the entry
+/// points AppShared uses to read or write the two Tier-2 sub-resources; GRDB
+/// stays sealed inside `Persistence`.
+///
+/// Both follow the same network-first → write-through → offline-fallback shape
+/// as `document(id:)`: the caching repository forwards to the server, replaces
+/// the cached row on success, and serves the cached row on failure. Notes are
+/// document-keyed and mutable; file-metadata is version-keyed and immutable.
+extension Database {
+  // MARK: - Notes (mutable, document-keyed)
+
+  /// Replace a document's cached notes list (a row replace, not a per-note
+  /// merge — the endpoint and mutations always return the full list).
+  public func setNotes(_ notes: [DocumentNote], serverID: UUID, documentID: UInt) throws {
+    try writer.write { db in
+      try DocumentNoteRecord(serverId: serverID, documentId: documentID, notes: notes)
+        .upsert(db)
+    }
+  }
+
+  /// A document's cached notes, or `nil` if never cached. `nil` (absent) is
+  /// distinct from `[]` (cached, genuinely no notes) so the offline fallback can
+  /// tell "nothing to serve" from "served an empty list".
+  public func notes(serverID: UUID, documentID: UInt) throws -> [DocumentNote]? {
+    try writer.read { db in
+      try DocumentNoteRecord
+        .filter(Column("server_id") == serverID && Column("document_id") == documentID)
+        .fetchOne(db)?
+        .domain
+    }
+  }
+
+  // MARK: - File-metadata (immutable, version-keyed)
+
+  /// Cache a file version's `/metadata/`. Immutable per version, so this only
+  /// writes the first time a version is seen (re-writing an identical row is
+  /// harmless).
+  public func setFileMetadata(_ metadata: Metadata, serverID: UUID, versionID: UInt) throws {
+    try writer.write { db in
+      try FileMetadataRecord(serverId: serverID, versionId: versionID, domain: metadata)
+        .upsert(db)
+    }
+  }
+
+  /// A file version's cached metadata, or `nil` if never cached.
+  public func fileMetadata(serverID: UUID, versionID: UInt) throws -> Metadata? {
+    try writer.read { db in
+      try FileMetadataRecord
+        .filter(Column("server_id") == serverID && Column("version_id") == versionID)
+        .fetchOne(db)?
+        .domain
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Database+DocumentDetail.swift
+++ b/Persistence/Sources/Persistence/Database+DocumentDetail.swift
@@ -15,22 +15,28 @@ extension Database {
 
   /// Replace a document's cached notes list (a row replace, not a per-note
   /// merge — the endpoint and mutations always return the full list).
-  public func setNotes(_ notes: [DocumentNote], serverID: UUID, documentID: UInt) throws {
-    try writer.write { db in
-      try DocumentNoteRecord(serverId: serverID, documentId: documentID, notes: notes)
-        .upsert(db)
+  public func setNotes(_ notes: [DocumentNote], serverID: UUID, documentID: UInt)
+    throws(DatabaseError)
+  {
+    try wrapping("setNotes") {
+      try writer.write { db in
+        try DocumentNoteRecord(serverId: serverID, documentId: documentID, notes: notes)
+          .upsert(db)
+      }
     }
   }
 
   /// A document's cached notes, or `nil` if never cached. `nil` (absent) is
   /// distinct from `[]` (cached, genuinely no notes) so the offline fallback can
   /// tell "nothing to serve" from "served an empty list".
-  public func notes(serverID: UUID, documentID: UInt) throws -> [DocumentNote]? {
-    try writer.read { db in
-      try DocumentNoteRecord
-        .filter(Column("server_id") == serverID && Column("document_id") == documentID)
-        .fetchOne(db)?
-        .domain
+  public func notes(serverID: UUID, documentID: UInt) throws(DatabaseError) -> [DocumentNote]? {
+    try wrapping("notes") {
+      try writer.read { db in
+        try DocumentNoteRecord
+          .filter(Column("server_id") == serverID && Column("document_id") == documentID)
+          .fetchOne(db)?
+          .domain
+      }
     }
   }
 
@@ -39,20 +45,26 @@ extension Database {
   /// Cache a file version's `/metadata/`. Immutable per version, so this only
   /// writes the first time a version is seen (re-writing an identical row is
   /// harmless).
-  public func setFileMetadata(_ metadata: Metadata, serverID: UUID, versionID: UInt) throws {
-    try writer.write { db in
-      try FileMetadataRecord(serverId: serverID, versionId: versionID, domain: metadata)
-        .upsert(db)
+  public func setFileMetadata(_ metadata: Metadata, serverID: UUID, versionID: UInt)
+    throws(DatabaseError)
+  {
+    try wrapping("setFileMetadata") {
+      try writer.write { db in
+        try FileMetadataRecord(serverId: serverID, versionId: versionID, domain: metadata)
+          .upsert(db)
+      }
     }
   }
 
   /// A file version's cached metadata, or `nil` if never cached.
-  public func fileMetadata(serverID: UUID, versionID: UInt) throws -> Metadata? {
-    try writer.read { db in
-      try FileMetadataRecord
-        .filter(Column("server_id") == serverID && Column("version_id") == versionID)
-        .fetchOne(db)?
-        .domain
+  public func fileMetadata(serverID: UUID, versionID: UInt) throws(DatabaseError) -> Metadata? {
+    try wrapping("fileMetadata") {
+      try writer.read { db in
+        try FileMetadataRecord
+          .filter(Column("server_id") == serverID && Column("version_id") == versionID)
+          .fetchOne(db)?
+          .domain
+      }
     }
   }
 }

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -1,0 +1,206 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// Document-cache operations — the only entry points AppShared uses to read or
+/// mutate document rows and cached query orderings; GRDB stays sealed inside
+/// `Persistence`.
+///
+/// Reads are pure cache reads (no network — that's the caching repository's
+/// `fillQuery`/`sync`). Writes are either a query fill (`writeQueryPage`, the
+/// network → DB replay materialization) or a single pessimistic-mutation
+/// write-through (`upsertDocument`, `deleteDocuments`).
+extension Database {
+  // MARK: - Writes
+
+  /// Upsert a batch of documents at a projection level, never downgrading a
+  /// row that is already richer (a Tier-1 list fill must not clobber a Tier-2
+  /// detail row's level / `detailFetchedAt` / permissions).
+  public func upsertDocuments(
+    _ domains: [Document], serverID: UUID, projectionLevel: DocumentProjection
+  ) throws {
+    try writer.write { db in
+      for domain in domains {
+        try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+      }
+    }
+  }
+
+  /// Single-row write-through (pessimistic mutation), same non-downgrade rule.
+  public func upsertDocument(
+    _ domain: Document, serverID: UUID, projectionLevel: DocumentProjection
+  ) throws {
+    try writer.write { db in
+      try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+    }
+  }
+
+  /// Replace (or append to) a cached query's ordered membership and upsert its
+  /// document rows in one transaction.
+  ///
+  /// - `replaceAll: true` (first page of a fill) clears the key's existing
+  ///   `query_order` first; subsequent pages pass `false` with an increasing
+  ///   `startPosition` so the background fill appends without rewriting earlier
+  ///   positions. Document rows go in *before* their `query_order` entries to
+  ///   satisfy the composite FK.
+  public func writeQueryPage(
+    queryKey: QueryKey, serverID: UUID, documents: [Document],
+    startPosition: Int, totalCount: UInt?, replaceAll: Bool,
+    projectionLevel: DocumentProjection = .metadata
+  ) throws {
+    try writer.write { db in
+      if replaceAll {
+        try QueryOrderRow
+          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+          .deleteAll(db)
+      }
+      for (offset, domain) in documents.enumerated() {
+        try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+        try QueryOrderRow(
+          serverId: serverID, queryKey: queryKey.rawValue,
+          position: startPosition + offset, remoteId: domain.id
+        ).upsert(db)
+      }
+      try setQueryMeta(
+        db, serverID: serverID, queryKey: queryKey,
+        totalCount: totalCount, orderStale: false)
+    }
+  }
+
+  /// Mark every cached query containing `remoteID` order-stale under its active
+  /// sort. v1 over-marks (any query the doc is a member of); the ordering
+  /// corrects on the next fill / delta.
+  public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID) throws {
+    try writer.write { db in
+      try db.execute(
+        sql: """
+          UPDATE query_meta SET order_stale = 1
+          WHERE server_id = ? AND query_key IN (
+            SELECT DISTINCT query_key FROM query_order
+            WHERE server_id = ? AND remote_id = ?)
+          """,
+        arguments: [serverID, serverID, remoteID])
+    }
+  }
+
+  /// Delete documents absent from the server's authoritative id set (the
+  /// remote-delete reconcile). The composite FK cascade removes their
+  /// `query_order` rows from every cached list at once.
+  public func deleteDocuments(serverID: UUID, removedIDs: [UInt]) throws {
+    guard !removedIDs.isEmpty else { return }
+    try writer.write { db in
+      _ =
+        try DocumentRecord
+        .filter(Column("server_id") == serverID && removedIDs.contains(Column("id")))
+        .deleteAll(db)
+    }
+  }
+
+  // MARK: - Reads (one-shot; observations live in Database+Observe)
+
+  /// A single cached document by `(server, id)`, or `nil` if not cached.
+  public func document(serverID: UUID, id: UInt) throws -> Document? {
+    try writer.read { db in
+      try DocumentRecord
+        .filter(Column("server_id") == serverID && Column("id") == id)
+        .fetchOne(db)?
+        .domain
+    }
+  }
+
+  /// A single cached document by archive serial number (resolves the ASN
+  /// scanner offline via the indexed `asn` column), or `nil` if not cached.
+  public func document(serverID: UUID, asn: UInt) throws -> Document? {
+    try writer.read { db in
+      try DocumentRecord
+        .filter(Column("server_id") == serverID && Column("asn") == asn)
+        .fetchOne(db)?
+        .domain
+    }
+  }
+
+  /// A window of a cached query's ordered answer: the `query_order ⋈ document`
+  /// join, `ORDER BY position` with `LIMIT`/`OFFSET`, so deletion gaps in
+  /// `position` are invisible. The observed live form is `observeDocumentPrefix`.
+  public func queryDocuments(
+    queryKey: QueryKey, serverID: UUID, limit: Int, offset: Int = 0
+  ) throws -> [Document] {
+    try writer.read { db in
+      try DocumentRecord.fetchAll(
+        db, sql: Self.queryWindowSQL,
+        arguments: [
+          serverID, queryKey.rawValue, limit, offset,
+        ]
+      ).map(\.domain)
+    }
+  }
+
+  /// Server total (scrollbar extent), locally-present count (reflects deletion
+  /// gaps), and order-stale flag for a cached query.
+  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws -> QueryStatus {
+    try writer.read { db in
+      try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+    }
+  }
+
+  // MARK: - Internals (shared with Database+Observe)
+
+  /// The windowed replay join, shared by the one-shot read and the observation.
+  static let queryWindowSQL = """
+    SELECT d.* FROM query_order q
+    JOIN document d ON d.server_id = q.server_id AND d.id = q.remote_id
+    WHERE q.server_id = ? AND q.query_key = ?
+    ORDER BY q.position
+    LIMIT ? OFFSET ?
+    """
+
+  static func fetchQueryStatus(
+    _ db: GRDB.Database, queryKey: QueryKey, serverID: UUID
+  ) throws -> QueryStatus {
+    let meta =
+      try QueryMetaRow
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+      .fetchOne(db)
+    let localCount =
+      try QueryOrderRow
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+      .fetchCount(db)
+    return QueryStatus(
+      totalCount: meta?.totalCount, localCount: localCount,
+      orderStale: meta?.orderStale ?? false)
+  }
+
+  /// Non-downgrade single-row upsert: keep the richer of the incoming and
+  /// existing projection (level + `detailFetchedAt` + permissions).
+  private func writeDocumentRow(
+    _ db: GRDB.Database, _ domain: Document, serverID: UUID,
+    projectionLevel: DocumentProjection
+  ) throws {
+    let incoming = DocumentRecord(
+      serverId: serverID, domain: domain, projectionLevel: projectionLevel)
+    if let existing =
+      try DocumentRecord
+      .filter(Column("server_id") == serverID && Column("id") == domain.id)
+      .fetchOne(db),
+      existing.projectionLevel > projectionLevel
+    {
+      var merged = incoming
+      merged.projectionLevel = existing.projectionLevel
+      merged.detailFetchedAt = existing.detailFetchedAt
+      merged.payload.permissions = existing.payload.permissions
+      try merged.upsert(db)
+    } else {
+      try incoming.upsert(db)
+    }
+  }
+
+  private func setQueryMeta(
+    _ db: GRDB.Database, serverID: UUID, queryKey: QueryKey,
+    totalCount: UInt?, orderStale: Bool
+  ) throws {
+    try QueryMetaRow(
+      serverId: serverID, queryKey: queryKey.rawValue,
+      totalCount: totalCount, orderStale: orderStale, filledAt: Date()
+    ).upsert(db)
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -135,6 +135,17 @@ extension Database {
     }
   }
 
+  /// Every cached document id for a server — the local set the remote-delete
+  /// reconcile diffs against the server's authoritative id set.
+  public func allDocumentIDs(serverID: UUID) throws -> Set<UInt> {
+    try writer.read { db in
+      try DocumentRecord
+        .select(Column("id"), as: UInt.self)
+        .filter(Column("server_id") == serverID)
+        .fetchSet(db)
+    }
+  }
+
   /// Server total (scrollbar extent), locally-present count (reflects deletion
   /// gaps), and order-stale flag for a cached query.
   public func queryStatus(queryKey: QueryKey, serverID: UUID) throws -> QueryStatus {

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -167,8 +167,7 @@ extension Database {
 
   /// Server total, locally-present count (reflects deletion gaps), and
   /// order-stale flag for a cached query.
-  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus
-  {
+  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus {
     try wrapping("queryStatus") {
       try writer.read { db in
         try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -165,8 +165,8 @@ extension Database {
     }
   }
 
-  /// Server total (scrollbar extent), locally-present count (reflects deletion
-  /// gaps), and order-stale flag for a cached query.
+  /// Server total, locally-present count (reflects deletion gaps), and
+  /// order-stale flag for a cached query.
   public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus
   {
     try wrapping("queryStatus") {

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -18,10 +18,12 @@ extension Database {
   /// detail row's level / `detailFetchedAt` / permissions).
   public func upsertDocuments(
     _ domains: [Document], serverID: UUID, projectionLevel: DocumentProjection
-  ) throws {
-    try writer.write { db in
-      for domain in domains {
-        try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+  ) throws(DatabaseError) {
+    try wrapping("upsertDocuments") {
+      try writer.write { db in
+        for domain in domains {
+          try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+        }
       }
     }
   }
@@ -29,9 +31,11 @@ extension Database {
   /// Single-row write-through (pessimistic mutation), same non-downgrade rule.
   public func upsertDocument(
     _ domain: Document, serverID: UUID, projectionLevel: DocumentProjection
-  ) throws {
-    try writer.write { db in
-      try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+  ) throws(DatabaseError) {
+    try wrapping("upsertDocument") {
+      try writer.write { db in
+        try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+      }
     }
   }
 
@@ -47,75 +51,87 @@ extension Database {
     queryKey: QueryKey, serverID: UUID, documents: [Document],
     startPosition: Int, totalCount: UInt?, replaceAll: Bool,
     projectionLevel: DocumentProjection = .metadata
-  ) throws {
-    try writer.write { db in
-      if replaceAll {
-        try QueryOrderRow
-          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
-          .deleteAll(db)
+  ) throws(DatabaseError) {
+    try wrapping("writeQueryPage") {
+      try writer.write { db in
+        if replaceAll {
+          try QueryOrderRow
+            .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+            .deleteAll(db)
+        }
+        for (offset, domain) in documents.enumerated() {
+          try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
+          try QueryOrderRow(
+            serverId: serverID, queryKey: queryKey.rawValue,
+            position: startPosition + offset, remoteId: domain.id
+          ).insert(db)
+        }
+        try setQueryMeta(
+          db, serverID: serverID, queryKey: queryKey,
+          totalCount: totalCount, orderStale: false)
       }
-      for (offset, domain) in documents.enumerated() {
-        try writeDocumentRow(db, domain, serverID: serverID, projectionLevel: projectionLevel)
-        try QueryOrderRow(
-          serverId: serverID, queryKey: queryKey.rawValue,
-          position: startPosition + offset, remoteId: domain.id
-        ).insert(db)
-      }
-      try setQueryMeta(
-        db, serverID: serverID, queryKey: queryKey,
-        totalCount: totalCount, orderStale: false)
     }
   }
 
   /// Mark every cached query containing `remoteID` order-stale under its active
   /// sort. v1 over-marks (any query the doc is a member of); the ordering
   /// corrects on the next fill / delta.
-  public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID) throws {
-    try writer.write { db in
-      try db.execute(
-        sql: """
-          UPDATE query_meta SET order_stale = 1
-          WHERE server_id = ? AND query_key IN (
-            SELECT DISTINCT query_key FROM query_order
-            WHERE server_id = ? AND remote_id = ?)
-          """,
-        arguments: [serverID, serverID, remoteID])
+  public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID)
+    throws(DatabaseError)
+  {
+    try wrapping("markQueriesOrderStale") {
+      try writer.write { db in
+        try db.execute(
+          sql: """
+            UPDATE query_meta SET order_stale = 1
+            WHERE server_id = ? AND query_key IN (
+              SELECT DISTINCT query_key FROM query_order
+              WHERE server_id = ? AND remote_id = ?)
+            """,
+          arguments: [serverID, serverID, remoteID])
+      }
     }
   }
 
   /// Delete documents absent from the server's authoritative id set (the
   /// remote-delete reconcile). The composite FK cascade removes their
   /// `query_order` rows from every cached list at once.
-  public func deleteDocuments(serverID: UUID, removedIDs: [UInt]) throws {
+  public func deleteDocuments(serverID: UUID, removedIDs: [UInt]) throws(DatabaseError) {
     guard !removedIDs.isEmpty else { return }
-    try writer.write { db in
-      _ =
-        try DocumentRecord
-        .filter(Column("server_id") == serverID && removedIDs.contains(Column("id")))
-        .deleteAll(db)
+    try wrapping("deleteDocuments") {
+      try writer.write { db in
+        _ =
+          try DocumentRecord
+          .filter(Column("server_id") == serverID && removedIDs.contains(Column("id")))
+          .deleteAll(db)
+      }
     }
   }
 
   // MARK: - Reads (one-shot; observations live in Database+Observe)
 
   /// A single cached document by `(server, id)`, or `nil` if not cached.
-  public func document(serverID: UUID, id: UInt) throws -> Document? {
-    try writer.read { db in
-      try DocumentRecord
-        .filter(Column("server_id") == serverID && Column("id") == id)
-        .fetchOne(db)?
-        .domain
+  public func document(serverID: UUID, id: UInt) throws(DatabaseError) -> Document? {
+    try wrapping("document(id:)") {
+      try writer.read { db in
+        try DocumentRecord
+          .filter(Column("server_id") == serverID && Column("id") == id)
+          .fetchOne(db)?
+          .domain
+      }
     }
   }
 
   /// A single cached document by archive serial number (resolves the ASN
   /// scanner offline via the indexed `asn` column), or `nil` if not cached.
-  public func document(serverID: UUID, asn: UInt) throws -> Document? {
-    try writer.read { db in
-      try DocumentRecord
-        .filter(Column("server_id") == serverID && Column("asn") == asn)
-        .fetchOne(db)?
-        .domain
+  public func document(serverID: UUID, asn: UInt) throws(DatabaseError) -> Document? {
+    try wrapping("document(asn:)") {
+      try writer.read { db in
+        try DocumentRecord
+          .filter(Column("server_id") == serverID && Column("asn") == asn)
+          .fetchOne(db)?
+          .domain
+      }
     }
   }
 
@@ -124,33 +140,40 @@ extension Database {
   /// `position` are invisible. The observed live form is `observeDocumentPrefix`.
   public func queryDocuments(
     queryKey: QueryKey, serverID: UUID, limit: Int, offset: Int = 0
-  ) throws -> [Document] {
-    try writer.read { db in
-      try DocumentRecord.fetchAll(
-        db, sql: Self.queryWindowSQL,
-        arguments: [
-          serverID, queryKey.rawValue, limit, offset,
-        ]
-      ).map(\.domain)
+  ) throws(DatabaseError) -> [Document] {
+    try wrapping("queryDocuments") {
+      try writer.read { db in
+        try DocumentRecord.fetchAll(
+          db, sql: Self.queryWindowSQL,
+          arguments: [
+            serverID, queryKey.rawValue, limit, offset,
+          ]
+        ).map(\.domain)
+      }
     }
   }
 
   /// Every cached document id for a server — the local set the remote-delete
   /// reconcile diffs against the server's authoritative id set.
-  public func allDocumentIDs(serverID: UUID) throws -> Set<UInt> {
-    try writer.read { db in
-      try DocumentRecord
-        .select(Column("id"), as: UInt.self)
-        .filter(Column("server_id") == serverID)
-        .fetchSet(db)
+  public func allDocumentIDs(serverID: UUID) throws(DatabaseError) -> Set<UInt> {
+    try wrapping("allDocumentIDs") {
+      try writer.read { db in
+        try DocumentRecord
+          .select(Column("id"), as: UInt.self)
+          .filter(Column("server_id") == serverID)
+          .fetchSet(db)
+      }
     }
   }
 
   /// Server total (scrollbar extent), locally-present count (reflects deletion
   /// gaps), and order-stale flag for a cached query.
-  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws -> QueryStatus {
-    try writer.read { db in
-      try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus
+  {
+    try wrapping("queryStatus") {
+      try writer.read { db in
+        try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+      }
     }
   }
 

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -81,14 +81,13 @@ extension Database {
   {
     try wrapping("markQueriesOrderStale") {
       try writer.write { db in
-        try db.execute(
-          sql: """
-            UPDATE query_meta SET order_stale = 1
-            WHERE server_id = ? AND query_key IN (
-              SELECT DISTINCT query_key FROM query_order
-              WHERE server_id = ? AND remote_id = ?)
-            """,
-          arguments: [serverID, serverID, remoteID])
+        let containing =
+          QueryOrderRow
+          .select(Column("query_key"), as: String.self)
+          .filter(Column("server_id") == serverID && Column("remote_id") == remoteID)
+        try QueryMetaRow
+          .filter(Column("server_id") == serverID && containing.contains(Column("query_key")))
+          .updateAll(db, Column("order_stale").set(to: true))
       }
     }
   }

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -59,7 +59,7 @@ extension Database {
         try QueryOrderRow(
           serverId: serverID, queryKey: queryKey.rawValue,
           position: startPosition + offset, remoteId: domain.id
-        ).upsert(db)
+        ).insert(db)
       }
       try setQueryMeta(
         db, serverID: serverID, queryKey: queryKey,

--- a/Persistence/Sources/Persistence/Database+Maintenance.swift
+++ b/Persistence/Sources/Persistence/Database+Maintenance.swift
@@ -17,6 +17,7 @@ extension Database {
       V3_CreateElementCache.multiRowTables
       + V3_CreateElementCache.singletonTables
       + V4_CreateDocumentCache.tables
+      + V5_CreateDocumentDetailCache.tables
     try writer.write { db in
       for table in tables {
         try db.execute(sql: "DELETE FROM \(table)")

--- a/Persistence/Sources/Persistence/Database+Maintenance.swift
+++ b/Persistence/Sources/Persistence/Database+Maintenance.swift
@@ -1,0 +1,26 @@
+import GRDB
+
+/// Cache-maintenance operations that span the element *and* document caches.
+///
+/// These deliberately leave `server` (the connection rows) untouched — they
+/// wipe only the *derived* cached data, so the configured servers survive a
+/// "clear local storage" action and the app re-fills from the network on the
+/// next sync / list open.
+extension Database {
+  /// Delete every cached row across the element and document caches, keeping the
+  /// `server` connection rows. The live observations repaint empty immediately.
+  ///
+  /// All cache tables FK-cascade from `server`, so this is *not* the same as
+  /// dropping connections; it clears the caches while the connections remain.
+  public func clearCache() throws {
+    let tables =
+      V3_CreateElementCache.multiRowTables
+      + V3_CreateElementCache.singletonTables
+      + V4_CreateDocumentCache.tables
+    try writer.write { db in
+      for table in tables {
+        try db.execute(sql: "DELETE FROM \(table)")
+      }
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Maintenance.swift
+++ b/Persistence/Sources/Persistence/Database+Maintenance.swift
@@ -12,15 +12,17 @@ extension Database {
   ///
   /// All cache tables FK-cascade from `server`, so this is *not* the same as
   /// dropping connections; it clears the caches while the connections remain.
-  public func clearCache() throws {
+  public func clearCache() throws(DatabaseError) {
     let tables =
       V3_CreateElementCache.multiRowTables
       + V3_CreateElementCache.singletonTables
       + V4_CreateDocumentCache.tables
       + V5_CreateDocumentDetailCache.tables
-    try writer.write { db in
-      for table in tables {
-        try db.execute(sql: "DELETE FROM \(table)")
+    try wrapping("clearCache") {
+      try writer.write { db in
+        for table in tables {
+          try db.execute(sql: "DELETE FROM \(table)")
+        }
       }
     }
   }

--- a/Persistence/Sources/Persistence/Database+Observe.swift
+++ b/Persistence/Sources/Persistence/Database+Observe.swift
@@ -74,8 +74,8 @@ extension Database {
     return stream(observation)
   }
 
-  /// Live status of a cached query — server total (scrollbar extent),
-  /// locally-present count (reflects deletion gaps), order-stale flag. Tracks
+  /// Live status of a cached query — server total, locally-present count
+  /// (reflects deletion gaps), order-stale flag. Tracks
   /// both `query_meta` and `query_order`, so a fill, a delete, or a stale-marking
   /// re-fires it.
   public func observeQueryStatus(

--- a/Persistence/Sources/Persistence/Database+Observe.swift
+++ b/Persistence/Sources/Persistence/Database+Observe.swift
@@ -51,6 +51,57 @@ extension Database {
     return stream(observation)
   }
 
+  /// Live **growing prefix** of a cached query's ordered answer: the
+  /// `query_order ⋈ document` join, `ORDER BY position LIMIT <limit>` (offset is
+  /// always 0 — this is a prefix, not a sliding window, so scroll-back needs no
+  /// re-subscription and deletion gaps in `position` are invisible).
+  ///
+  /// The list view-model grows `limit` monotonically as the user scrolls and
+  /// re-subscribes; per-emission work is bounded by `limit` (what's been scrolled
+  /// to), not the whole filled set — the win over observing the entire array
+  /// during the eager background fill. Re-fires automatically as the fill appends
+  /// rows and as mutations write the joined `document` rows.
+  public func observeDocumentPrefix(
+    queryKey: QueryKey, serverID: UUID, limit: Int
+  ) -> AsyncThrowingStream<[Document], Error> {
+    let key = queryKey.rawValue
+    let observation = ValueObservation.tracking { db -> [Document] in
+      try DocumentRecord.fetchAll(
+        db, sql: Self.queryWindowSQL,
+        arguments: [serverID, key, limit, 0]
+      ).map(\.domain)
+    }
+    return stream(observation)
+  }
+
+  /// Live status of a cached query — server total (scrollbar extent),
+  /// locally-present count (reflects deletion gaps), order-stale flag. Tracks
+  /// both `query_meta` and `query_order`, so a fill, a delete, or a stale-marking
+  /// re-fires it.
+  public func observeQueryStatus(
+    queryKey: QueryKey, serverID: UUID
+  ) -> AsyncThrowingStream<QueryStatus, Error> {
+    let observation = ValueObservation.tracking { db -> QueryStatus in
+      try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+    }
+    return stream(observation)
+  }
+
+  /// Live single document by `(server, id)` (`nil` until cached) — the
+  /// single-row analogue of ``observeDocumentPrefix``, for surfaces that display
+  /// one document and must repaint on mutation/sync (detail, preview).
+  public func observeDocument(
+    serverID: UUID, id: UInt
+  ) -> AsyncThrowingStream<Document?, Error> {
+    let observation = ValueObservation.tracking { db -> Document? in
+      try DocumentRecord
+        .filter(Column("server_id") == serverID && Column("id") == id)
+        .fetchOne(db)?
+        .domain
+    }
+    return stream(observation)
+  }
+
   /// Shared adapter: drive a `ValueObservation` into an `AsyncThrowingStream`,
   /// mirroring ``observeConnections()``. Cancelling the consuming task tears
   /// down the underlying observation.

--- a/Persistence/Sources/Persistence/Database+Seeded.swift
+++ b/Persistence/Sources/Persistence/Database+Seeded.swift
@@ -19,6 +19,7 @@ extension Database {
     users: [User] = [],
     groups: [UserGroup] = [],
     customFields: [CustomField] = [],
+    documents: [Document] = [],
     uiSettings: UISettings? = nil,
     serverConfiguration: ServerConfiguration? = nil
   ) throws -> Database {
@@ -37,6 +38,10 @@ extension Database {
     try database.replaceElements(users, of: UserRecord.self, serverID: serverID)
     try database.replaceElements(groups, of: UserGroupRecord.self, serverID: serverID)
     try database.replaceElements(customFields, of: CustomFieldRecord.self, serverID: serverID)
+
+    if !documents.isEmpty {
+      try database.upsertDocuments(documents, serverID: serverID, projectionLevel: .metadata)
+    }
 
     if let uiSettings {
       try database.setUISettings(uiSettings, serverID: serverID)

--- a/Persistence/Sources/Persistence/Database.swift
+++ b/Persistence/Sources/Persistence/Database.swift
@@ -198,9 +198,12 @@ extension Database {
   /// Run a GRDB access, re-wrapping whatever it throws as a ``DatabaseError``
   /// so callers outside this package can present it without importing GRDB.
   ///
-  /// The `throws(DatabaseError)` is what lets accessors declare the same, which
-  /// in turn means an accessor cannot reach GRDB except through here: a direct
-  /// `try writer.read { }` throws an untyped error and fails to compile.
+  /// The `throws(DatabaseError)` is what lets accessors declare the same, and
+  /// *within an accessor that declares it* a direct `try writer.read { }` then
+  /// fails to compile — it throws an untyped error. The compiler enforces
+  /// nothing on an accessor that stays untyped-`throws`, so the typed signature
+  /// is the part to keep: drop it and raw `GRDB.DatabaseError`s escape the
+  /// package again.
   func wrapping<T>(_ operation: String, _ body: () throws -> T) throws(DatabaseError) -> T {
     do {
       return try body()

--- a/Persistence/Sources/Persistence/Migrations/Migrations.swift
+++ b/Persistence/Sources/Persistence/Migrations/Migrations.swift
@@ -43,6 +43,10 @@ enum Migrations {
       try V3_CreateElementCache.run(db)
     }
 
+    migrator.registerMigration("v4_create_document_cache") { db in
+      try V4_CreateDocumentCache.run(db)
+    }
+
     return migrator
   }
 }

--- a/Persistence/Sources/Persistence/Migrations/Migrations.swift
+++ b/Persistence/Sources/Persistence/Migrations/Migrations.swift
@@ -47,6 +47,10 @@ enum Migrations {
       try V4_CreateDocumentCache.run(db)
     }
 
+    migrator.registerMigration("v5_create_document_detail_cache") { db in
+      try V5_CreateDocumentDetailCache.run(db)
+    }
+
     return migrator
   }
 }

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -1,0 +1,91 @@
+import GRDB
+
+/// Document-metadata cache tables (Stage 8).
+///
+/// Two jobs, two tables:
+///
+/// - `document` — one row per `(server_id, id)`, query-independent. A document
+///   that appears in many lists still has a single metadata row here. Indexed
+///   columns carry what the join/lookups need (`title`, `asn`, the completeness
+///   marker `projection_level` / `detail_fetched_at`); the long tail lives in the
+///   `data` JSON blob, exactly like the element cache.
+/// - `query_order` — one row per `(server_id, query_key, position)` → `remote_id`.
+///   Pure membership + ordering: replaying a cached list is a join through this
+///   table (`ORDER BY position`), so the server's exact order is preserved and
+///   ad-hoc offline filtering is intentionally unsupported. The composite FK to
+///   `document` with `ON DELETE CASCADE` is load-bearing: deleting one document
+///   row drops it from *every* list at once.
+/// - `query_meta` — one row per `(server_id, query_key)`: server-reported
+///   `total_count` (the scrollbar extent, which survives deletion gaps) and an
+///   `order_stale` flag set by mutations under the active sort.
+///
+/// Every table FK-references `server(id)` with `ON DELETE CASCADE`, so removing a
+/// connection tears down its whole document cache too.
+enum V4_CreateDocumentCache {
+  static func run(_ db: GRDB.Database) throws {
+    try db.create(table: "document", options: [.strict]) { t in
+      t.column("server_id", .blob)
+        .notNull()
+        .references("server", onDelete: .cascade)
+      t.column("id", .integer).notNull()
+      t.column("title", .text).notNull()
+      // Promoted out of the JSON blob so the ASN scanner can resolve
+      // `WHERE asn = ?` against an index.
+      t.column("asn", .integer)
+      // Completeness marker: 0 id-only / 1 renderable / 2 detail.
+      t.column("projection_level", .integer).notNull()
+      // Set when Tier-2 detail lands; distinguishes "null on the server" from
+      // "not fetched yet". Stored as text (GRDB's Date encoding) for STRICT.
+      t.column("detail_fetched_at", .text)
+      t.column("data", .text).notNull()
+      t.primaryKey(["server_id", "id"])
+    }
+
+    try db.create(table: "query_order", options: [.strict]) { t in
+      t.column("server_id", .blob).notNull()
+      t.column("query_key", .text).notNull()
+      t.column("position", .integer).notNull()
+      t.column("remote_id", .integer).notNull()
+      t.primaryKey(["server_id", "query_key", "position"])
+
+      // Drop a list entry whenever its document row is deleted (the remote-delete
+      // cascade). Parent is `document`'s `(server_id, id)` primary key.
+      t.foreignKey(
+        ["server_id", "remote_id"], references: "document",
+        columns: ["server_id", "id"], onDelete: .cascade)
+    }
+
+    // Reverse lookup: "which queries contain this document?" — used by the
+    // mutation order-stale marking and to back the FK cascade efficiently. The
+    // forward/ordered scan (`WHERE server_id=? AND query_key=? ORDER BY position`)
+    // is already served by the primary-key index.
+    try db.create(
+      index: "idx_query_order_doc", on: "query_order",
+      columns: ["server_id", "remote_id"])
+
+    try db.create(table: "query_meta", options: [.strict]) { t in
+      t.column("server_id", .blob)
+        .notNull()
+        .references("server", onDelete: .cascade)
+      t.column("query_key", .text).notNull()
+      t.column("total_count", .integer)
+      t.column("order_stale", .integer).notNull().defaults(to: 0)
+      t.column("filled_at", .text)
+      t.primaryKey(["server_id", "query_key"])
+    }
+
+    // Regenerable per-server sync cursors (one row per server). Stored as REAL
+    // (`timeIntervalSinceReferenceDate`) for exact round-trips — the delta
+    // comparison is precision-sensitive. Cleared by `clearCache` (see `tables`).
+    try db.create(table: "server_sync_state", options: [.strict]) { t in
+      t.column("server_id", .blob)
+        .notNull()
+        .references("server", onDelete: .cascade)
+      // Newest document `modified` applied by the changed-metadata delta (R3δ).
+      t.column("delta_watermark", .real)
+      // Completed-at of the last successful proactive full-library fill.
+      t.column("library_coverage_at", .real)
+      t.primaryKey(["server_id"])
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -22,6 +22,14 @@ import GRDB
 /// Every table FK-references `server(id)` with `ON DELETE CASCADE`, so removing a
 /// connection tears down its whole document cache too.
 enum V4_CreateDocumentCache {
+  /// All document-cache tables. Listed `query_order`-before-`document` so a
+  /// blanket clear deletes children before parents (the cascade makes order
+  /// immaterial for correctness, but explicit is cheaper than relying on it).
+  /// `server_sync_state` is regenerable sync state (delta watermark + library
+  /// coverage), so a cache clear resets it too — the reconcile re-baselines and
+  /// the proactive fill re-runs over the now-empty cache.
+  static let tables = ["query_order", "query_meta", "document", "server_sync_state"]
+
   static func run(_ db: GRDB.Database) throws {
     try db.create(table: "document", options: [.strict]) { t in
       t.column("server_id", .blob)

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -16,7 +16,7 @@ import GRDB
 ///   `document` with `ON DELETE CASCADE` is load-bearing: deleting one document
 ///   row drops it from *every* list at once.
 /// - `query_meta` — one row per `(server_id, query_key)`: server-reported
-///   `total_count` (the scrollbar extent, which survives deletion gaps) and an
+///   `total_count` (the server's count, which survives deletion gaps) and an
 ///   `order_stale` flag set by mutations under the active sort.
 ///
 /// Every table FK-references `server(id)` with `ON DELETE CASCADE`, so removing a

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -61,7 +61,10 @@ enum V4_CreateDocumentCache {
       t.column("query_key", .text).notNull()
       t.column("position", .integer).notNull()
       t.column("remote_id", .integer).notNull()
-      t.primaryKey(["server_id", "query_key", "position"])
+      // `.replace` so a second writer claiming a position overwrites rather than
+      // aborting the whole page: the list fill and the proactive library fill can
+      // target the same query, and a thrown write kills the rest of the fill.
+      t.primaryKey(["server_id", "query_key", "position"], onConflict: .replace)
 
       // A document appears at most once per query. The server can repeat one
       // across adjacent pages when an insert/delete shifts the page offsets;

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -63,6 +63,12 @@ enum V4_CreateDocumentCache {
       t.column("remote_id", .integer).notNull()
       t.primaryKey(["server_id", "query_key", "position"])
 
+      // A document appears at most once per query. The server can repeat one
+      // across adjacent pages when an insert/delete shifts the page offsets;
+      // `.ignore` skips the second placement (leaving a `position` gap, which
+      // the ordered replay tolerates) while a `position` collision still aborts.
+      t.uniqueKey(["server_id", "query_key", "remote_id"], onConflict: .ignore)
+
       // Drop a list entry whenever its document row is deleted (the remote-delete
       // cascade). Parent is `document`'s `(server_id, id)` primary key.
       t.foreignKey(

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -2,7 +2,7 @@ import GRDB
 
 /// Document-metadata cache tables (Stage 8).
 ///
-/// Two jobs, two tables:
+/// Three tables, three jobs:
 ///
 /// - `document` — one row per `(server_id, id)`, query-independent. A document
 ///   that appears in many lists still has a single metadata row here. Indexed
@@ -21,14 +21,15 @@ import GRDB
 ///
 /// Every table FK-references `server(id)` with `ON DELETE CASCADE`, so removing a
 /// connection tears down its whole document cache too.
+///
+/// Per-server *sync cursors* deliberately live elsewhere: nothing in this build
+/// keeps one, so the table that holds them is created by the migration that
+/// introduces the first reader rather than sitting here unused.
 enum V4_CreateDocumentCache {
   /// All document-cache tables. Listed `query_order`-before-`document` so a
   /// blanket clear deletes children before parents (the cascade makes order
   /// immaterial for correctness, but explicit is cheaper than relying on it).
-  /// `server_sync_state` is regenerable sync state (delta watermark + library
-  /// coverage), so a cache clear resets it too — the reconcile re-baselines and
-  /// the proactive fill re-runs over the now-empty cache.
-  static let tables = ["query_order", "query_meta", "document", "server_sync_state"]
+  static let tables = ["query_order", "query_meta", "document"]
 
   static func run(_ db: GRDB.Database) throws {
     try db.create(table: "document", options: [.strict]) { t in
@@ -96,20 +97,6 @@ enum V4_CreateDocumentCache {
       t.column("order_stale", .integer).notNull().defaults(to: 0)
       t.column("filled_at", .text)
       t.primaryKey(["server_id", "query_key"])
-    }
-
-    // Regenerable per-server sync cursors (one row per server). Stored as REAL
-    // (`timeIntervalSinceReferenceDate`) for exact round-trips — the delta
-    // comparison is precision-sensitive. Cleared by `clearCache` (see `tables`).
-    try db.create(table: "server_sync_state", options: [.strict]) { t in
-      t.column("server_id", .blob)
-        .notNull()
-        .references("server", onDelete: .cascade)
-      // Newest document `modified` applied by the changed-metadata delta (R3δ).
-      t.column("delta_watermark", .real)
-      // Completed-at of the last successful proactive full-library fill.
-      t.column("library_coverage_at", .real)
-      t.primaryKey(["server_id"])
     }
   }
 }

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -41,6 +41,13 @@ enum V4_CreateDocumentCache {
       t.primaryKey(["server_id", "id"])
     }
 
+    // Serves `document(serverID:asn:)` (the ASN-scanner lookup). Partial: most
+    // documents have no ASN, so rows with `asn IS NULL` don't bloat the index.
+    try db.create(
+      index: "idx_document_asn", on: "document",
+      columns: ["server_id", "asn"],
+      condition: Column("asn") != nil)
+
     try db.create(table: "query_order", options: [.strict]) { t in
       t.column("server_id", .blob).notNull()
       t.column("query_key", .text).notNull()

--- a/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
@@ -1,0 +1,44 @@
+import GRDB
+
+/// Per-document detail-cache tables (Stage 8 follow-up) — the two Tier-2
+/// sub-resources that don't ride the `document` row's `data` blob because they
+/// have different keys and lifecycles:
+///
+/// - `document_note` — one row per `(server_id, document_id)`, holding the whole
+///   notes list as a JSON `data` blob. **Mutable**: each fetch / create / delete
+///   replaces the row, so it's keyed by document id (not version). The inline
+///   `notes` array on the document object is count-only by design (its shape
+///   changed across backends), so the stable content source is the separate
+///   `/notes/` endpoint cached here.
+/// - `file_metadata` — one row per `(server_id, version_id)`, holding the
+///   `/metadata/` sub-resource (checksums, sizes, mime, parsed item lists) as a
+///   JSON `data` blob. **Immutable per file version** (like `ContentStore`), so
+///   keying by version means a cached copy never goes stale until the version
+///   changes.
+///
+/// Both FK-reference `server(id)` with `ON DELETE CASCADE`, so removing a
+/// connection tears down its detail cache along with the rest.
+enum V5_CreateDocumentDetailCache {
+  /// Both detail-cache tables, for the blanket "clear local storage" sweep.
+  static let tables = ["document_note", "file_metadata"]
+
+  static func run(_ db: GRDB.Database) throws {
+    try db.create(table: "document_note", options: [.strict]) { t in
+      t.column("server_id", .blob)
+        .notNull()
+        .references("server", onDelete: .cascade)
+      t.column("document_id", .integer).notNull()
+      t.column("data", .text).notNull()
+      t.primaryKey(["server_id", "document_id"])
+    }
+
+    try db.create(table: "file_metadata", options: [.strict]) { t in
+      t.column("server_id", .blob)
+        .notNull()
+        .references("server", onDelete: .cascade)
+      t.column("version_id", .integer).notNull()
+      t.column("data", .text).notNull()
+      t.primaryKey(["server_id", "version_id"])
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
@@ -1,0 +1,60 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a document's cached notes list (`document_note` table, keyed
+/// `(server_id, document_id)`).
+///
+/// The whole list lives in one row's JSON `data` blob: the `/notes/` endpoint
+/// always returns the full list, and create/delete return the updated full list,
+/// so a cache write is a row *replace*, never a per-note merge. `DocumentNote`
+/// isn't `Codable`, so the long tail is an explicit storage `NotePayload` mapped
+/// by hand (the Stage 3 principle: storage shape ≠ wire shape ≠ domain shape).
+public struct DocumentNoteRecord:
+  FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
+{
+  public static let databaseTableName = "document_note"
+
+  public var serverId: UUID
+  public var documentId: UInt
+  public var notes: [NotePayload]
+
+  /// Storage-local copy of a `DocumentNote` (`DocumentNote.User` is already a
+  /// wire-symmetric `Codable` leaf, so it's reused directly).
+  public struct NotePayload: Codable, Sendable, Equatable {
+    public var id: UInt
+    public var note: String
+    public var created: Date
+    public var user: DocumentNote.User?
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case documentId = "document_id"
+    case notes = "data"
+  }
+
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+}
+
+extension DocumentNoteRecord {
+  public init(serverId: UUID, documentId: UInt, notes: [DocumentNote]) {
+    self.serverId = serverId
+    self.documentId = documentId
+    self.notes = notes.map {
+      NotePayload(id: $0.id, note: $0.note, created: $0.created, user: $0.user)
+    }
+  }
+
+  public var domain: [DocumentNote] {
+    notes.map {
+      DocumentNote(id: $0.id, note: $0.note, created: $0.created, user: $0.user)
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Models/DocumentRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentRecord.swift
@@ -1,0 +1,150 @@
+import Common
+import DataModel
+import Foundation
+import GRDB
+
+/// Completeness of a cached `document` row (the "tier" from the fetch model).
+///
+/// `idOnly` is an ordering/membership placeholder (renders a skeleton cell);
+/// `metadata` is renderable in a list cell; `detail` carries the full object
+/// (custom fields, notes, permissions) fetched when a document is opened.
+/// `Comparable` so the non-downgrade upsert can keep the richer of two writes.
+public enum DocumentProjection: Int, Codable, Sendable, Comparable {
+  case idOnly = 0
+  case metadata = 1
+  case detail = 2
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
+}
+
+/// GRDB record for a cached `Document` (`document` table, keyed `(server_id, id)`).
+///
+/// Bespoke rather than an `ElementRecord`: documents are ordered through
+/// `query_order` (never by `name`), carry a projection level, and `Document` is
+/// not `Codable` — so the long tail is an explicit storage `Payload`, mapped by
+/// hand (the Stage 3 principle: storage shape ≠ wire shape ≠ domain shape).
+public struct DocumentRecord:
+  FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
+{
+  public static let databaseTableName = "document"
+
+  public var serverId: UUID
+  public var id: UInt
+  public var title: String
+  public var asn: UInt?
+  public var projectionLevel: DocumentProjection
+  public var detailFetchedAt: Date?
+  public var payload: Payload
+
+  /// Storage-local copy of a `DocumentVersion` (decoupled from the domain type
+  /// so the on-disk shape doesn't track domain changes).
+  public struct VersionPayload: Codable, Sendable, Equatable {
+    public var id: UInt
+    public var added: Date
+    public var label: String?
+    public var checksum: String?
+    public var isRoot: Bool
+  }
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var documentType: UInt?
+    public var correspondent: UInt?
+    public var created: Date
+    public var tags: [UInt]
+    public var added: Date?
+    public var modified: Date?
+    public var originalFileName: String?
+    public var archivedFileName: String?
+    public var storagePath: UInt?
+    public var owner: Owner
+    public var pageCount: Int?
+    public var notesCount: Int
+    public var customFields: CustomFieldRawEntryList
+    public var versions: [VersionPayload]
+    public var userCanChange: Bool
+    // Populated only at `.detail`; preserved across lower-tier upserts.
+    public var permissions: Permissions?
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case id
+    case title
+    case asn
+    case projectionLevel = "projection_level"
+    case detailFetchedAt = "detail_fetched_at"
+    case payload = "data"
+  }
+
+  // Storage-dedicated JSON coders for the `data` column (sorted keys ⇒
+  // deterministic on-disk output), matching the element records.
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+}
+
+extension DocumentRecord {
+  public init(serverId: UUID, domain: Document, projectionLevel: DocumentProjection) {
+    self.serverId = serverId
+    id = domain.id
+    title = domain.title
+    asn = domain.asn
+    self.projectionLevel = projectionLevel
+    detailFetchedAt = projectionLevel == .detail ? Date() : nil
+    payload = Payload(
+      documentType: domain.documentType,
+      correspondent: domain.correspondent,
+      created: domain.created,
+      tags: domain.tags,
+      added: domain.added,
+      modified: domain.modified,
+      originalFileName: domain.originalFileName,
+      archivedFileName: domain.archivedFileName,
+      storagePath: domain.storagePath,
+      owner: domain.owner,
+      pageCount: domain.pageCount,
+      notesCount: domain.notes.count,
+      customFields: domain.customFields,
+      versions: domain.versions.map {
+        VersionPayload(
+          id: $0.id, added: $0.added, label: $0.label,
+          checksum: $0.checksum, isRoot: $0.isRoot)
+      },
+      userCanChange: domain.userCanChange,
+      permissions: domain.permissions)
+  }
+
+  public var domain: Document {
+    var document = Document(
+      id: id,
+      title: title,
+      asn: asn,
+      documentType: payload.documentType,
+      correspondent: payload.correspondent,
+      created: payload.created,
+      tags: payload.tags,
+      added: payload.added,
+      modified: payload.modified,
+      originalFileName: payload.originalFileName,
+      archivedFileName: payload.archivedFileName,
+      storagePath: payload.storagePath,
+      owner: payload.owner,
+      pageCount: payload.pageCount,
+      notes: NotesPayload(count: payload.notesCount),
+      customFields: payload.customFields,
+      versions: payload.versions.map {
+        DocumentVersion(
+          id: $0.id, added: $0.added, label: $0.label,
+          checksum: $0.checksum, isRoot: $0.isRoot)
+      },
+      userCanChange: payload.userCanChange)
+    document.permissions = payload.permissions
+    return document
+  }
+}

--- a/Persistence/Sources/Persistence/Models/FileMetadataRecord.swift
+++ b/Persistence/Sources/Persistence/Models/FileMetadataRecord.swift
@@ -1,0 +1,85 @@
+import DataModel
+import Foundation
+import GRDB
+
+/// GRDB record for a file version's cached `/metadata/` sub-resource
+/// (`file_metadata` table, keyed `(server_id, version_id)`).
+///
+/// Immutable per file version, so a cached copy never goes stale until the
+/// version changes — hence the version key rather than the document id. `Metadata`
+/// isn't `Codable`, so the payload is an explicit storage mirror mapped by hand
+/// (`Metadata.Item` is already a wire-symmetric `Codable` leaf and is reused).
+public struct FileMetadataRecord:
+  FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
+{
+  public static let databaseTableName = "file_metadata"
+
+  public var serverId: UUID
+  public var versionId: UInt
+  public var payload: Payload
+
+  public struct Payload: Codable, Sendable, Equatable {
+    public var originalChecksum: String
+    public var originalSize: Int64
+    public var originalMimeType: String
+    public var mediaFilename: String
+    public var hasArchiveVersion: Bool
+    public var originalMetadata: [Metadata.Item]
+    public var archiveChecksum: String?
+    public var archiveMediaFilename: String?
+    public var originalFilename: String
+    public var archiveSize: Int64?
+    public var archiveMetadata: [Metadata.Item]?
+    public var lang: String
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case versionId = "version_id"
+    case payload = "data"
+  }
+
+  public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
+    ElementStorage.encoder
+  }
+
+  public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
+    ElementStorage.decoder
+  }
+}
+
+extension FileMetadataRecord {
+  public init(serverId: UUID, versionId: UInt, domain: Metadata) {
+    self.serverId = serverId
+    self.versionId = versionId
+    payload = Payload(
+      originalChecksum: domain.originalChecksum,
+      originalSize: domain.originalSize,
+      originalMimeType: domain.originalMimeType,
+      mediaFilename: domain.mediaFilename,
+      hasArchiveVersion: domain.hasArchiveVersion,
+      originalMetadata: domain.originalMetadata,
+      archiveChecksum: domain.archiveChecksum,
+      archiveMediaFilename: domain.archiveMediaFilename,
+      originalFilename: domain.originalFilename,
+      archiveSize: domain.archiveSize,
+      archiveMetadata: domain.archiveMetadata,
+      lang: domain.lang)
+  }
+
+  public var domain: Metadata {
+    Metadata(
+      originalChecksum: payload.originalChecksum,
+      originalSize: payload.originalSize,
+      originalMimeType: payload.originalMimeType,
+      mediaFilename: payload.mediaFilename,
+      hasArchiveVersion: payload.hasArchiveVersion,
+      originalMetadata: payload.originalMetadata,
+      archiveChecksum: payload.archiveChecksum,
+      archiveMediaFilename: payload.archiveMediaFilename,
+      originalFilename: payload.originalFilename,
+      archiveSize: payload.archiveSize,
+      archiveMetadata: payload.archiveMetadata,
+      lang: payload.lang)
+  }
+}

--- a/Persistence/Sources/Persistence/Models/QueryKey.swift
+++ b/Persistence/Sources/Persistence/Models/QueryKey.swift
@@ -1,0 +1,55 @@
+import CryptoKit
+import DataModel
+import Foundation
+
+/// Stable identity of a *cached query* — the key under which a list's ordered
+/// membership is stored in `query_order` / `query_meta`.
+///
+/// The list is not always a saved view: it can be the default list, a saved view
+/// with the user's sort changed, or a saved view plus an ad-hoc filter — each of
+/// which the server answers with a *different ordered membership*. So a
+/// server-replay query derives its key by hashing the **effective server query**
+/// (the filter rules' query items + the sort), which is exactly what determines
+/// the server's response. Keying on a saved-view id instead would collide all of
+/// those.
+///
+/// Two notes on correctness:
+/// - The hash is **CryptoKit `SHA256`**, not Swift's `Hasher` — `Hasher` is
+///   seeded per process, so a `Hasher`-derived key would change every launch and
+///   never match yesterday's cached rows.
+/// - The canonical input is `FilterRule.queryItems(for:)` (which already sorts
+///   multi-value rule values) re-sorted as `name=value` lines, so it is
+///   independent of dictionary iteration order and of the transient
+///   `FilterState.modified` flag (which is not a query parameter).
+///
+/// Virtual / client-defined views (e.g. Stage 14's pinned "Downloaded" list) use
+/// a ``init(sentinel:)`` well-known key instead of a hash, since they have no
+/// server query to replay.
+public struct QueryKey: Hashable, Sendable {
+  public let rawValue: String
+
+  public init(serverID: UUID, filter: FilterState) {
+    let ordering = (filter.sortOrder.reverse ? "-" : "") + filter.sortField.rawValue
+    // `.legacy` is used as a *canonical* encoding, not because the request will
+    // use it: the same search is spelled `title_content`/`title__icontains`
+    // pre-3.0 and `text`/`title_search` on 3.0+, and hashing whichever the
+    // backend happens to want would move every key when a server upgrades.
+    // Fixing the encoding keeps a query's identity stable across that upgrade.
+    let ruleLines =
+      FilterRule.queryItems(for: filter.rules(for: .legacy))
+      .map { "\($0.name)=\($0.value ?? "")" }
+      .sorted()
+    let canonical = (["ordering=\(ordering)"] + ruleLines).joined(separator: "\n")
+
+    var hasher = SHA256()
+    hasher.update(data: Data(serverID.uuidString.utf8))
+    hasher.update(data: Data([0]))  // domain separator
+    hasher.update(data: Data(canonical.utf8))
+    rawValue = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+  }
+
+  /// A well-known, non-hashed key for a virtual/local view.
+  public init(sentinel: String) {
+    rawValue = sentinel
+  }
+}

--- a/Persistence/Sources/Persistence/Models/QueryOrderRow.swift
+++ b/Persistence/Sources/Persistence/Models/QueryOrderRow.swift
@@ -1,0 +1,59 @@
+import Foundation
+import GRDB
+
+/// One ordered membership entry of a cached query (`query_order` table).
+/// `position` is the server-order index (0-based, gappy after a deletion — gaps
+/// are made invisible by windowing on ordered row offset, not by renumbering).
+struct QueryOrderRow: FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
+{
+  static let databaseTableName = "query_order"
+
+  var serverId: UUID
+  var queryKey: String
+  var position: Int
+  var remoteId: UInt
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case queryKey = "query_key"
+    case position
+    case remoteId = "remote_id"
+  }
+}
+
+/// Per-query bookkeeping (`query_meta` table): the server-reported total (the
+/// scrollbar extent, which survives local deletion gaps) and the order-stale
+/// flag a mutation sets when it changes a field under the active sort.
+struct QueryMetaRow: FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable {
+  static let databaseTableName = "query_meta"
+
+  var serverId: UUID
+  var queryKey: String
+  var totalCount: UInt?
+  var orderStale: Bool
+  var filledAt: Date?
+
+  enum CodingKeys: String, CodingKey {
+    case serverId = "server_id"
+    case queryKey = "query_key"
+    case totalCount = "total_count"
+    case orderStale = "order_stale"
+    case filledAt = "filled_at"
+  }
+}
+
+/// Public status of a cached query, surfaced to the list view-model: the
+/// server's `totalCount` (scrollbar extent), how many rows are locally present
+/// (`localCount`, reflects deletion gaps), and whether the cached order is stale
+/// under the active sort.
+public struct QueryStatus: Equatable, Sendable {
+  public var totalCount: UInt?
+  public var localCount: Int
+  public var orderStale: Bool
+
+  public init(totalCount: UInt?, localCount: Int, orderStale: Bool) {
+    self.totalCount = totalCount
+    self.localCount = localCount
+    self.orderStale = orderStale
+  }
+}

--- a/Persistence/Sources/Persistence/Models/QueryOrderRow.swift
+++ b/Persistence/Sources/Persistence/Models/QueryOrderRow.swift
@@ -21,9 +21,9 @@ struct QueryOrderRow: FetchableRecord, PersistableRecord, TableRecord, Codable, 
   }
 }
 
-/// Per-query bookkeeping (`query_meta` table): the server-reported total (the
-/// scrollbar extent, which survives local deletion gaps) and the order-stale
-/// flag a mutation sets when it changes a field under the active sort.
+/// Per-query bookkeeping (`query_meta` table): the server-reported total (which
+/// survives local deletion gaps) and the order-stale flag a mutation sets when
+/// it changes a field under the active sort.
 struct QueryMetaRow: FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable {
   static let databaseTableName = "query_meta"
 
@@ -43,9 +43,10 @@ struct QueryMetaRow: FetchableRecord, PersistableRecord, TableRecord, Codable, S
 }
 
 /// Public status of a cached query, surfaced to the list view-model: the
-/// server's `totalCount` (scrollbar extent), how many rows are locally present
-/// (`localCount`, reflects deletion gaps), and whether the cached order is stale
-/// under the active sort.
+/// server's `totalCount` (what the count pill shows — the list renders only the
+/// locally-loaded prefix, so this is not a scroll extent), how many rows are
+/// locally present (`localCount`, reflects deletion gaps), and whether the
+/// cached order is stale under the active sort.
 public struct QueryStatus: Equatable, Sendable {
   public var totalCount: UInt?
   public var localCount: Int

--- a/Persistence/Tests/PersistenceTests/DatabaseSchemaTests.swift
+++ b/Persistence/Tests/PersistenceTests/DatabaseSchemaTests.swift
@@ -78,4 +78,15 @@ struct DatabaseSchemaTests {
     }
     #expect(serverExists)
   }
+
+  @Test("v4 indexes document.asn for the ASN-scanner lookup")
+  func v4IndexesDocumentAsn() throws {
+    let database = try Database.inMemory()
+    try database.writer.read { db in
+      let indexed = try db.indexes(on: "document").contains { index in
+        index.columns == ["server_id", "asn"]
+      }
+      #expect(indexed)
+    }
+  }
 }

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -255,6 +255,31 @@ struct DocumentCacheTests {
     #expect(removed == [1])
   }
 
+  // MARK: - Cache wipe (keeps connections)
+
+  @Test("clearCache wipes document + query rows but keeps the server connection")
+  func clearCacheKeepsServer() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "A")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+
+    try database.clearCache()
+
+    let counts = try await database.writer.read { db in
+      (
+        try DocumentRecord.fetchCount(db),
+        try QueryOrderRow.fetchCount(db),
+        try QueryMetaRow.fetchCount(db)
+      )
+    }
+    #expect(counts == (0, 0, 0))
+    // The connection survives the wipe.
+    #expect(try database.allConnections().contains { $0.id == server })
+  }
+
   // MARK: - Cascade from server delete
 
   @Test("removing a connection tears down its document + query_order rows")

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -1,0 +1,264 @@
+import DataModel
+import Foundation
+import GRDB
+import Testing
+
+@testable import Persistence
+
+@Suite("DocumentCache")
+struct DocumentCacheTests {
+  // MARK: - Helpers
+
+  private func date(_ t: TimeInterval) -> Date { Date(timeIntervalSince1970: t) }
+
+  private func doc(_ id: UInt, _ title: String, asn: UInt? = nil) -> Document {
+    Document(
+      id: id, title: title, asn: asn, created: date(1000), tags: [],
+      owner: .user(1))
+  }
+
+  /// A fresh in-memory DB with one server registered.
+  private func database(_ server: UUID) throws -> Persistence.Database {
+    try Database.seeded(serverID: server)
+  }
+
+  private func record(
+    _ database: Persistence.Database, _ server: UUID, _ id: UInt
+  ) throws -> DocumentRecord? {
+    try database.writer.read { db in
+      try DocumentRecord
+        .filter(Column("server_id") == server && Column("id") == id)
+        .fetchOne(db)
+    }
+  }
+
+  // MARK: - Round-trip
+
+  @Test("DocumentRecord round-trips a fully-populated document, including versions")
+  func roundTrip() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    var input = Document(
+      id: 1, title: "Invoice", asn: 42, documentType: 2, correspondent: 3,
+      created: date(1000), tags: [4, 5], added: date(2000), modified: date(3000),
+      originalFileName: "scan.pdf", archivedFileName: "archive.pdf",
+      storagePath: 6, owner: .user(7), pageCount: 3, notes: NotesPayload(count: 2),
+      versions: [
+        DocumentVersion(id: 1, added: date(1000), isRoot: true),
+        DocumentVersion(id: 9, added: date(5000), label: "v2", isRoot: false),
+      ])
+    // Mirror how a document arrives from the API (permissions assigned post-init,
+    // which also sets setPermissions via didSet) so equality holds round-trip.
+    input.permissions = Permissions { $0.view = .init(users: [1, 2]) }
+
+    try database.upsertDocument(input, serverID: server, projectionLevel: .detail)
+    let output = try database.document(serverID: server, id: 1)
+
+    #expect(output == input)
+    #expect(output?.currentVersionID == 9)  // newest by `added`
+    #expect(output?.rootVersionID == 1)
+  }
+
+  @Test("document(asn:) resolves via the indexed column")
+  func resolvesByAsn() async throws {
+    let server = UUID()
+    let database = try database(server)
+    try database.upsertDocuments(
+      [doc(1, "A", asn: 100), doc(2, "B", asn: 200)],
+      serverID: server, projectionLevel: .metadata)
+
+    #expect(try database.document(serverID: server, asn: 200)?.id == 2)
+    #expect(try database.document(serverID: server, asn: 999) == nil)
+  }
+
+  // MARK: - query_order replay
+
+  @Test("queryDocuments replays the server order, not id/sort order")
+  func replaysServerOrder() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "test")
+
+    // Written out of natural id order.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server,
+      documents: [doc(3, "C"), doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 3, replaceAll: true)
+
+    let replayed = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    #expect(replayed.map(\.id) == [3, 1, 2])
+  }
+
+  @Test("a page-appended fill preserves order and updates the count")
+  func appendPreservesOrder() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "test")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 4, replaceAll: true)
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
+      startPosition: 2, totalCount: 4, replaceAll: false)
+
+    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    #expect(all.map(\.id) == [1, 2, 3, 4])
+    #expect(try database.queryStatus(queryKey: key, serverID: server).totalCount == 4)
+  }
+
+  // MARK: - Windowing + deletion gaps
+
+  @Test("the window is by ordered row offset, so deletion gaps are invisible")
+  func deletionGapInvisible() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "test")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server,
+      documents: (10...14).map { doc($0, "d\($0)") },
+      startPosition: 0, totalCount: 5, replaceAll: true)
+
+    // Delete the doc at position 2 — its query_order row cascades away.
+    try database.deleteDocuments(serverID: server, removedIDs: [12])
+
+    let window = try database.queryDocuments(queryKey: key, serverID: server, limit: 5)
+    #expect(window.map(\.id) == [10, 11, 13, 14])  // gap at position 2 is invisible
+
+    // Offset windows step by ordered row, not by raw position.
+    let tail = try database.queryDocuments(queryKey: key, serverID: server, limit: 2, offset: 2)
+    #expect(tail.map(\.id) == [13, 14])
+
+    let status = try database.queryStatus(queryKey: key, serverID: server)
+    #expect(status.localCount == 4)  // one row gone locally
+    #expect(status.totalCount == 5)  // server extent unchanged
+  }
+
+  @Test("a delete cascades to every query containing the document")
+  func cascadeAcrossQueries() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let keyA = QueryKey(sentinel: "A")
+    let keyB = QueryKey(sentinel: "B")
+
+    try database.writeQueryPage(
+      queryKey: keyA, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+    try database.writeQueryPage(
+      queryKey: keyB, serverID: server, documents: [doc(2, "B"), doc(3, "C")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+
+    try database.deleteDocuments(serverID: server, removedIDs: [2])
+
+    #expect(
+      try database.queryDocuments(queryKey: keyA, serverID: server, limit: 10).map(\.id) == [1])
+    #expect(
+      try database.queryDocuments(queryKey: keyB, serverID: server, limit: 10).map(\.id) == [3])
+  }
+
+  // MARK: - Non-downgrade upsert
+
+  @Test("a Tier-1 upsert does not clobber an existing Tier-2 row")
+  func nonDowngradeUpsert() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    var detailed = doc(1, "Detail")
+    detailed.permissions = Permissions { $0.view = .init(users: [9]) }
+    try database.upsertDocument(detailed, serverID: server, projectionLevel: .detail)
+
+    // A later list fill arrives at Tier-1 with no permissions.
+    try database.upsertDocuments([doc(1, "Detail")], serverID: server, projectionLevel: .metadata)
+
+    let stored = try record(database, server, 1)
+    #expect(stored?.projectionLevel == .detail)
+    #expect(stored?.detailFetchedAt != nil)
+    #expect(stored?.payload.permissions?.view.users == [9])
+  }
+
+  @Test("a Tier-2 upsert upgrades an existing Tier-1 row")
+  func upgradeToDetail() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try database.upsertDocuments([doc(1, "Doc")], serverID: server, projectionLevel: .metadata)
+    #expect(try record(database, server, 1)?.projectionLevel == .metadata)
+    #expect(try record(database, server, 1)?.detailFetchedAt == nil)
+
+    var detailed = doc(1, "Doc")
+    detailed.permissions = Permissions { $0.change = .init(groups: [3]) }
+    try database.upsertDocument(detailed, serverID: server, projectionLevel: .detail)
+
+    let stored = try record(database, server, 1)
+    #expect(stored?.projectionLevel == .detail)
+    #expect(stored?.detailFetchedAt != nil)
+    #expect(stored?.payload.permissions?.change.groups == [3])
+  }
+
+  // MARK: - Order staleness
+
+  @Test("markQueriesOrderStale flips the flag only for queries containing the doc")
+  func markOrderStale() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let keyA = QueryKey(sentinel: "A")
+    let keyB = QueryKey(sentinel: "B")
+
+    try database.writeQueryPage(
+      queryKey: keyA, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+    try database.writeQueryPage(
+      queryKey: keyB, serverID: server, documents: [doc(2, "B")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+
+    #expect(try database.queryStatus(queryKey: keyA, serverID: server).orderStale == false)
+
+    try database.markQueriesOrderStale(containing: 1, serverID: server)
+
+    #expect(try database.queryStatus(queryKey: keyA, serverID: server).orderStale == true)
+    #expect(try database.queryStatus(queryKey: keyB, serverID: server).orderStale == false)
+  }
+
+  @Test("a fresh fill clears the order-stale flag")
+  func fillClearsStale() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "A")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+    try database.markQueriesOrderStale(containing: 1, serverID: server)
+    #expect(try database.queryStatus(queryKey: key, serverID: server).orderStale == true)
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+    #expect(try database.queryStatus(queryKey: key, serverID: server).orderStale == false)
+  }
+
+  // MARK: - Cascade from server delete
+
+  @Test("removing a connection tears down its document + query_order rows")
+  func connectionCascade() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "A")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+
+    _ = try database.deleteConnection(id: server)
+
+    let counts = try await database.writer.read { db in
+      (
+        try DocumentRecord.fetchCount(db),
+        try QueryOrderRow.fetchCount(db),
+        try QueryMetaRow.fetchCount(db)
+      )
+    }
+    #expect(counts == (0, 0, 0))
+  }
+}

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -239,6 +239,22 @@ struct DocumentCacheTests {
     #expect(try database.queryStatus(queryKey: key, serverID: server).orderStale == false)
   }
 
+  // MARK: - Reconcile support
+
+  @Test("allDocumentIDs returns every cached document id for the server")
+  func allDocumentIDs() async throws {
+    let server = UUID()
+    let database = try database(server)
+    try database.upsertDocuments(
+      [doc(1, "A"), doc(2, "B"), doc(3, "C")], serverID: server, projectionLevel: .metadata)
+
+    #expect(try database.allDocumentIDs(serverID: server) == [1, 2, 3])
+    // The reconcile diff: local − server.
+    let serverIDs: Set<UInt> = [2, 3, 4]
+    let removed = try database.allDocumentIDs(serverID: server).subtracting(serverIDs)
+    #expect(removed == [1])
+  }
+
   // MARK: - Cascade from server delete
 
   @Test("removing a connection tears down its document + query_order rows")

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -108,6 +108,44 @@ struct DocumentCacheTests {
     #expect(try database.queryStatus(queryKey: key, serverID: server).totalCount == 4)
   }
 
+  @Test("a document repeated across a page boundary is placed only once")
+  func overlappingPageDoesNotDuplicate() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "test")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B"), doc(3, "C")],
+      startPosition: 0, totalCount: 4, replaceAll: true)
+    // Page 2 re-delivers doc 3, as it does when the page offsets shift.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
+      startPosition: 3, totalCount: 4, replaceAll: false)
+
+    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    #expect(all.map(\.id) == [1, 2, 3, 4])
+    // A duplicate would inflate `localCount` as well as duplicating the row.
+    #expect(try database.queryStatus(queryKey: key, serverID: server).localCount == 4)
+  }
+
+  @Test("uniqueness is per query, so a document can sit in several lists")
+  func uniquenessIsScopedToTheQuery() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let a = QueryKey(sentinel: "a")
+    let b = QueryKey(sentinel: "b")
+
+    try database.writeQueryPage(
+      queryKey: a, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+    try database.writeQueryPage(
+      queryKey: b, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+
+    #expect(try database.queryDocuments(queryKey: a, serverID: server, limit: 10).map(\.id) == [1])
+    #expect(try database.queryDocuments(queryKey: b, serverID: server, limit: 10).map(\.id) == [1])
+  }
+
   // MARK: - Windowing + deletion gaps
 
   @Test("the window is by ordered row offset, so deletion gaps are invisible")

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -128,6 +128,25 @@ struct DocumentCacheTests {
     #expect(try database.queryStatus(queryKey: key, serverID: server).localCount == 4)
   }
 
+  @Test("a second writer on the same position overwrites instead of throwing")
+  func positionCollisionDoesNotAbort() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "test")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+    // A concurrent fill lands on the same positions with different documents.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
+      startPosition: 0, totalCount: 2, replaceAll: false)
+
+    // The later write wins, as it did when this used `upsert`.
+    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    #expect(all.map(\.id) == [3, 4])
+  }
+
   @Test("uniqueness is per query, so a document can sit in several lists")
   func uniquenessIsScopedToTheQuery() async throws {
     let server = UUID()

--- a/Persistence/Tests/PersistenceTests/DocumentDetailCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentDetailCacheTests.swift
@@ -1,0 +1,154 @@
+import DataModel
+import Foundation
+import GRDB
+import Testing
+
+@testable import Persistence
+
+@Suite("DocumentDetailCache")
+struct DocumentDetailCacheTests {
+  // MARK: - Helpers
+
+  private func date(_ t: TimeInterval) -> Date { Date(timeIntervalSince1970: t) }
+
+  private func database(_ server: UUID) throws -> Persistence.Database {
+    try Database.seeded(serverID: server)
+  }
+
+  private func note(_ id: UInt, _ text: String, user: DocumentNote.User? = nil) -> DocumentNote {
+    DocumentNote(id: id, note: text, created: date(1000), user: user)
+  }
+
+  private func metadata(_ checksum: String, archive: Bool = false) -> Metadata {
+    Metadata(
+      originalChecksum: checksum,
+      originalSize: 1234,
+      originalMimeType: "application/pdf",
+      mediaFilename: "scan.pdf",
+      hasArchiveVersion: archive,
+      originalMetadata: [
+        .init(namespace: "ns", prefix: "pre", key: "k", value: "v")
+      ],
+      archiveChecksum: archive ? "arch-\(checksum)" : nil,
+      archiveMediaFilename: archive ? "archive.pdf" : nil,
+      originalFilename: "scan.pdf",
+      archiveSize: archive ? 5678 : nil,
+      archiveMetadata: archive ? [.init(namespace: "a", prefix: "p", key: "ak", value: "av")] : nil,
+      lang: "en")
+  }
+
+  // MARK: - Notes round-trip
+
+  @Test("notes round-trip through set + read, preserving user")
+  func notesRoundTrip() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    let notes = [
+      note(1, "First", user: .init(id: 7, username: "alice")),
+      note(2, "Second"),
+    ]
+    try database.setNotes(notes, serverID: server, documentID: 42)
+
+    #expect(try database.notes(serverID: server, documentID: 42) == notes)
+  }
+
+  @Test("absent notes read as nil, distinct from a cached empty list")
+  func notesAbsentVsEmpty() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    #expect(try database.notes(serverID: server, documentID: 42) == nil)
+
+    try database.setNotes([], serverID: server, documentID: 42)
+    #expect(try database.notes(serverID: server, documentID: 42) == [])
+  }
+
+  @Test("set replaces the whole notes list, never merges")
+  func notesReplace() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try database.setNotes([note(1, "a"), note(2, "b")], serverID: server, documentID: 42)
+    try database.setNotes([note(3, "c")], serverID: server, documentID: 42)
+
+    #expect(try database.notes(serverID: server, documentID: 42) == [note(3, "c")])
+  }
+
+  // MARK: - File-metadata round-trip
+
+  @Test("file-metadata round-trips, including the archive fields and item lists")
+  func metadataRoundTrip() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    let input = metadata("abc123", archive: true)
+    try database.setFileMetadata(input, serverID: server, versionID: 9)
+
+    let output = try #require(try database.fileMetadata(serverID: server, versionID: 9))
+    #expect(output.originalChecksum == input.originalChecksum)
+    #expect(output.hasArchiveVersion == input.hasArchiveVersion)
+    #expect(output.archiveChecksum == input.archiveChecksum)
+    #expect(output.archiveSize == input.archiveSize)
+    #expect(output.originalMetadata.map(\.value) == ["v"])
+    #expect(output.archiveMetadata?.map(\.value) == ["av"])
+    #expect(output.lang == input.lang)
+  }
+
+  @Test("absent file-metadata reads as nil")
+  func metadataAbsent() throws {
+    let server = UUID()
+    let database = try database(server)
+    #expect(try database.fileMetadata(serverID: server, versionID: 9) == nil)
+  }
+
+  @Test("file-metadata is keyed per version")
+  func metadataVersionKeyed() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try database.setFileMetadata(metadata("v1sum"), serverID: server, versionID: 1)
+    try database.setFileMetadata(metadata("v2sum"), serverID: server, versionID: 2)
+
+    #expect(try database.fileMetadata(serverID: server, versionID: 1)?.originalChecksum == "v1sum")
+    #expect(try database.fileMetadata(serverID: server, versionID: 2)?.originalChecksum == "v2sum")
+  }
+
+  // MARK: - Server isolation
+
+  @Test("notes and file-metadata are isolated per server")
+  func serverIsolation() throws {
+    let serverA = UUID()
+    let serverB = UUID()
+    let database = try database(serverA)
+    // Register the second server so its FK is satisfiable.
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverB,
+        url: URL(string: "https://other.example.com/api/")!,
+        user: .init(id: 1, isSuperUser: true, username: "bob")))
+
+    try database.setNotes([note(1, "a-note")], serverID: serverA, documentID: 42)
+    try database.setFileMetadata(metadata("a-sum"), serverID: serverA, versionID: 9)
+
+    #expect(try database.notes(serverID: serverB, documentID: 42) == nil)
+    #expect(try database.fileMetadata(serverID: serverB, versionID: 9) == nil)
+    #expect(try database.notes(serverID: serverA, documentID: 42) == [note(1, "a-note")])
+  }
+
+  // MARK: - Cascade
+
+  @Test("clearCache drops cached notes and file-metadata")
+  func clearCacheSweeps() throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try database.setNotes([note(1, "a")], serverID: server, documentID: 42)
+    try database.setFileMetadata(metadata("sum"), serverID: server, versionID: 9)
+
+    try database.clearCache()
+
+    #expect(try database.notes(serverID: server, documentID: 42) == nil)
+    #expect(try database.fileMetadata(serverID: server, versionID: 9) == nil)
+  }
+}

--- a/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
@@ -1,0 +1,187 @@
+import DataModel
+import Foundation
+import Testing
+
+@testable import Persistence
+
+@Suite("DocumentObservation")
+struct DocumentObservationTests {
+  // MARK: - Helpers
+
+  private struct TimeoutError: Error {}
+
+  private func firstValue<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
+  /// The emission that lands *after* `action` runs (consumes the initial value
+  /// first, which also guarantees the observation is subscribed before the write).
+  private func value<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>,
+    afterSubscribe action: @escaping @Sendable () async throws -> Void
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      _ = try await iterator.next()
+      try await action()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
+  private func withTimeout<T: Sendable>(
+    seconds: Double = 3,
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+      group.addTask { try await operation() }
+      group.addTask {
+        try await Task.sleep(for: .seconds(seconds))
+        throw TimeoutError()
+      }
+      let result = try await group.next()!
+      group.cancelAll()
+      return result
+    }
+  }
+
+  private func doc(_ id: UInt, _ title: String) -> Document {
+    Document(
+      id: id, title: title, created: Date(timeIntervalSince1970: 1000), tags: [], owner: .user(1))
+  }
+
+  // MARK: - observeDocumentPrefix
+
+  @Test("observeDocumentPrefix emits the current window in replay order")
+  func prefixInitial() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(3, "C"), doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 3, replaceAll: true)
+
+    let initial = try await firstValue(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10))
+    #expect(initial.map(\.id) == [3, 1, 2])
+  }
+
+  @Test("observeDocumentPrefix honours the limit (prefix, not the whole set)")
+  func prefixLimited() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: (1...5).map { doc($0, "d\($0)") },
+      startPosition: 0, totalCount: 5, replaceAll: true)
+
+    let window = try await firstValue(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 2))
+    #expect(window.map(\.id) == [1, 2])
+  }
+
+  @Test("observeDocumentPrefix re-emits as a background fill appends pages")
+  func prefixReemitsOnAppend() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 4, replaceAll: true)
+
+    let grown = try await value(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
+    ) {
+      try database.writeQueryPage(
+        queryKey: key, serverID: server, documents: [self.doc(3, "C"), self.doc(4, "D")],
+        startPosition: 2, totalCount: 4, replaceAll: false)
+    }
+    #expect(grown.map(\.id) == [1, 2, 3, 4])
+  }
+
+  @Test("observeDocumentPrefix re-emits an in-place metadata update")
+  func prefixReemitsOnUpsert() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+
+    let updated = try await value(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
+    ) {
+      try database.upsertDocument(
+        self.doc(1, "A-edited"), serverID: server, projectionLevel: .metadata)
+    }
+    #expect(updated.first(where: { $0.id == 1 })?.title == "A-edited")
+  }
+
+  @Test("observeDocumentPrefix re-emits with the gap invisible after a delete")
+  func prefixReemitsOnDelete() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B"), doc(3, "C")],
+      startPosition: 0, totalCount: 3, replaceAll: true)
+
+    let remaining = try await value(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
+    ) {
+      try database.deleteDocuments(serverID: server, removedIDs: [2])
+    }
+    #expect(remaining.map(\.id) == [1, 3])
+  }
+
+  // MARK: - observeQueryStatus
+
+  @Test("observeQueryStatus reports counts and re-emits after markStale")
+  func queryStatus() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 5, replaceAll: true)
+
+    let initial = try await firstValue(
+      from: database.observeQueryStatus(queryKey: key, serverID: server))
+    #expect(initial == QueryStatus(totalCount: 5, localCount: 2, orderStale: false))
+
+    let stale = try await value(
+      from: database.observeQueryStatus(queryKey: key, serverID: server)
+    ) {
+      try database.markQueriesOrderStale(containing: 1, serverID: server)
+    }
+    #expect(stale.orderStale == true)
+  }
+
+  // MARK: - observeDocument
+
+  @Test("observeDocument emits nil cold, then the value, then in-place updates")
+  func singleDocument() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+
+    let cold = try await firstValue(from: database.observeDocument(serverID: server, id: 1))
+    #expect(cold == nil)
+
+    let appeared = try await value(from: database.observeDocument(serverID: server, id: 1)) {
+      try database.upsertDocument(self.doc(1, "A"), serverID: server, projectionLevel: .metadata)
+    }
+    #expect(appeared?.title == "A")
+
+    let edited = try await value(from: database.observeDocument(serverID: server, id: 1)) {
+      try database.upsertDocument(
+        self.doc(1, "A-edited"), serverID: server, projectionLevel: .metadata)
+    }
+    #expect(edited?.title == "A-edited")
+  }
+}

--- a/Persistence/Tests/PersistenceTests/QueryKeyTests.swift
+++ b/Persistence/Tests/PersistenceTests/QueryKeyTests.swift
@@ -1,0 +1,67 @@
+import DataModel
+import Foundation
+import Testing
+
+@testable import Persistence
+
+@Suite("QueryKey")
+struct QueryKeyTests {
+  private let server = UUID()
+
+  @Test("is deterministic across re-computation (the SHA-vs-Hasher guard)")
+  func deterministic() {
+    let filter = FilterState.empty
+    #expect(
+      QueryKey(serverID: server, filter: filter).rawValue
+        == QueryKey(serverID: server, filter: filter).rawValue)
+  }
+
+  @Test("ignores the transient `modified` flag")
+  func ignoresModified() {
+    let a = FilterState.empty
+    var b = FilterState.empty
+    b.modified = true
+    #expect(QueryKey(serverID: server, filter: a) == QueryKey(serverID: server, filter: b))
+  }
+
+  @Test("changes when the sort order flips")
+  func sortOrderMatters() {
+    let asc = FilterState.empty.with { $0.sortOrder = .ascending }
+    let desc = FilterState.empty.with { $0.sortOrder = .descending }
+    #expect(QueryKey(serverID: server, filter: asc) != QueryKey(serverID: server, filter: desc))
+  }
+
+  @Test("changes when the sort field changes")
+  func sortFieldMatters() {
+    let byAsn = FilterState.empty.with { $0.sortField = .asn }
+    let byTitle = FilterState.empty.with { $0.sortField = .title }
+    #expect(
+      QueryKey(serverID: server, filter: byAsn) != QueryKey(serverID: server, filter: byTitle))
+  }
+
+  @Test("changes when a filter rule changes")
+  func filterRulesMatter() {
+    let one = FilterState.empty.with { $0.correspondent = .anyOf(ids: [1]) }
+    let two = FilterState.empty.with { $0.correspondent = .anyOf(ids: [2]) }
+    #expect(QueryKey(serverID: server, filter: one) != QueryKey(serverID: server, filter: two))
+  }
+
+  @Test("is independent of the order ids were added to a multi-value filter")
+  func idOrderStable() {
+    let a = FilterState.empty.with { $0.correspondent = .anyOf(ids: [1, 2, 3]) }
+    let b = FilterState.empty.with { $0.correspondent = .anyOf(ids: [3, 1, 2]) }
+    #expect(QueryKey(serverID: server, filter: a) == QueryKey(serverID: server, filter: b))
+  }
+
+  @Test("is scoped to the server")
+  func serverScoped() {
+    let filter = FilterState.empty
+    #expect(
+      QueryKey(serverID: UUID(), filter: filter) != QueryKey(serverID: UUID(), filter: filter))
+  }
+
+  @Test("a sentinel key is its literal string")
+  func sentinel() {
+    #expect(QueryKey(sentinel: "local:downloaded").rawValue == "local:downloaded")
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,4 +1,5 @@
 - Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart
+- Document notes and file metadata are cached when viewed, so they remain available offline
 - Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version
 - Title search and title and content search now use the new search API on Paperless-ngx v3.0 and later, matching what the web interface does. The same search now returns the same documents in both. Older servers are unaffected.
 - The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -108,6 +108,11 @@ class DocumentDetailModel {
         guard !Task.isCancelled else { return }
         download = .loading
       }
+      // Cancel the delayed `.loading` flip on *every* exit path. Without this
+      // the error path leaves `setLoading` pending, and 0.5s later it overwrites
+      // the just-set `.error` back to `.loading` — pinning the preview's loading
+      // overlay on screen even though the download already failed.
+      defer { setLoading.cancel() }
       do {
         let url = try await store.repository.download(
           document: document,
@@ -124,7 +129,6 @@ class DocumentDetailModel {
         }
 
         download = .loaded(url: url, document: pdfDocument)
-        setLoading.cancel()
 
         // Start downloading the original in the background
         Task { await downloadOriginal() }
@@ -132,7 +136,6 @@ class DocumentDetailModel {
       } catch {
         download = .error
         Logger.shared.error("Unable to get document downloaded for preview rendering: \(error)")
-        break
       }
 
     default:

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -87,24 +87,27 @@ class DocumentDetailModel {
   /// `modified`. The three enrichments — file-metadata, notes, edit suggestions —
   /// only need the document id, so they run concurrently afterwards.
   ///
-  /// Every step swallows + logs its own failure rather than surfacing a toast:
-  /// these are background enrichments whose job is to warm the offline caches,
-  /// and the one critical failure (the PDF) is already shown via
-  /// `download == .error`. An offline open just serves whatever is cached.
-  func load() async {
-    await loadDocument()
-    async let metadata: Void = loadMetadata()
-    async let notes: Void = loadNotes()
-    async let suggestions: Void = loadSuggestionsQuietly()
+  /// Each step always logs its failure. Whether it's *surfaced* is the caller's
+  /// choice via `onError`: an on-appear load (`.task`) passes nothing and stays
+  /// silent (the load isn't user-initiated, and the one critical failure — the
+  /// PDF — already shows via `download == .error`); a pull-to-refresh passes a
+  /// handler so failures toast. Offline-connectivity errors are dropped by
+  /// `ErrorController.shouldSuppress`, so a parallel offline refresh won't spam.
+  func load(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
+    await loadDocument(onError: onError)
+    async let metadata: Void = loadMetadata(onError: onError)
+    async let notes: Void = loadNotes(onError: onError)
+    async let suggestions: Void = loadSuggestionsQuietly(onError: onError)
     _ = await (metadata, notes, suggestions)
   }
 
-  func loadMetadata() async {
+  func loadMetadata(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
     do {
       metadata = try await store.repository.metadata(documentId: document.id)
     } catch is CancellationError {
     } catch {
       Logger.shared.error("Error loading document metadata: \(error)")
+      onError?(error)
     }
   }
 
@@ -113,29 +116,31 @@ class DocumentDetailModel {
   /// a document opened online has its notes written through to the cache even if
   /// the user never taps the notes button. Routed through `store.notes(for:)` so
   /// the `.note` view-permission gate is respected.
-  func loadNotes() async {
+  func loadNotes(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
     do {
       _ = try await store.notes(for: document)
     } catch is CancellationError {
     } catch {
       Logger.shared.error("Error loading document notes: \(error)")
+      onError?(error)
     }
   }
 
   /// The quiet (open-path) form of `loadSuggestions()`: suggestions are an
-  /// edit-sheet enrichment, so a failure to load them is logged, not surfaced.
-  /// `updateDocument()` calls the throwing `loadSuggestions()` directly, where
-  /// the error propagates into the edit-save flow.
-  private func loadSuggestionsQuietly() async {
+  /// edit-sheet enrichment. `updateDocument()` calls the throwing
+  /// `loadSuggestions()` directly, where the error propagates into the edit-save
+  /// flow; here a failure is logged and only surfaced when `onError` is supplied.
+  private func loadSuggestionsQuietly(onError: (@MainActor @Sendable (any Error) -> Void)?) async {
     do {
       try await loadSuggestions()
     } catch is CancellationError {
     } catch {
       Logger.shared.error("Error loading document suggestions: \(error)")
+      onError?(error)
     }
   }
 
-  func loadDocument() async {
+  func loadDocument(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
     // Resolve the fresh document FIRST so the download path can validate
     // the ContentStore cache against the server's current `modified`
     // timestamp. If we kicked off both in parallel, a stale `modified`
@@ -145,8 +150,10 @@ class DocumentDetailModel {
       if let updated = try await store.document(id: document.id) {
         document = updated
       }
+    } catch is CancellationError {
     } catch {
       Logger.shared.error("Error updating document with full perms for editing: \(error)")
+      onError?(error)
     }
 
     switch download {

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -78,12 +78,60 @@ class DocumentDetailModel {
     }
   }
 
+  /// Load everything a freshly-opened (or pulled-to-refresh) document needs from
+  /// the server, best-effort.
+  ///
+  /// `loadDocument()` runs first and alone: it resolves the full-perms document
+  /// (and so caches it, which the file-metadata version key depends on) before
+  /// the PDF download validates the on-disk cache against the server's
+  /// `modified`. The three enrichments — file-metadata, notes, edit suggestions —
+  /// only need the document id, so they run concurrently afterwards.
+  ///
+  /// Every step swallows + logs its own failure rather than surfacing a toast:
+  /// these are background enrichments whose job is to warm the offline caches,
+  /// and the one critical failure (the PDF) is already shown via
+  /// `download == .error`. An offline open just serves whatever is cached.
+  func load() async {
+    await loadDocument()
+    async let metadata: Void = loadMetadata()
+    async let notes: Void = loadNotes()
+    async let suggestions: Void = loadSuggestionsQuietly()
+    _ = await (metadata, notes, suggestions)
+  }
+
   func loadMetadata() async {
     do {
       metadata = try await store.repository.metadata(documentId: document.id)
     } catch is CancellationError {
     } catch {
       Logger.shared.error("Error loading document metadata: \(error)")
+    }
+  }
+
+  /// Warm the notes cache on open so they're available offline later. The notes
+  /// view fetches its own (network-first) copy when presented; this just ensures
+  /// a document opened online has its notes written through to the cache even if
+  /// the user never taps the notes button. Routed through `store.notes(for:)` so
+  /// the `.note` view-permission gate is respected.
+  func loadNotes() async {
+    do {
+      _ = try await store.notes(for: document)
+    } catch is CancellationError {
+    } catch {
+      Logger.shared.error("Error loading document notes: \(error)")
+    }
+  }
+
+  /// The quiet (open-path) form of `loadSuggestions()`: suggestions are an
+  /// edit-sheet enrichment, so a failure to load them is logged, not surfaced.
+  /// `updateDocument()` calls the throwing `loadSuggestions()` directly, where
+  /// the error propagates into the edit-save flow.
+  private func loadSuggestionsQuietly() async {
+    do {
+      try await loadSuggestions()
+    } catch is CancellationError {
+    } catch {
+      Logger.shared.error("Error loading document suggestions: \(error)")
     }
   }
 

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -11,9 +11,20 @@ import Foundation
 import Networking
 import Nuke
 import Observation
+import Persistence
 import SwiftUI
 import os
 
+/// Drives the document list as a **source-of-truth observer**: `documents` is
+/// assigned from a GRDB `observeDocumentPrefix` live query, never a network
+/// fetch. The network's only job is to *fill* the cache (`fillDocumentQuery`).
+///
+/// The observed window is a **growing prefix** `[0, prefixLimit)` (offset 0, only
+/// `prefixLimit` grows). Scrolling near the end bumps `prefixLimit` in coarse
+/// steps and re-subscribes; scrolling back is free (the rows are already inside
+/// the prefix). This needs only the forgiving "near the bottom" heuristic — no
+/// precise visible-set tracking — so it tolerates SwiftUI's unreliable cell
+/// lifecycle the same way the old append-only paging did.
 @MainActor
 @Observable
 class DocumentListViewModel {
@@ -21,35 +32,29 @@ class DocumentListViewModel {
   private var filterState: FilterState
   private var errorController: ErrorController
 
+  /// Assigned by the document observation; never a network fetch.
   var documents: [Document] = []
   var ready = false
-
   var noPermissions = false
 
-  // Total document count reported by the server. nil until the first page is
-  // fetched, or when the active source has no notion of a server-side total.
+  /// Server-reported total (scrollbar extent), from the query-status observation.
   var totalCount: UInt?
 
-  private var inFlight: Int = 0
-  var isFetching: Bool { inFlight > 0 }
+  /// True while a fill (page-1 await) or refresh is in flight.
+  private(set) var isFetching = false
 
-  private var source: (any DocumentSource)?
-  private var exhausted: Bool = false
-  // Guards against concurrent fetchMoreIfNeeded calls. Cells near the bottom
-  // can each fire `.task` near-simultaneously when a batch first appears,
-  // and without this guard each one would launch a paged fetch.
-  private var loadingMore: Bool = false
-  // Tracks document IDs we've already added so we can dedup paged responses.
-  // The server can return the same document on adjacent pages if a new doc
-  // is inserted between fetches and shifts the page offsets — without dedup
-  // this surfaces as a SwiftUI ForEach duplicate-ID warning and stutters.
-  private var seenIds: Set<UInt> = []
+  // Growing-prefix state.
+  @ObservationIgnored private var queryKey: QueryKey?
+  @ObservationIgnored private var prefixLimit: Int
+  @ObservationIgnored private nonisolated(unsafe) var fill: QueryFillHandle?
+  @ObservationIgnored private nonisolated(unsafe) var documentTask: Task<Void, Never>?
+  @ObservationIgnored private nonisolated(unsafe) var statusTask: Task<Void, Never>?
 
-  private var initialBatchSize: UInt = 250
-  private var batchSize: UInt = 250
-  private var fetchMargin = 10
-  private let highPriorityPrefetchCount = 10
+  private let initialLimit = 250
+  private let widenStep = 250
+  private let fetchMargin = 25
 
+  @ObservationIgnored private var prefetchedIds: Set<UInt> = []
   private var imagePrefetcher: ImagePrefetcher
   private var prefetchPipeline: ImagePipeline
 
@@ -61,216 +66,165 @@ class DocumentListViewModel {
     self.store = store
     self.filterState = filterState
     self.errorController = errorController
+    prefixLimit = initialLimit
     let prefetchPipeline = store.imagePipeline
     self.prefetchPipeline = prefetchPipeline
     imagePrefetcher = ImagePrefetcher(pipeline: prefetchPipeline)
-
     imagePrefetcher.didComplete = {
       Logger.shared.debug("Thumbnail prefetching completed")
     }
   }
 
-  private func updatePrefetcherIfNeeded() {
-    let pipeline = store.imagePipeline
-    guard pipeline !== prefetchPipeline else { return }
+  deinit {
+    documentTask?.cancel()
+    statusTask?.cancel()
+    fill?.cancel()
+  }
 
-    imagePrefetcher.stopPrefetching()
-    prefetchPipeline = pipeline
-    imagePrefetcher = ImagePrefetcher(pipeline: pipeline)
-    imagePrefetcher.didComplete = {
-      Logger.shared.debug("Thumbnail prefetching completed")
+  // MARK: - Loading
+
+  func load() async {
+    Logger.shared.debug("DocumentListViewModel.load")
+    // Idempotent: the observation owns `documents`, so a second `.task` firing
+    // must not re-subscribe / re-fill.
+    guard documentTask == nil else { return }
+
+    // Up-to-date permissions (soft: a sync failure leaves cached perms in place).
+    try? await store.fetchUISettings()
+    guard hasViewPermission() else {
+      noPermissions = true
+      ready = true
+      return
     }
+    noPermissions = false
+
+    guard let key = store.documentQueryKey(filter: filterState) else {
+      // No caching backend (e.g. logged out) — nothing to show.
+      ready = true
+      return
+    }
+    subscribe(to: key, resettingWindow: true)
+    await fill(userInitiated: false)
+    ready = true
   }
 
   func reload() async {
     Logger.shared.debug("DocumentListViewModel.reload")
+    teardown()
     documents = []
-    seenIds = []
-    source = nil
+    prefetchedIds = []
+    ready = false
     await load()
-    try? await Task.sleep(for: .seconds(0.1))
-    ready = true
   }
 
-  private func ensurePermissions() throws {
-    guard store.permissions.test(.view, for: .document) else {
-      throw PermissionsError(resource: .document, operation: .view)
+  /// Pull-to-refresh / filter change: re-sync elements, re-point the observation
+  /// if the query changed, and re-fill from the network.
+  func refresh(filter: FilterState? = nil, userInitiated: Bool = false) async {
+    if let filter { filterState = filter }
+
+    do {
+      try await store.sync(userInitiated: userInitiated)
+    } catch {
+      Logger.shared.error("Element sync during refresh failed: \(error)")
+      if userInitiated { errorController.push(error: error) }
+    }
+
+    guard hasViewPermission() else {
+      noPermissions = true
+      return
     }
     noPermissions = false
+
+    guard let key = store.documentQueryKey(filter: filterState) else { return }
+    if key != queryKey {
+      subscribe(to: key, resettingWindow: true)
+    }
+    await fill(userInitiated: userInitiated)
   }
 
-  func load() async {
-    Logger.shared.debug("DocumentListViewModel.load")
-    guard documents.isEmpty else { return }
-    inFlight += 1
-    defer { inFlight -= 1 }
+  /// Kick the eager fill: page 1 awaited (DB write → observation repaints), the
+  /// rest paged in the background. Offline → the cached rows already on screen
+  /// stay; only a user-initiated refresh surfaces the error.
+  private func fill(userInitiated: Bool) async {
+    isFetching = true
+    defer { isFetching = false }
+    fill?.cancel()
     do {
-      // Ensure we have up-to-date permissions
-      try await store.fetchUISettings()
-      if source == nil {
-        source = try store.repository.documents(filter: filterState)
-      }
-      try ensurePermissions()
-      let batch = try await source!.fetch(limit: initialBatchSize)
-      totalCount = await source!.totalCount
-
-      let requests: [ImageRequest] =
-        try batch
-        .enumerated()
-        .map { index, document in
-          let urlRequest = try store.repository.thumbnailRequest(document: document)
-          let fullPriority: ImageRequest.Priority =
-            index < highPriorityPrefetchCount ? .high : .normal
-          return [
-            ImageRequest(urlRequest: urlRequest, priority: fullPriority),
-            ImageRequest(urlRequest: urlRequest, processors: [.resize(width: 130)]),
-          ]
-        }
-        .flatMap { $0 }
-
-      //      let requests =
-      //    try batch
-      //    .map { try store.repository.thumbnailRequest(document: $0) }
-      //    .map { ImageRequest(urlRequest: $0, processors: [.resize(width: 130)]) }
-
-      Logger.shared.debug("Prefetching \(requests.count) thumbnail images")
-      updatePrefetcherIfNeeded()
-      imagePrefetcher.startPrefetching(with: requests)
-
-      documents = batch
-      seenIds = Set(batch.map(\.id))
-      Logger.shared.debug("DocumentListViewModel.load loading complete")
-    } catch let error as PermissionsError {
-      noPermissions = true
-      Logger.shared.warning("Insufficient permissions to load documents: \(error)")
+      fill = try await store.fillDocumentQuery(filter: filterState)
     } catch {
-      Logger.shared.error("DocumentList failed to load documents: \(error)")
-      errorController.push(error: error)
+      Logger.shared.error("Document fill failed (offline?): \(error)")
+      if userInitiated { errorController.push(error: error) }
     }
   }
 
-  func fetchMoreIfNeeded(currentIndex: Int) async {
-    if exhausted || loadingMore { return }
-    guard currentIndex >= documents.count - fetchMargin else { return }
-    loadingMore = true
-    let repository = store.repository
-    let highPriorityCount = highPriorityPrefetchCount
-    Task.detached {
-      defer { Task { @MainActor in self.loadingMore = false } }
+  // MARK: - Growing-prefix windowing (no network)
+
+  func fetchMoreIfNeeded(currentIndex: Int) {
+    guard let key = queryKey else { return }
+    // Only grow, and only when the prefix is actually full (more may exist).
+    guard documents.count >= prefixLimit else { return }
+    guard currentIndex + fetchMargin >= prefixLimit else { return }
+    prefixLimit += widenStep
+    startDocumentObservation(key, limit: prefixLimit)
+  }
+
+  // MARK: - Observation
+
+  private func subscribe(to key: QueryKey, resettingWindow: Bool) {
+    queryKey = key
+    if resettingWindow {
+      prefixLimit = initialLimit
+      prefetchedIds = []
+    }
+    startStatusObservation(key)
+    startDocumentObservation(key, limit: prefixLimit)
+  }
+
+  private func startDocumentObservation(_ key: QueryKey, limit: Int) {
+    documentTask?.cancel()
+    documentTask = Task { @MainActor [weak self] in
+      guard let self else { return }
       do {
-        Logger.shared.info("Fetching additional documents")
-        guard let source = await self.source else {
-          return
+        for try await docs in store.observeDocumentPrefix(queryKey: key, limit: limit) {
+          documents = docs
+          prefetchThumbnails(for: docs)
         }
-
-        let batch = try await source.fetch(limit: self.batchSize)
-        let sourceExhausted = await source.isExhausted
-        let sourceTotal = await source.totalCount
-        if batch.isEmpty {
-          await MainActor.run {
-            self.exhausted = true
-          }
-          return
-        }
-
-        let requests =
-          try batch
-          .enumerated()
-          .map { index, document in
-            let urlRequest = try repository.thumbnailRequest(document: document)
-            let fullPriority: ImageRequest.Priority =
-              index < highPriorityCount ? .high : .normal
-            return [
-              ImageRequest(urlRequest: urlRequest, priority: fullPriority),
-              ImageRequest(urlRequest: urlRequest, processors: [.resize(width: 130)]),
-            ]
-          }
-          .flatMap { $0 }
-
-        Logger.shared.debug("Prefetching \(requests.count) thumbnail images")
-        await self.updatePrefetcherIfNeeded()
-        await self.imagePrefetcher.startPrefetching(with: requests)
-
-        await MainActor.run {
-          let fresh = batch.filter { self.seenIds.insert($0.id).inserted }
-          self.documents += fresh
-          if let sourceTotal {
-            self.totalCount = sourceTotal
-          }
-          if sourceExhausted {
-            self.exhausted = true
-          }
-        }
+      } catch is CancellationError {
       } catch {
-        Logger.shared.error("DocumentList failed to load more if needed: \(error)")
-        await self.errorController.push(error: error)
+        Logger.shared.error("Document observation terminated: \(error)")
       }
     }
   }
 
-  func refresh(filter: FilterState? = nil, retain: Bool = false, userInitiated: Bool = false)
-    async throws -> [Document]
-  {
-    inFlight += 1
-    defer { inFlight -= 1 }
-    try await store.sync(userInitiated: userInitiated)
-
-    if let filter {
-      filterState = filter
-    }
-    exhausted = false
-    do {
-      try ensurePermissions()
-      source = try store.repository.documents(filter: filterState)
-
-      let batch = try await source!.fetch(limit: retain ? UInt(documents.count) : initialBatchSize)
-      totalCount = await source!.totalCount
-      seenIds = Set(batch.map(\.id))
-
-      let requests =
-        try batch
-        .enumerated()
-        .map { index, document in
-          let urlRequest = try self.store.repository.thumbnailRequest(document: document)
-          let fullPriority: ImageRequest.Priority =
-            index < highPriorityPrefetchCount ? .high : .normal
-          return [
-            ImageRequest(urlRequest: urlRequest, priority: fullPriority),
-            ImageRequest(urlRequest: urlRequest, processors: [.resize(width: 130)]),
-          ]
+  private func startStatusObservation(_ key: QueryKey) {
+    statusTask?.cancel()
+    statusTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      do {
+        for try await status in store.observeQueryStatus(queryKey: key) {
+          totalCount = status.totalCount
         }
-        .flatMap { $0 }
-
-      Logger.shared.debug("Prefetching \(requests.count) thumbnail images")
-      updatePrefetcherIfNeeded()
-      imagePrefetcher.startPrefetching(with: requests)
-
-      return batch
-    } catch let error as PermissionsError {
-      Logger.shared.error("Insufficient permissions to refresh documents: \(error)")
-      noPermissions = true
-      throw error
-    } catch {
-      Logger.shared.error("DocumentList failed to refresh: \(error)")
-      errorController.push(error: error)
-      throw error
+      } catch is CancellationError {
+      } catch {
+        Logger.shared.error("Query-status observation terminated: \(error)")
+      }
     }
   }
 
-  func replace(documents: [Document]) {
-    self.documents = documents
-    seenIds = Set(documents.map(\.id))
+  private func teardown() {
+    documentTask?.cancel()
+    documentTask = nil
+    statusTask?.cancel()
+    statusTask = nil
+    fill?.cancel()
+    fill = nil
+    queryKey = nil
   }
 
-  func removed(document: Document) {
-    documents.removeAll(where: { $0.id == document.id })
-    seenIds.remove(document.id)
-  }
+  // MARK: - Permissions / inbox helpers
 
-  func updated(document: Document) {
-    if let target = documents.firstIndex(where: { $0.id == document.id }) {
-      documents[target] = document
-    }
+  private func hasViewPermission() -> Bool {
+    store.permissions.test(.view, for: .document)
   }
 
   func hasInboxTags(document: Document) -> Bool {
@@ -279,11 +233,34 @@ class DocumentListViewModel {
 
   func removeInboxTags(document: Document) async {
     guard hasInboxTags(document: document) else { return }
-
     var document = document
     let inboxTagIDs = Set(store.tags.values.filter(\.isInboxTag).map(\.id))
     document.tags.removeAll { inboxTagIDs.contains($0) }
-
     _ = try? await store.updateDocument(document)
+  }
+
+  // MARK: - Thumbnail prefetch
+
+  private func prefetchThumbnails(for documents: [Document]) {
+    let fresh = documents.filter { prefetchedIds.insert($0.id).inserted }
+    guard !fresh.isEmpty else { return }
+    let requests =
+      fresh
+      .compactMap { try? store.repository.thumbnailRequest(document: $0) }
+      .map { ImageRequest(urlRequest: $0, processors: [.resize(width: 130)]) }
+    guard !requests.isEmpty else { return }
+    updatePrefetcherIfNeeded()
+    imagePrefetcher.startPrefetching(with: requests)
+  }
+
+  private func updatePrefetcherIfNeeded() {
+    let pipeline = store.imagePipeline
+    guard pipeline !== prefetchPipeline else { return }
+    imagePrefetcher.stopPrefetching()
+    prefetchPipeline = pipeline
+    imagePrefetcher = ImagePrefetcher(pipeline: pipeline)
+    imagePrefetcher.didComplete = {
+      Logger.shared.debug("Thumbnail prefetching completed")
+    }
   }
 }

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -215,9 +215,13 @@ class DocumentListViewModel {
   private func startDocumentObservation(_ key: QueryKey, limit: Int) {
     documentTask?.cancel()
     documentTask = Task { @MainActor [weak self] in
-      guard let self else { return }
+      // Re-check `self` inside the loop, not before it: a `guard let self` out
+      // here stays strong across every suspension, and this task is stored on
+      // the view model — so neither would ever deallocate.
+      guard let store = self?.store else { return }
       do {
         for try await docs in store.observeDocumentPrefix(queryKey: key, limit: limit) {
+          guard let self else { break }
           documents = docs
           prefetchThumbnails(for: docs)
         }
@@ -231,9 +235,10 @@ class DocumentListViewModel {
   private func startStatusObservation(_ key: QueryKey) {
     statusTask?.cancel()
     statusTask = Task { @MainActor [weak self] in
-      guard let self else { return }
+      guard let store = self?.store else { return }
       do {
         for try await status in store.observeQueryStatus(queryKey: key) {
+          guard let self else { break }
           totalCount = status.totalCount
         }
       } catch is CancellationError {

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -37,7 +37,9 @@ class DocumentListViewModel {
   var ready = false
   var noPermissions = false
 
-  /// Server-reported total (scrollbar extent), from the query-status observation.
+  /// Server-reported total, from the query-status observation. Drives the count
+  /// pill and the "has anything at all" gate — *not* the scroll extent, which
+  /// follows the loaded prefix, since the list only ever renders `documents`.
   var totalCount: UInt?
 
   /// True while a fill (page-1 await) or refresh is in flight.

--- a/swift-paperless/ViewModel/DocumentListViewModel.swift
+++ b/swift-paperless/ViewModel/DocumentListViewModel.swift
@@ -104,7 +104,13 @@ class DocumentListViewModel {
       return
     }
     subscribe(to: key, resettingWindow: true)
-    await fill(userInitiated: false)
+    do {
+      try await runFill()
+    } catch {
+      // Initial load is silent: offline shows whatever is cached (or nothing),
+      // never a toast. A user-initiated refresh is where errors surface.
+      Logger.shared.error("Document fill failed (offline?): \(error)")
+    }
     ready = true
   }
 
@@ -119,42 +125,68 @@ class DocumentListViewModel {
 
   /// Pull-to-refresh / filter change: re-sync elements, re-point the observation
   /// if the query changed, and re-fill from the network.
+  ///
+  /// The element sync and the document fill are independent network passes that
+  /// both fail when offline. We collect the *first* error and surface a single
+  /// toast at the end, so a pull-to-refresh while offline doesn't stack two
+  /// identical alerts.
   func refresh(filter: FilterState? = nil, userInitiated: Bool = false) async {
     if let filter { filterState = filter }
 
+    var firstError: (any Error)?
     do {
       try await store.sync(userInitiated: userInitiated)
     } catch {
       Logger.shared.error("Element sync during refresh failed: \(error)")
-      if userInitiated { errorController.push(error: error) }
+      firstError = error
     }
 
     guard hasViewPermission() else {
       noPermissions = true
+      surface(firstError, userInitiated: userInitiated)
       return
     }
     noPermissions = false
 
-    guard let key = store.documentQueryKey(filter: filterState) else { return }
+    guard let key = store.documentQueryKey(filter: filterState) else {
+      surface(firstError, userInitiated: userInitiated)
+      return
+    }
     if key != queryKey {
       subscribe(to: key, resettingWindow: true)
     }
-    await fill(userInitiated: userInitiated)
+    do {
+      try await runFill()
+    } catch {
+      Logger.shared.error("Document fill failed (offline?): \(error)")
+      if firstError == nil { firstError = error }
+    }
+
+    surface(firstError, userInitiated: userInitiated)
+  }
+
+  private func surface(_ error: (any Error)?, userInitiated: Bool) {
+    guard userInitiated, let error else { return }
+    errorController.push(error: error)
   }
 
   /// Kick the eager fill: page 1 awaited (DB write → observation repaints), the
-  /// rest paged in the background. Offline → the cached rows already on screen
-  /// stay; only a user-initiated refresh surfaces the error.
-  private func fill(userInitiated: Bool) async {
+  /// rest paged in the background. Throws the underlying error so the caller
+  /// decides whether to surface it (coalesced with the element-sync error).
+  private func runFill() async throws {
     isFetching = true
     defer { isFetching = false }
     fill?.cancel()
-    do {
-      fill = try await store.fillDocumentQuery(filter: filterState)
-    } catch {
-      Logger.shared.error("Document fill failed (offline?): \(error)")
-      if userInitiated { errorController.push(error: error) }
-    }
+    let handle = try await store.fillDocumentQuery(filter: filterState)
+    fill = handle
+    // Adopt the fill's authoritative count immediately. `observeQueryStatus`
+    // would deliver the same number, but only a beat *after* the page-1 write
+    // — and in that beat `documents` is still the pre-emission `[]`. Without
+    // this, switching to a not-yet-cached view momentarily reads as
+    // `documents.isEmpty && !isFetching && totalCount == 0` and flashes
+    // "No documents" before the observation repaints. Setting it here keeps
+    // the empty-state guard on the loading branch until the rows arrive.
+    totalCount = handle.totalCount
   }
 
   // MARK: - Growing-prefix windowing (no network)

--- a/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
@@ -24,6 +24,24 @@ struct DocumentMetadataView: View {
     metadata != nil
   }
 
+  /// Fetch this document's file-metadata. The on-appear `.task` (`userInitiated:
+  /// false`) skips when the parent detail load already filled `metadata` and
+  /// stays silent on failure; a pull-to-refresh (`true`) always re-fetches and
+  /// toasts failures. Mirrors the notes view's silent-on-appear / visible-on-
+  /// refresh split.
+  private func load(userInitiated: Bool) async {
+    if metadata != nil, !userInitiated { return }
+    do {
+      metadata = try await store.repository.metadata(documentId: document.id)
+    } catch let error where error.isCancellationError {
+    } catch {
+      Logger.shared.error("Error loading document metadata: \(error)")
+      if userInitiated {
+        errorController.push(error: error)
+      }
+    }
+  }
+
   var body: some View {
     NavigationStack {
       Form {
@@ -106,6 +124,14 @@ struct DocumentMetadataView: View {
         ToolbarItem(placement: .cancellationAction) {
           CancelIconButton()
         }
+      }
+
+      .refreshable {
+        await load(userInitiated: true)
+      }
+
+      .task {
+        await load(userInitiated: false)
       }
     }
 

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -665,7 +665,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     }
     .refreshable {
       let model = viewModel
-      async let load: () = model.load()
+      async let load: () = model.load(onError: { errorController.push(error: $0) })
       // Only on pull-to-refresh, not inside `load()`: refreshing permissions
       // means a full element sync, which is not what opening a document should
       // cost.

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -665,10 +665,12 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     }
     .refreshable {
       let model = viewModel
-      async let document: () = model.loadDocument()
-      async let metadata: () = model.loadMetadata()
+      async let load: () = model.load()
+      // Only on pull-to-refresh, not inside `load()`: refreshing permissions
+      // means a full element sync, which is not what opening a document should
+      // cost.
       async let permissions: () = model.refreshPermissions()
-      _ = await (document, metadata, permissions)
+      _ = await (load, permissions)
     }
     .safeAreaInset(edge: .bottom) {
       metadataBar
@@ -786,9 +788,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     }
 
     .task {
-      await viewModel.loadDocument()
-      await viewModel.loadMetadata()
-      try? await viewModel.loadSuggestions()
+      await viewModel.load()
     }
 
     .onChange(of: routeManager.pendingRoute, initial: true, handlePendingRoute)

--- a/swift-paperless/Views/Document/Detail/V4/TagsEditSheet.swift
+++ b/swift-paperless/Views/Document/Detail/V4/TagsEditSheet.swift
@@ -117,6 +117,7 @@ struct TagsEditSheet: View {
 
   private func save() {
     Task {
+      let originalTags = viewModel.document.tags
       do {
         saving = true
         viewModel.document.tags = tagIds
@@ -126,6 +127,7 @@ struct TagsEditSheet: View {
         dismiss()
       } catch {
         saving = false
+        viewModel.document.tags = originalTags
         errorController.push(error: error)
       }
     }

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -194,20 +194,11 @@ struct DocumentList: View {
 
   private func onReceiveEvent(event: DocumentStore.Event) {
     switch event {
-    case .deleted(let document):
-      withAnimation {
-        viewModel.removed(document: document)
-      }
-    case .changed(let document):
-      viewModel.updated(document: document)
-    case .changeReceived:
-      Task {
-        if let documents = try? await viewModel.refresh(retain: true) {
-          withAnimation {
-            viewModel.replace(documents: documents)
-          }
-        }
-      }
+    case .deleted, .changed, .changeReceived:
+      // Source-of-truth: a mutation write-throughs to the DB and the document
+      // observation repaints the list in place (a delete cascades out of every
+      // query_order). Nothing to do here.
+      break
     case .repositoryWillChange:
       filterModel.ready = false
       viewModel.ready = false
@@ -228,15 +219,7 @@ struct DocumentList: View {
   }
 
   func refresh() async {
-    do {
-      let documents = try await viewModel.refresh(userInitiated: true)
-      withAnimation {
-        viewModel.replace(documents: documents)
-      }
-    } catch {
-      Logger.shared.error("Error refreshing documents: \(error)")
-      errorController.push(error: error)
-    }
+    await viewModel.refresh(userInitiated: true)
   }
 
   var body: some View {
@@ -253,7 +236,23 @@ struct DocumentList: View {
           }
       } else {
         let documents = viewModel.documents
-        if !documents.isEmpty {
+        if documents.isEmpty {
+          // No rows yet: distinguish "still filling" (cold cache + a fill in
+          // flight, or the server reports a non-empty count) from a genuinely
+          // empty result, so we don't flash "No documents" during the fill.
+          if viewModel.isFetching || (viewModel.totalCount ?? 0) > 0 {
+            LoadingDocumentList()
+          } else {
+            NoDocumentsView(filtering: filterModel.filterState.filtering)
+              .equatable()
+              .refreshable {
+                await Task {
+                  await refresh()
+                }.value
+              }
+              .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+          }
+        } else {
           ScrollViewReader { proxy in
             List {
               Section {
@@ -272,7 +271,8 @@ struct DocumentList: View {
                   .alignmentGuide(.listRowSeparatorLeading) { _ in 15 }
 
                   .task {
-                    await viewModel.fetchMoreIfNeeded(currentIndex: idx)
+                    // Pure local windowing: grow the observed prefix. No network.
+                    viewModel.fetchMoreIfNeeded(currentIndex: idx)
                   }
                 }
               }
@@ -293,15 +293,6 @@ struct DocumentList: View {
               }
             }
           }
-        } else {
-          NoDocumentsView(filtering: filterModel.filterState.filtering)
-            .equatable()
-            .refreshable {
-              await Task {
-                await refresh()
-              }.value
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
       }
     }
@@ -310,9 +301,7 @@ struct DocumentList: View {
 
     .onChange(of: filterModel.filterState) { _, filter in
       Task {
-        if let documents = try? await viewModel.refresh(filter: filter) {
-          viewModel.replace(documents: documents)
-        }
+        await viewModel.refresh(filter: filter)
       }
     }
 
@@ -331,7 +320,6 @@ struct DocumentList: View {
 
     .task {
       await viewModel.load()
-      viewModel.ready = true
     }
 
     .onEvent(from: store.events, perform: onReceiveEvent)

--- a/swift-paperless/Views/Document/DocumentPreview.swift
+++ b/swift-paperless/Views/Document/DocumentPreview.swift
@@ -250,44 +250,52 @@ private struct IntegratedDocumentPreview: View {
 
   var body: some View {
     ZStack {
-      if case .error = downloadState {
+      // Thumbnail acts as a stable underlay while the PDF fades in on top.
+      // Avoids both layers being ~50% transparent mid-animation, which would
+      // bleed the dark background through and look like "fading through black".
+      // Once the PDF is fully opaque, `thumbnailHidden` flips and the
+      // thumbnail unmounts — without animation, since the flip happens
+      // outside the .animation(value: downloadState) scope — so the now-
+      // invisible thumbnail no longer peeks through during page scrolling.
+      //
+      // It also stays put under an `.error`: offline (or any failed PDF
+      // download) we keep the cached thumbnail rather than swapping in a
+      // placeholder symbol.
+      if !thumbnailHidden {
+        image.image?
+          .resizable()
+          .scaledToFit()
+          .blur(radius: 5, opaque: true)
+          .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+          .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+              .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1 / UIScreen.main.scale)
+          )
+          .padding(.horizontal, PDFPagingPreview.pageInset)
+          .transition(.identity)
+      }
+
+      if case .loaded(url: _, document: let pdfDocument) = downloadState {
+        PDFPagingPreview(
+          document: pdfDocument,
+          currentPage: $currentPage,
+          transitionID: transitionID,
+          transitionNamespace: transitionNamespace,
+          onTap: onTap
+        )
+        .transition(.opacity)
+        .scrollDisabled(!thumbnailHidden)
+      }
+
+      // The "unable to load" placeholder shows only when the PDF failed *and*
+      // there's no thumbnail to fall back on and we're not still fetching one.
+      // Otherwise it would flash over a thumbnail that's about to resolve (the
+      // download can fail-fast offline before the cached thumbnail loads).
+      if case .error = downloadState, image.image == nil, !image.isLoading {
         Label("Unable to load preview", systemImage: "eye.slash")
           .labelStyle(.iconOnly)
           .imageScale(.large)
           .frame(maxWidth: .infinity, alignment: .center)
-      } else {
-        // Thumbnail acts as a stable underlay while the PDF fades in on top.
-        // Avoids both layers being ~50% transparent mid-animation, which would
-        // bleed the dark background through and look like "fading through black".
-        // Once the PDF is fully opaque, `thumbnailHidden` flips and the
-        // thumbnail unmounts — without animation, since the flip happens
-        // outside the .animation(value: downloadState) scope — so the now-
-        // invisible thumbnail no longer peeks through during page scrolling.
-        if !thumbnailHidden {
-          image.image?
-            .resizable()
-            .scaledToFit()
-            .blur(radius: 5, opaque: true)
-            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .overlay(
-              RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1 / UIScreen.main.scale)
-            )
-            .padding(.horizontal, PDFPagingPreview.pageInset)
-            .transition(.identity)
-        }
-
-        if case .loaded(url: _, document: let pdfDocument) = downloadState {
-          PDFPagingPreview(
-            document: pdfDocument,
-            currentPage: $currentPage,
-            transitionID: transitionID,
-            transitionNamespace: transitionNamespace,
-            onTap: onTap
-          )
-          .transition(.opacity)
-          .scrollDisabled(!thumbnailHidden)
-        }
       }
     }
     .padding(.vertical, 16)

--- a/swift-paperless/Views/Settings/DebugMenuView.swift
+++ b/swift-paperless/Views/Settings/DebugMenuView.swift
@@ -14,9 +14,13 @@ import os
 
 struct DebugMenuView: View {
   @Environment(ConnectionManager.self) private var connectionManager
+  @Environment(DocumentStore.self) private var store
+  @EnvironmentObject private var errorController: ErrorController
   private let appSettings = AppSettings.shared
   @State private var showResetConfirmation = false
   @State private var exportResult: ExportResult?
+  @State private var showClearCacheConfirmation = false
+  @State private var showCacheClearedConfirmation = false
 
   /// Outcome of the legacy-storage export, reported in an alert rather than
   /// through `ErrorController` so it stays visible above the settings sheet.
@@ -39,6 +43,16 @@ struct DebugMenuView: View {
     } catch {
       Logger.shared.error("Legacy connection export failed: \(error)")
       exportResult = .failed(error.localizedDescription)
+    }
+  }
+
+  private func clearCache() {
+    do {
+      try store.wipeLocalCache()
+      showCacheClearedConfirmation = true
+    } catch {
+      Logger.shared.error("Failed to clear local cache: \(error)")
+      errorController.push(error: error)
     }
   }
 
@@ -98,6 +112,36 @@ struct DebugMenuView: View {
             so you can export, wipe the database, and relaunch to test recovery.
             """)
       }
+
+      Section {
+        Button {
+          showClearCacheConfirmation = true
+        } label: {
+          Label {
+            Text(.settings(.clearCache))
+          } icon: {
+            Image(systemName: "trash")
+          }
+        }
+        .confirmationDialog(
+          String(localized: .settings(.clearCacheConfirmationTitle)),
+          isPresented: $showClearCacheConfirmation,
+          titleVisibility: .visible
+        ) {
+          Button(role: .destructive) {
+            clearCache()
+          } label: {
+            Text(.settings(.clearCache))
+          }
+          Button(.app(.cancel), role: .cancel) {}
+        } message: {
+          Text(.settings(.clearCacheConfirmation))
+        }
+      } header: {
+        Text(.settings(.localStorage))
+      } footer: {
+        Text(.settings(.localStorageDescription))
+      }
     }
     .navigationTitle(String(localized: .settings(.debugMenu)))
     .navigationBarTitleDisplayMode(.inline)
@@ -121,16 +165,25 @@ struct DebugMenuView: View {
           dismissButton: .default(Text(.app(.ok))))
       }
     }
+    .alert(
+      String(localized: .settings(.cacheCleared)),
+      isPresented: $showCacheClearedConfirmation
+    ) {
+      Button(.app(.ok)) {}
+    }
   }
 }
 
 #Preview("Debug menu") {
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
+  @Previewable @State var store = DocumentStore.preview()
 
   NavigationStack {
     DebugMenuView()
       .environment(connectionManager)
+      .environment(store)
+      .environmentObject(ErrorController())
   }
 }
 


### PR DESCRIPTION
This pull request introduces a major refactor to the document caching and synchronization logic, implementing a robust offline-first architecture for document lists and details. The changes remove the in-memory document cache from `DocumentStore`, shifting all state to the database and introducing a new cache observation and fill API. Additionally, it adds mechanisms for reconciling remote deletions and metadata changes, ensuring local data stays consistent with the server, and improves pessimistic write-through and cache fallback behavior for document operations.

**Document caching and observation API:**

* Removed the in-memory `documents` dictionary from `DocumentStore`, and replaced all access with direct observation of the database-backed cache. Added new methods such as `documentQueryKey`, `fillDocumentQuery`, `observeDocumentPrefix`, `observeQueryStatus`, and `observeDocument` to provide a GRDB-free, offline-first interface for views. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L23-L24) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R670-R765)

* Implemented a full document list fill (`fillQuery`) in `CachingRepository`, which eagerly fetches the first page and then background-fills the rest, enabling instant offline access and smooth scrolling. [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR64-R83) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR182-R219)

**Remote reconciliation and cache consistency:**

* Added throttled remote-delete reconciliation (`reconcileDocuments` and `reconcileDocumentDeletions`), which periodically fetches the server's authoritative document IDs and removes any locally cached documents that no longer exist on the server. Also added a delta-based changed-metadata refresh (`reconcileDocumentChanges`) to keep cached documents up-to-date without re-fetching entire lists. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R116-R123) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R367-R370) [[3]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR64-R83) [[4]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)

* Introduced `DocumentDeltaWatermark`, a per-server metadata watermark stored in UserDefaults, to efficiently track and limit delta refreshes. Also provided a method to clear all watermarks when wiping the local cache. [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR32-R52) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)

**Write-through and fallback improvements:**

* Updated document update, delete, and fetch methods in `CachingRepository` to write through confirmed changes to the cache, mark queries as stale, and serve cached data on network failures, ensuring consistent offline behavior and immediate UI updates.

**Other enhancements:**

* Added cache wipe logic to `DocumentStore`, ensuring all local data (database, blobs, image cache, and watermarks) can be cleared for maintenance or debugging.
* Extended repository protocols and implementations to support efficient ID fetching and fallback strategies. [[1]](diffhunk://#diff-89d221ed691ac94c47dbd34fd50c6fd0b087608b1fb700dbc2d9b5e60856aa6cR105-R108) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)

These changes collectively enable robust, efficient, and user-friendly offline document browsing and editing, while keeping the local cache tightly synchronized with the server.

---

**Document caching and observation:**
- Removed in-memory document cache from `DocumentStore` and replaced with database-backed, observable cache API for document lists and details. Added new methods for query key computation, cache fill, observation, and cache wipe. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L23-L24) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R670-R765)
- Implemented `fillQuery` in `CachingRepository` for eager, background-filled document list caching, enabling instant offline access. [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR64-R83) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR182-R219)

**Remote reconciliation and cache consistency:**
- Added throttled remote-delete reconciliation (`reconcileDocuments`/`reconcileDocumentDeletions`) and delta-based metadata refresh (`reconcileDocumentChanges`) to keep the local cache consistent with server state. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R116-R123) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R367-R370) [[3]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR64-R83) [[4]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)
- Introduced `DocumentDeltaWatermark` for efficient per-server metadata sync, and a method to clear all watermarks during cache wipe. [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR32-R52) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)

**Write-through and fallback improvements:**
- Updated document update, delete, and fetch operations to write through to the cache, mark affected queries as stale, and serve cached data on network failures for robust offline-first behavior.

**Other enhancements:**
- Added comprehensive cache wipe logic to `DocumentStore` for database, blobs, image cache, and per-server watermarks.
- Extended repository protocols for efficient document ID fetching and fallback. [[1]](diffhunk://#diff-89d221ed691ac94c47dbd34fd50c6fd0b087608b1fb700dbc2d9b5e60856aa6cR105-R108) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL366-R647)

## Review round (2026-08-16)

Six follow-up commits at the end of this PR's range, from an agent-authored review pass
(details and the full finding list in [this comment](https://github.com/paulgessinger/swift-paperless/pull/600#issuecomment-5306727572); deferrals tracked in #656).

| Commit | What it fixes |
|---|---|
| `keep a document from being placed twice in one cached query` | `query_order` had no uniqueness on `remote_id`, and the in-memory dedup this PR removed was never replaced — so a document the server repeats across adjacent pages was stored twice and rendered twice. Unique key with `ON CONFLICT IGNORE`, plus `.insert` in place of `.upsert`. |
| `let the list view model deallocate while its observations run` | `guard let self` outside an infinite `for await` kept the view model and its two `ValueObservation` streams alive forever; each iPad rotation stacked another pair. |
| `don't let a position collision abort a query fill` | Follow-on from the first commit: `.insert` made a `position` collision throw where `upsert` had silently overwritten, and the background fill swallows the throw. Explicit `.replace` on the primary key. |
| `page the remote-delete id sweep over a unique ordering` | The sweep inherited `FilterState.empty`'s sort — archive serial number, NULL for most documents — so paging it was unstable, and anything dropped across a page boundary reads as a remote deletion. |
| `send the negotiated search API on the document-id sweep` | `documentIDs` always spelled its rules the legacy way while its neighbour passed the negotiated value. |
| `report a failed blob purge instead of claiming success` | `purge()` swallowed the removal error and then recreated the directory, so a failed wipe reported clean — and the debug action exists to leave an *empty* store for cold-launch testing. |

Two findings are deliberately **not** fixed here:

- **An interrupted list fill truncates the cache and reports it as complete** — the highest-impact
  finding of the round, deferred to #618 where the per-query error surface exists (#656 item 18).
  This PR ships with it live.
- **The changed-metadata delta stranded any backlog larger than its cap** — fixed on #617 instead,
  where that function has its final shape.

Verified: builds clean at the stack tip, all four packages pass, no conflicted commit in the stack.
Nothing was driven in the simulator.

## Review round 2 (2026-08-16, Paul's inline comments)

Twenty inline comments; six more follow-up commits here, plus one on #617 and one on #627.

| Commit | What it does |
|---|---|
| `reach the document cache through Database.wrapping` | Every document-cache accessor was untyped `throws` calling GRDB directly, against the invariant `Database+Elements` states — so raw `GRDB.DatabaseError`s escaped the package. All of `Database+Documents` / `+DocumentDetail` / `+Maintenance` now declare `throws(DatabaseError)`. No caller changes needed. |
| `create server_sync_state in the migration that first uses it` | `V4` created a table nothing in this build reads or writes; both its columns belong to #617. Moved to #617's `V6` (`270489a9`), where the first reader lives. |
| `express the order-stale marking in GRDB's query interface` | Raw `UPDATE … WHERE query_key IN (SELECT …)` replaced by a subquery + `updateAll`. |
| `scope DocumentStore.clear and name the metadata version lookup` | `clear()` had no callers outside the type → `private`, with its now-much-smaller job stated. The dense version-id optional chain became `fileMetadataVersionID(documentId:)`. |
| `say what a cached query's total actually drives` | Eight places claimed `totalCount` was a "scrollbar extent". It drives the count pill; the list only renders the loaded prefix. Also trimmed the id-sweep comment. |
| `page the documentIDs default over a unique ordering too` | The `Repository` default implementation carried the same non-unique-paging bug the `ApiRepository` override was fixed for last round. |

Filed from this round: **#669** — cached query keys are never garbage-collected when they stop being reachable, which blocks both changing `FilterState.empty`'s default sort and retiring `QueryKey`'s `.legacy` encoding. Ledger item 10 (stale `Stage N` comments) is closed by a sweep at the top of #627.

Verified: all four packages pass (629 tests), app builds clean at this PR's head *and* at the stack tip, no conflicted commit in the stack.

## Review round 3 (2026-08-17, lint pass)

Two follow-up commits at the end of this PR's range.

| Commit | What it does |
|---|---|
| `apply swift-format to the queryStatus signature` | CI lint was red. Last round's `reach the document cache through Database.wrapping` added `throws(DatabaseError)` to `Database.queryStatus`, pushing the opening brace onto its own line; swift-format joins it back. Confirmed against the version CI actually pins (602.0.0, via prek) — the local toolchain is 603.0.0 and agrees. |
| `drop the documentIDs default, make the paging fallback explicit` | Answers the one open inline comment on `CachingRepository.documentIDs`. The `Repository` default that paged the full Tier-1 list is gone; `documentIDs` is now a bare requirement, and the paging fallback survives as a helper (`pagedDocumentIDs(filter:)`) that `NullRepository` / `PreviewRepository` / `TransientRepository` opt into by name. |

The second commit changes the answer to that thread. The passthrough on `CachingRepository`
was previously deletable-but-load-bearing: removing it still compiled and silently dropped
callers onto the paging default instead of `ApiRepository`'s `fields=id` projection. With the
default gone, deleting it is a compile error — the footgun the comment was pointing at no
longer exists. Keeping it on the protocol (rather than moving it to an extension) remains
required: `CachingRepository<Wrapped>` calls it through a protocol-constrained generic, so a
non-requirement would dispatch statically and miss the override.

Still open from that thread: whether to point `reconcileDocumentDeletions` at `self.documentIDs`
instead of `wrapped.documentIDs`, so the passthrough is genuinely exercised. Behaviour-neutral,
not done here.

**Stack impact.** #617–#627 were rebased onto this PR's new head. Two real conflicts in
`Repository.swift`, both where #617 adds `documents(filter:fullPerms:)` immediately next to
`documentIDs` and then removes it again a few commits later: resolved by keeping both in
`full_perms list projection (R4b)`, and by applying the removal in `always request full_perms on
the document list`. The other 37 conflicted commits were propagation and cleared with them.

Verified: `Networking` builds clean at all five PR heads, 215 Networking tests pass at the stack
tip, the app scheme builds clean on the simulator at this PR's head *and* at the stack tip, and
prek is green here. Nothing was driven in the simulator.

Not fixed: `current_changelog.txt` loses its trailing newline from #617's `Offline & Sync settings
screen` commit onward, so `end-of-file-fixer` fails on #617/#618/#620/#627 (not on this PR).
Pre-existing and unrelated to this round.

## Manual test checklist

Nothing in this PR has been driven in the simulator — all verification so far is builds, unit
tests, and lint. This is the list that would actually exercise it. Roughly ordered so each
section leaves the app in a useful state for the next.

**Setup:** a server with enough documents to page (≥ 100), at least one saved view, and a way to
change data server-side (web UI in a browser next to the simulator).

### 1. Cold start and first fill

- [x] Settings → Advanced → **Clear Cached Data**, confirm. Toast reads "Cached data cleared", server connections survive.
- [x] Force-quit, relaunch. Document list appears without a visible empty-state flash before the first rows land.
- [x] The count pill shows the server's total, not just the number of rows loaded so far.
- [x] Scroll to the bottom. Rows keep arriving; no gaps, no spinner that never resolves.
- [x] Scroll the whole list looking for the **same document appearing twice** — this was a real bug (`keep a document from being placed twice in one cached query`) and page boundaries are where it showed.

### 2. Offline browsing

- [x] With the list populated, enable Airplane Mode. Back out to the list and return — rows still render from cache.
- [ ] Pull to refresh while offline. Expect **no** error message: `ErrorController.suppressBannerCoveredErrors` drops connectivity-class errors while the device is offline by design. The `offlineToast` it defers to only fires on the online→offline *transition*, so once that has gone there is no surface at all — filed as **#671**, pre-existing and not introduced here.
- [x] Open a document you viewed while online: title, tags, correspondent, and **notes** all render offline.
- [x] Open the metadata sheet for that document — cached file metadata is there.
- [x] Open a document you have *not* opened before while offline. It should fail gracefully, not hang on a loading overlay.
- [x] Leave Airplane Mode. The list recovers on its own or on one pull-to-refresh.

### 3. Detail view load behaviour

- [x] Open a document, back out, reopen. Reopening is instant and shows **no loading spinner** (loads on appear are deliberately silent now).
- [ ] Pull to refresh *inside* the detail view. This one *does* show progress. **Known broken at this PR's head** — every refresh cancels itself and toasts "cancelled", including with no new document version; fixed in #620 by `859716b1b` (moves the load off the gesture's task), which should cover any trigger, not just the version bump its commit message describes. Explicit re-test owed there: [#620 comment](https://github.com/paulgessinger/swift-paperless/pull/620#issuecomment-5319956615).
- [x] Confirm the thumbnail stays visible while the full preview loads — it should not blank out and come back.
- [x] Open a document with several notes. They should be there immediately on second open (prefetched).

### 4. Mutations write through

- [x] Edit a document's title. The list row updates immediately, without a manual refresh.
- [x] Change tags from the tags sheet and save. Row reflects it.
- [ ] Now break it on purpose: Airplane Mode on, change tags, save. The save fails **and the tags visibly revert** rather than sticking in the changed-but-unsaved state.
- [x] Delete a document in-app. It disappears from the list and does not come back on refresh.

### 5. Reconciling with server-side changes

- [x] Delete a document **in the web UI**, then pull to refresh in the app. It disappears locally. (This is the unfiltered id sweep; it's throttled, so give it a refresh or two.)
- [x] Delete several documents server-side at once and refresh. All of them go — none survive, and *nothing else* disappears with them. (Unstable paging here used to read as false deletions.)
- [x] Edit a document's title **in the web UI**, refresh in the app. The change shows up without re-fetching the whole list.
- [x] Switch to a saved view and back to the default list. Both render correct, distinct contents.
- [x] Use search/filters, then clear them. Results are correct and the list returns to the full set.

### 6. Scanner and odd paths

- [x] Scan or enter an ASN that exists. It resolves to the right document (this PR added the index behind that lookup).
- [x] Scan an ASN that doesn't exist — clean "not found", no hang.
- [x] On iPad: open the list and **rotate 10–15 times**, then keep using the app. Watch for slowdown or memory growth. A leak here kept a view model and two DB observations alive per rotation; it's fixed, but rotation is how you'd see a regression.

### 7. Cache wipe

- [x] **Clear Cached Data** again with documents cached and a preview downloaded. Confirm the toast, then check that documents re-download and the app is not left in a broken state.
- [ ] Verify server connections are still configured afterwards.

### Known-live, please don't file these

- **No feedback when an action fails offline** — pull-to-refresh says nothing, and a tag save offline shows a spinner, returns the save button, keeps your edit, and says nothing (the change is *not* saved). Deliberate suppression whose surface only fires on the offline *transition*. Filed as **#671** (ledger #656 item 28); pre-existing, not introduced here.

- **Pull-to-refresh scroll hitch** — the scroll stops tracking your finger for a beat at the trigger threshold, then snaps to catch up. Main-thread SQLite: #660 (also noted on #669 as a possible contributing factor). Reproduces offline as well, slightly weaker. Accepted for now.

- **An interrupted list fill truncates the cache and reports it as complete** — deferred to #618 (#656 item 18). If you kill the app mid-fill and the list is short until the next refresh, that's this.
- **Cached query keys are never garbage-collected** (#669). Not user-visible; storage only.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)  👈
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->








