### PR TITLE
fix: stop data scanner behind detail sheet

### DIFF
--- a/swift-paperless/Views/DataScannerView.swift
+++ b/swift-paperless/Views/DataScannerView.swift
@@ -588,6 +588,7 @@ struct DataScannerView: View {
         isScanning: $isScanning,
         patterns: asnPatterns
       ) { document in
+        isScanning = false
         self.document = document
       }
       .transaction { t in
@@ -647,7 +648,9 @@ struct DataScannerView: View {
         }
       }
 
-      .sheet(item: $document) { document in
+      .sheet(item: $document, onDismiss: {
+        isScanning = true
+      }) { document in
         DetailView(document: document)
       }
     }


### PR DESCRIPTION
## Summary
- Stops the data scanner before presenting a scanned document's detail sheet.
- Resumes scanning when the detail sheet is dismissed.

Closes #603

## Why
The scanner result callback currently presents `DetailView` by assigning `document`, but leaves `isScanning` set to `true`. Since `DataScannerViewInternal.updateUIViewController` only calls `stopScanning()` when `isScanning` becomes false, the `DataScannerViewController` can keep the camera session active behind the detail sheet.

## Fix
The scan result callback now sets `isScanning = false` before assigning `self.document`. The existing `updateUIViewController` path then calls `stopScanning()` on the underlying `DataScannerViewController`.

The sheet also sets `isScanning = true` in `onDismiss`, so returning from document detail resumes scanning while the scanner view remains open.

## How to test in Xcode
1. Check out this branch:
   ```sh
   git fetch origin pull/<PR_NUMBER>/head:data-scanner-stop-behind-detail
   git checkout data-scanner-stop-behind-detail
   ```
   Or fetch the fork branch directly:
   ```sh
   git fetch https://github.com/benaltair/swift-paperless.git fix/data-scanner-stop-behind-detail
   git checkout FETCH_HEAD
   ```
2. Generate the Xcode project:
   ```sh
   brew install xcodegen
   xcodegen generate
   ```
3. Open `swift-paperless.xcodeproj` in Xcode.
4. Build and run the `swift-paperless` scheme on a real iPhone, since `DataScannerViewController` needs a camera-capable device.
5. Open the data scanner flow and scan/tap a document result.
6. Confirm the document detail sheet opens and the camera indicator turns off while the sheet is visible.
7. Dismiss the detail sheet and confirm scanning resumes.

## Local verification
Could not run Swift/Xcode verification in this Linux Hermes environment because `swift`/Xcode are not installed here. The change is intentionally small and limited to scanner state handling in `DataScannerView.swift`.
