### PR TITLE
fix: Decoding saved view with null value rule

### DIFF
--- a/DataModel/Sources/DataModel/Model/FilterRuleModel.swift
+++ b/DataModel/Sources/DataModel/Model/FilterRuleModel.swift
@@ -289,7 +289,13 @@ extension FilterRule: Codable {
         }
       }
     } catch DecodingError.typeMismatch {
-      value = try .invalid(value: container.decodeOrConvert(String.self, forKey: .value))
+      // The typed decode failed (wrong JSON type, or a `null` where the rule
+      // expects a concrete value, e.g. a tag-typed rule with `value: null`).
+      // Fall back to capturing whatever string is there as `.invalid`; a null
+      // value has no string representation, so record it as an empty invalid
+      // value rather than re-throwing and failing the whole response decode.
+      value = try .invalid(
+        value: container.decodeOrConvertOptional(String.self, forKey: .value) ?? "")
     }
   }
 

--- a/DataModel/Tests/DataModelTests/Data/SavedView/saved_view_does_not_have_tag_null.json
+++ b/DataModel/Tests/DataModelTests/Data/SavedView/saved_view_does_not_have_tag_null.json
@@ -1,0 +1,200 @@
+{
+    "count": 7,
+    "next": null,
+    "previous": null,
+    "all": [
+        4,
+        7,
+        3,
+        6,
+        5,
+        8,
+        1
+    ],
+    "results": [
+        {
+            "id": 4,
+            "name": "Active Car Insurance",
+            "show_on_dashboard": false,
+            "show_in_sidebar": true,
+            "sort_field": "added",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 6,
+                    "value": "284"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "264"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                }
+            ],
+            "page_size": null,
+            "display_mode": "smallCards",
+            "display_fields": [
+                "title",
+                "created",
+                "tag",
+                "correspondent",
+                "documenttype",
+                "storagepath",
+                "note",
+                "owner",
+                "shared",
+                "asn"
+            ],
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 7,
+            "name": "Active Health Insurance",
+            "show_on_dashboard": false,
+            "show_in_sidebar": true,
+            "sort_field": "added",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 19,
+                    "value": "Membership certificate"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "372"
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 3,
+            "name": "Active Home Insurance",
+            "show_on_dashboard": false,
+            "show_in_sidebar": true,
+            "sort_field": "modified",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "323"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "264"
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 6,
+            "name": "Active Life Insurance",
+            "show_on_dashboard": false,
+            "show_in_sidebar": true,
+            "sort_field": "added",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "325"
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 5,
+            "name": "Active Rental Insurance",
+            "show_on_dashboard": false,
+            "show_in_sidebar": true,
+            "sort_field": "added",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 6,
+                    "value": "129"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "264"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 8,
+            "name": "Active Voice/Data Contract",
+            "show_on_dashboard": false,
+            "show_in_sidebar": false,
+            "sort_field": "created",
+            "sort_reverse": true,
+            "filter_rules": [
+                {
+                    "rule_type": 6,
+                    "value": "156"
+                },
+                {
+                    "rule_type": 6,
+                    "value": "407"
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        },
+        {
+            "id": 1,
+            "name": "Inbox",
+            "show_on_dashboard": true,
+            "show_in_sidebar": false,
+            "sort_field": null,
+            "sort_reverse": false,
+            "filter_rules": [
+                {
+                    "rule_type": 17,
+                    "value": null
+                }
+            ],
+            "page_size": null,
+            "display_mode": null,
+            "display_fields": null,
+            "owner": 2,
+            "user_can_change": true
+        }
+    ]
+}

--- a/DataModel/Tests/DataModelTests/SavedViewTest.swift
+++ b/DataModel/Tests/DataModelTests/SavedViewTest.swift
@@ -185,6 +185,45 @@ struct SavedViewTest {
     #expect(first.userCanChange == true)
   }
 
+  // Regression test for a user-reported failure: a saved view ("Inbox")
+  // carries a `does_not_have_tag` rule (rule_type 17, a tag-typed rule) whose
+  // value is `null`. FilterRule's decoder used to try `.tag` (UInt) first,
+  // hit the null, fall into the `catch DecodingError.typeMismatch` recovery,
+  // try to decode the null as a String again, throw a second uncaught
+  // typeMismatch and fail the whole ListResponse decode. The null value is now
+  // captured as `.invalid` so the response decodes.
+  @Test func testDecodingListWithNullValueTagRule() throws {
+    let data = try #require(
+      testData("Data/SavedView/saved_view_does_not_have_tag_null.json"))
+    let result = try decoder.decode(ListResponse<SavedView>.self, from: data)
+
+    #expect(result.count == 7)
+    #expect(result.results.count == 7)
+
+    let inbox = try #require(result.results.first { $0.id == 1 })
+    #expect(inbox.name == "Inbox")
+    #expect(inbox.filterRules.count == 1)
+
+    let rule = try #require(inbox.filterRules.first)
+    #expect(rule.ruleType == .doesNotHaveTag)
+    #expect(rule.value == .invalid(value: ""))
+  }
+
+  // Minimal regression test pinpointing the root cause: a tag-typed rule with
+  // a null value decodes as `.invalid` instead of throwing.
+  @Test func testDecodingTagRuleWithNullValue() throws {
+    let input = """
+      {
+          "rule_type": 17,
+          "value": null
+      }
+      """.data(using: .utf8)!
+
+    let rule = try decoder.decode(FilterRule.self, from: input)
+    #expect(rule.ruleType == .doesNotHaveTag)
+    #expect(rule.value == .invalid(value: ""))
+  }
+
   @Test func testDecodingOwnerNull() throws {
     let input = """
       {

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,1 +1,2 @@
 - Fix untranslated strings in document notes
+- Fix saved views failing to load when a filter rule has a null value (e.g. a "does not have tag" rule)


### PR DESCRIPTION
A saved view carrying a filter rule with a null value (e.g. a "does not have tag" rule with value: null) failed to decode, which took down the whole saved-views list response. FilterRule's typeMismatch recovery now captures a null as an empty .invalid value instead of re-throwing.