### PR TITLE
feat: Offline sync is multi-server

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -857,25 +857,55 @@ extension DocumentStore {
     lastDocumentReconcile = Date()
     report(SyncActivity(stage: .reconcile), for: .reconcile)
     defer { report(nil, for: .reconcile) }
-    do {
-      // Deletes first (correctness), then the changed-metadata delta (freshness),
-      // then the saved-view membership sweep (so newly-matched docs — now landed
-      // at detail by the delta — appear in every offline list). The last two are
-      // no-ops unless *Entire library* is enabled.
-      try await NetworkTransfer.$category.withValue(.reconcile) {
-        try await backend.reconcileDocumentDeletions()
+
+    // Each sweep carries its own catch. The delete sweep is the most
+    // failure-prone of the three — it fetches the server's entire live id set —
+    // and under one shared `do` its failure took the freshness delta *and* the
+    // membership rebuild down with it, so a single flaky request cost the whole
+    // reconcile. Cancellation is the exception: it means the pass as a whole is
+    // unwanted (a repository swap, a background time budget running out), so it
+    // stops the remaining sweeps instead of being logged and stepped over.
+    var succeeded = 0
+    var cancelled = false
+
+    func sweep(_ label: String, _ body: () async throws -> Void) async {
+      guard !cancelled else { return }
+      do {
+        try await body()
+        succeeded += 1
+      } catch {
+        guard !error.isCancellationError else {
+          Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+          cancelled = true
+          return
+        }
+        Logger.sync.info("Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+      }
+    }
+
+    // Deletes first (correctness), then the changed-metadata delta (freshness),
+    // then the saved-view membership sweep (so newly-matched docs — now landed
+    // at detail by the delta — appear in every offline list). The last two are
+    // no-ops unless *Entire library* is enabled.
+    await NetworkTransfer.$category.withValue(.reconcile) {
+      await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+      await sweep("changes") {
         try await backend.reconcileDocumentChanges { [weak self] in
           // The delta finishing doesn't end the reconcile — the membership
           // sweep runs after it — so fall back to the bare stage.
           self?.report($0 ?? SyncActivity(stage: .reconcile), for: .reconcile)
         }
-        try await backend.reconcileSavedViewMembership()
       }
-      // Only on success: a server that fails every sweep must not display a
-      // fresh "last refreshed" while nothing is actually being refreshed.
+      await sweep("membership") { try await backend.reconcileSavedViewMembership() }
+    }
+
+    // A pass in which *something* refreshed counts: a server that fails every
+    // sweep must not display a fresh "last refreshed" while nothing is actually
+    // being refreshed, but one failing sweep shouldn't erase the two that
+    // worked. Same policy as `fillLibrary`'s coverage marker. A cancelled pass
+    // stamps nothing — it didn't finish, it was called off.
+    if succeeded > 0, !cancelled {
       lastReconcileAt = Date()
-    } catch {
-      Logger.sync.info("Document reconcile failed (suppressed): \(error)")
     }
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -299,14 +299,36 @@ public final class DocumentStore: Sendable {
     lastSyncError = nil
   }
 
-  public func set(repository: some Repository, reload: Bool = true) {
-    // A repository that doesn't front the DB detaches the element projection
-    // (see `wireElementStore()`), which blanks every element read site until the
-    // next relaunch. That is legitimate before login, but only via `init` —
-    // anything *replacing* a live repository is expected to assemble a caching
-    // stack, so a bare one here is a caller bug. Be loud instead of silently
-    // emptying the UI: this exact mistake shipped once already, from
-    // `ConnectionsView.updateExtraHeaders`.
+  /// Point the store at `connection` — the only supported way to put it on a server.
+  ///
+  /// The store assembles the stack itself, through ``makeCachingRepository``, so a
+  /// caller cannot hand it a bare uncached repository. That mistake detaches the
+  /// element projection and blanks every element read site until the next relaunch,
+  /// and it shipped once already from `ConnectionsView.updateExtraHeaders`; keeping
+  /// the assembly in here is what makes it unrepresentable rather than merely
+  /// discouraged.
+  public func activate(
+    connection: StoredConnection,
+    database: Database,
+    manager: ConnectionManager,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode,
+    reload: Bool = true
+  ) async throws {
+    let repository = try await makeCachingRepository(
+      for: connection, database: database, manager: manager, mode: mode)
+    install(repository: repository, reload: reload)
+  }
+
+  /// The single chokepoint for swapping the live repository. Private on purpose:
+  /// see ``activate(connection:database:manager:mode:reload:)``. Any future path
+  /// that needs to swap repositories should route through here so the invariant
+  /// below keeps covering it.
+  private func install(repository: some Repository, reload: Bool) {
+    // A repository that doesn't front the DB detaches the element projection (see
+    // `wireElementStore()`). That is legitimate before login, but only via `init`;
+    // replacing a *live* repository with a bare one is always a bug. Unreachable
+    // today — `activate` is the only caller — so this is a backstop, not a guard
+    // against anything currently in the tree.
     if !(repository is any CachingBackend) {
       Logger.shared.fault(
         "Installing non-caching repository \(String(describing: type(of: repository)), privacy: .public) on a live store; element projection will stay detached until relaunch"
@@ -314,7 +336,7 @@ public final class DocumentStore: Sendable {
     }
     // An element sync in flight belongs to the *outgoing* backend: it writes the
     // old server's rows, and `runSyncElements` would let the caller's follow-up
-    // sync join it (both callers do `set(repository:)` → `sync()`) and return
+    // sync join it (both `activate` callers do `activate` → `sync()`) and return
     // without ever fetching the new server's cache. Nothing here is worth
     // keeping, so cancel rather than detach.
     syncTask?.cancel()

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -469,11 +469,11 @@ public final class DocumentStore: Sendable {
   /// sync still sees the error. This is what entry views call eagerly on
   /// appear, and what pull-to-refresh calls with `userInitiated: true`.
   public func sync(userInitiated: Bool = false) async throws {
-    Logger.shared.notice("Sync store (userInitiated: \(userInitiated))")
+    Logger.sync.notice("Sync store (userInitiated: \(userInitiated))")
     do {
       try await runSyncElements()
       lastSyncError = nil
-      Logger.shared.info("Sync store complete")
+      Logger.sync.info("Sync store complete")
       // Reconcile remote deletes alongside the element sync (throttled,
       // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
       let userInitiated = userInitiated
@@ -484,7 +484,7 @@ public final class DocumentStore: Sendable {
       // connection switch. Drop it before the userInitiated rethrow so neither
       // case toasts.
       if error.isCancellationError {
-        Logger.shared.debug("Element sync cancelled")
+        Logger.sync.debug("Element sync cancelled")
         return
       }
       if userInitiated { throw error }
@@ -494,7 +494,7 @@ public final class DocumentStore: Sendable {
       if let displayable = error as? any DisplayableError {
         lastSyncError = displayable
       }
-      Logger.shared.error("Background sync failed (suppressed): \(error)")
+      Logger.sync.error("Background sync failed (suppressed): \(error)")
     }
   }
 
@@ -503,16 +503,16 @@ public final class DocumentStore: Sendable {
   /// do with it). A no-op without a caching backend.
   private func runSyncElements() async throws {
     if let syncTask {
-      Logger.shared.debug("Joining in-flight element sync")
+      Logger.sync.debug("Joining in-flight element sync")
       return try await syncTask.value
     }
     guard let backend = repository as? any CachingBackend else {
       // No DB-backed repository (e.g. NullRepository before login). Nothing to
       // sync; the projection is empty until a caching repository is set.
-      Logger.shared.info("Sync skipped: repository is not a caching backend")
+      Logger.sync.info("Sync skipped: repository is not a caching backend")
       return
     }
-    Logger.shared.debug("Starting element sync")
+    Logger.sync.debug("Starting element sync")
     let task = Task { [weak self] in
       try await NetworkTransfer.$category.withValue(.sync) {
         try await backend.syncElements { self?.report($0, for: .elementSync) }
@@ -853,7 +853,7 @@ extension DocumentStore {
       // fresh "last refreshed" while nothing is actually being refreshed.
       lastReconcileAt = Date()
     } catch {
-      Logger.shared.info("Document reconcile failed (suppressed): \(error)")
+      Logger.sync.info("Document reconcile failed (suppressed): \(error)")
     }
   }
 
@@ -882,9 +882,9 @@ extension DocumentStore {
           self?.report($0, for: .libraryFill)
         }
       } catch is CancellationError {
-        Logger.shared.info("Proactive library fill cancelled")
+        Logger.sync.info("Proactive library fill cancelled")
       } catch {
-        Logger.shared.info("Proactive library fill failed (suppressed): \(error)")
+        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
       }
     }
     libraryFillTask = task
@@ -907,7 +907,7 @@ extension DocumentStore {
     do {
       try await backend.fillDocumentDetails { [weak self] in self?.report($0, for: .detailFill) }
     } catch {
-      Logger.shared.info("Proactive detail fill failed (suppressed): \(error)")
+      Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -182,6 +182,15 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     return mode
   }
 
+  /// Friendly-name + UUID for sync logs (see ``StoredConnection/logLabel``);
+  /// falls back to the bare UUID if the connection row can't be read.
+  private var serverLogLabel: String {
+    guard let record = try? database.connection(id: serverID) else {
+      return "[\(serverID.uuidString)]"
+    }
+    return StoredConnection(record: record).logLabel
+  }
+
   // MARK: - CachingBackend
 
   public func syncElements(progress: SyncProgressReporter?) async throws {
@@ -313,7 +322,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           }
         } catch is CancellationError {
         } catch {
-          Logger.shared.error("Background query fill failed: \(error)")
+          Logger.sync.error("Background query fill failed: \(error)")
         }
       }
     }
@@ -338,6 +347,9 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       [(nil, .default)] + savedViews.map { ($0.name, FilterState(savedView: $0)) }
 
     var succeeded = 0
+    Logger.sync.info(
+      "Library fill: \(views.count, privacy: .public) view(s) for server \(self.serverLogLabel, privacy: .public)"
+    )
     for (index, (name, filter)) in views.enumerated() {
       try Task.checkCancellation()
       // A downgrade mid-fill means the rest of these views are no longer wanted,
@@ -345,7 +357,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       // write back rows it has just reclaimed. One connection-row read per view,
       // and there are few views.
       guard offlineBrowsingMode == .entireLibrary else {
-        Logger.shared.info("Library fill: mode left Entire library mid-pass; stopping")
+        Logger.sync.info("Library fill: mode left Entire library mid-pass; stopping")
         return
       }
       progress?(
@@ -376,7 +388,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // A rejected view (e.g. an advanced full-text query the server won't run)
         // must not block the *whole* library's coverage. Record it so the
         // Offline & Sync screen can warn, and carry on.
-        Logger.shared.warning(
+        Logger.sync.warning(
           "Library fill: '\(name ?? "default", privacy: .public)' failed (\(error)); skipping")
         try? database.recordQuerySyncError(
           serverID: serverID, queryKey: key.rawValue, savedViewName: name,
@@ -391,7 +403,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // empty cache — the ordinary shape of Wi-Fi with the server unreachable,
     // since neither `isExpensive` nor `isConstrained` means reachable.
     guard succeeded > 0 else {
-      Logger.shared.warning(
+      Logger.sync.warning(
         "Library fill: all \(views.count, privacy: .public) views failed; leaving coverage unset")
       return
     }
@@ -485,7 +497,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       }
     }
 
-    Logger.shared.info(
+    Logger.sync.info(
       "Detail fill: seeded \(seeded, privacy: .public) empty-notes rows, fetched \(fetchedNotes, privacy: .public) notes, \(fetchedMetadata, privacy: .public) metadata"
     )
   }
@@ -503,7 +515,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       let domains = try await fetch()
       try database.replaceElements(domains, of: type, serverID: serverID)
     } catch let error where Self.isSkippable(error) {
-      Logger.shared.info(
+      Logger.sync.info(
         "Skipping \(R.databaseTableName, privacy: .public) sync: \(error)")
     }
   }
@@ -519,7 +531,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       try database.setUISettings(settings, serverID: serverID)
       return settings.permissions
     } catch {
-      Logger.shared.info(
+      Logger.sync.info(
         "uiSettings sync failed (\(error)); gating sync on cached permissions")
       return try? database.uiSettings(serverID: serverID)?.permissions
     }
@@ -530,7 +542,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       let config = try await wrapped.serverConfiguration()
       try database.setServerConfiguration(config, serverID: serverID)
     } catch let error where Self.isSkippable(error) {
-      Logger.shared.info("Skipping serverConfiguration sync: \(error)")
+      Logger.sync.info("Skipping serverConfiguration sync: \(error)")
     }
   }
 
@@ -811,7 +823,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     let removed = localIDs.subtracting(serverIDs)
     guard !removed.isEmpty else { return }
 
-    Logger.shared.info(
+    Logger.sync.info(
       "Reconcile: dropping \(removed.count, privacy: .public) remotely-deleted documents")
     try database.deleteDocuments(serverID: serverID, removedIDs: Array(removed))
   }
@@ -891,7 +903,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       // refresh rows already cached. Either way the row is written at `.full`.
       let toUpsert = entireLibrary ? changed : changed.filter { localIDs.contains($0.id) }
       if !toUpsert.isEmpty {
-        Logger.shared.info(
+        Logger.sync.info(
           "Reconcile: refreshing \(toUpsert.count, privacy: .public) changed documents")
         try database.upsertDocuments(toUpsert, serverID: serverID)
         // Note edits bump `modified`, so a changed doc's cached notes may be
@@ -936,7 +948,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       } catch is CancellationError {
         throw CancellationError()
       } catch {
-        Logger.shared.info(
+        Logger.sync.info(
           "Membership sweep: '\(name ?? "default", privacy: .public)' failed (\(error)); continuing"
         )
         try? database.recordQuerySyncError(
@@ -957,7 +969,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     do {
       try database.setDeltaWatermark(date, serverID: serverID)
     } catch {
-      Logger.shared.error("setDeltaWatermark failed: \(error)")
+      Logger.sync.error("setDeltaWatermark failed: \(error)")
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -174,7 +174,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   /// this: a new fill drains the current owner before touching the key, and the
   /// membership sweep steps over a key that is mid-fill. Main-actor isolated
   /// like the rest of this class, so claiming and clearing never interleave.
-  private var activeFills: [QueryKey: Task<Void, Never>] = [:]
+  private var activeFills: [QueryKey: Task<Void, any Error>] = [:]
 
   public init(wrapping: Wrapped, database: Database, serverID: UUID) {
     wrapped = wrapping
@@ -320,7 +320,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Detached tasks inherit no task-local, so re-establish `.fill` here.
     let (firstPage, pageOne) = AsyncThrowingStream<UInt?, any Error>.makeStream()
     let task = Task.detached(priority: .utility) {
-      await NetworkTransfer.$category.withValue(.fill) {
+      try await NetworkTransfer.$category.withValue(.fill) {
         var position = 0
         do {
           let batch = try await source.fetch(limit: pageSize)
@@ -332,40 +332,55 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           pageOne.yield(total)
           pageOne.finish()
         } catch {
-          // The caller's problem, not the background's: offline on open means
-          // the list falls back to whatever is already cached.
+          // Page 1 is the caller's problem, not the background's: offline on
+          // open means the list falls back to whatever is already cached. The
+          // caller sees it through the stream, so this task ends quietly.
           pageOne.finish(throwing: error)
           return
         }
 
         // Background-page the rest to disk (append). When this completes the
         // whole view is local; scrolling then needs no network (v1).
-        do {
-          while !Task.isCancelled {
-            if await source.isExhausted { break }
-            let batch = try await source.fetch(limit: pageSize)
-            if batch.isEmpty { break }
-            // Re-check between the fetch returning and the write. Cancellation
-            // is how a newer fill takes the key over, and by now its page-1
-            // replace may already have landed — writing here would graft our
-            // stale positions onto its rows.
-            try Task.checkCancellation()
-            try database.writeQueryPage(
-              queryKey: key, serverID: serverID, documents: batch,
-              startPosition: position, totalCount: await source.totalCount,
-              replaceAll: false)
-            position += batch.count
-          }
-        } catch is CancellationError {
-        } catch {
-          Logger.sync.error("Background query fill failed: \(error)")
+        while true {
+          // Cancellation ends the fill as an error, not as a quiet `break`.
+          // The key is truncated either way, and a silent stop is exactly how
+          // a caller came to treat a 250-row order as the whole query.
+          try Task.checkCancellation()
+          if await source.isExhausted { break }
+          let batch = try await source.fetch(limit: pageSize)
+          if batch.isEmpty { break }
+          // Re-check between the fetch returning and the write. Cancellation is
+          // how a newer fill takes the key over, and by now its page-1 replace
+          // may already have landed — writing here would graft our stale
+          // positions onto its rows.
+          try Task.checkCancellation()
+          try database.writeQueryPage(
+            queryKey: key, serverID: serverID, documents: batch,
+            startPosition: position, totalCount: await source.totalCount,
+            replaceAll: false)
+          position += batch.count
         }
+
+        // Reached the end of the query: the cached order is now its complete
+        // membership, and only here is that recorded. Page 1's `replaceAll`
+        // cleared the stamp, so anything that stopped us short leaves the key
+        // marked incomplete for the next pass to redo.
+        try database.markQueryFillComplete(queryKey: key, serverID: serverID)
       }
     }
 
     activeFills[key] = task
     Task { [weak self] in
-      await task.value
+      do {
+        try await task.value
+      } catch is CancellationError {
+        // A newer fill drained us, or the view went away. Expected.
+      } catch {
+        // `fillLibrary` awaits the fill and reports its failure where the user
+        // can see it. The interactive path doesn't await the background paging
+        // at all, so without this its failures would be entirely silent.
+        Logger.sync.error("Background query fill failed: \(error)")
+      }
       // Retract only our own registration: a newer fill may have drained and
       // replaced us while this was waiting.
       guard let self, activeFills[key] == task else { return }
@@ -393,7 +408,9 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   private func drainFill(for key: QueryKey) async {
     guard let owner = activeFills[key] else { return }
     owner.cancel()
-    await owner.value
+    // Its outcome is the departing fill's own business (its registration task
+    // logs it) — all this needs is for it to have stopped writing.
+    _ = try? await owner.value
     if activeFills[key] == owner { activeFills[key] = nil }
   }
 
@@ -445,12 +462,28 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // this loop can honour is between views — so cancelling mid-view still
         // paged the whole thing, which is exactly what a background time budget
         // or a server switch cannot afford.
-        await withTaskCancellationHandler {
-          await handle.awaitCompletion()
+        try await withTaskCancellationHandler {
+          try await handle.awaitCompletion()
         } onCancel: {
           handle.cancel()
         }
         try Task.checkCancellation()
+        // Not just "nothing threw": the stamp is the fill's own word that it
+        // paged the query to the end. A truncated order counted as covered
+        // would stamp the coverage marker and suppress the retry for a day,
+        // leaving the list hard-stopped at whatever page it reached — with the
+        // count pill still claiming the server's full total.
+        guard (try? database.queryFillCompletedAt(queryKey: key, serverID: serverID)) ?? nil != nil
+        else {
+          // A backstop, not the main path: the fill throws on every way of
+          // stopping short, so reaching here means the stamp and the outcome
+          // disagree. Left as a log rather than a user-facing message — there
+          // is nothing to tell the user beyond "it will run again".
+          Logger.sync.warning(
+            "Library fill: '\(name ?? "default", privacy: .public)' ended incomplete; not counting it as covered"
+          )
+          continue
+        }
         try? database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
         succeeded += 1
       } catch is CancellationError {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -169,6 +169,13 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   public let database: Database
   public let serverID: UUID
 
+  /// The in-flight fill per `QueryKey` — page 1 included, not only the
+  /// background continuation. Every writer of a key's `query_order` consults
+  /// this: a new fill drains the current owner before touching the key, and the
+  /// membership sweep steps over a key that is mid-fill. Main-actor isolated
+  /// like the rest of this class, so claiming and clearing never interleave.
+  private var activeFills: [QueryKey: Task<Void, Never>] = [:]
+
   public init(wrapping: Wrapped, database: Database, serverID: UUID) {
     wrapped = wrapping
     self.database = database
@@ -288,32 +295,61 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   /// library fill.
   public func fillQuery(filter: FilterState) async throws -> QueryFillHandle {
     let key = QueryKey(serverID: serverID, filter: filter)
+
+    // Two fills on one key used to interleave: the newcomer's page-1
+    // `replaceAll: true` deletes every `query_order` row for the key, and the
+    // older fill then keeps appending from its own position counter, leaving a
+    // hole only a later full fill repairs. Neither write errors — the primary
+    // key is ON CONFLICT REPLACE and the unique key ON CONFLICT IGNORE — so
+    // nothing notices. Routine rather than hypothetical since the foreground
+    // library fill started paging `[(nil, .default)] + savedViews`, the very
+    // keys an open list is filling.
+    await drainFill(for: key)
+
     let source = try wrapped.documents(filter: filter)
     let pageSize = Endpoint.defaultDocumentPageSize
-
-    // Page 1 awaited: first window on screen + the exact total for the count pill.
-    let firstPage = try await NetworkTransfer.$category.withValue(.fill) {
-      try await source.fetch(limit: pageSize)
-    }
-    let total = await source.totalCount
-    try database.writeQueryPage(
-      queryKey: key, serverID: serverID, documents: firstPage,
-      startPosition: 0, totalCount: total, replaceAll: true)
-
-    // Background-page the rest to disk (append). When this completes the whole
-    // view is local; scrolling then needs no network (v1). Detached tasks don't
-    // inherit the task-local, so re-establish the `.fill` transfer category here.
     let database = database
     let serverID = serverID
-    let firstCount = firstPage.count
+
+    // Page 1 is still awaited by the caller (first window on screen + the exact
+    // total for the count pill) but is written from inside the fill's own task,
+    // so the key has a single owner from its very first write. Written from the
+    // caller's context it was unclaimed until the background task existed, and
+    // the membership sweep's whole-key `replaceQueryOrder` could land in that
+    // gap — after which the fill appended page 2 onto a different ordering.
+    // Detached tasks inherit no task-local, so re-establish `.fill` here.
+    let (firstPage, pageOne) = AsyncThrowingStream<UInt?, any Error>.makeStream()
     let task = Task.detached(priority: .utility) {
       await NetworkTransfer.$category.withValue(.fill) {
-        var position = firstCount
+        var position = 0
+        do {
+          let batch = try await source.fetch(limit: pageSize)
+          let total = await source.totalCount
+          try database.writeQueryPage(
+            queryKey: key, serverID: serverID, documents: batch,
+            startPosition: 0, totalCount: total, replaceAll: true)
+          position = batch.count
+          pageOne.yield(total)
+          pageOne.finish()
+        } catch {
+          // The caller's problem, not the background's: offline on open means
+          // the list falls back to whatever is already cached.
+          pageOne.finish(throwing: error)
+          return
+        }
+
+        // Background-page the rest to disk (append). When this completes the
+        // whole view is local; scrolling then needs no network (v1).
         do {
           while !Task.isCancelled {
             if await source.isExhausted { break }
             let batch = try await source.fetch(limit: pageSize)
             if batch.isEmpty { break }
+            // Re-check between the fetch returning and the write. Cancellation
+            // is how a newer fill takes the key over, and by now its page-1
+            // replace may already have landed — writing here would graft our
+            // stale positions onto its rows.
+            try Task.checkCancellation()
             try database.writeQueryPage(
               queryKey: key, serverID: serverID, documents: batch,
               startPosition: position, totalCount: await source.totalCount,
@@ -326,8 +362,43 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         }
       }
     }
+
+    activeFills[key] = task
+    Task { [weak self] in
+      await task.value
+      // Retract only our own registration: a newer fill may have drained and
+      // replaced us while this was waiting.
+      guard let self, activeFills[key] == task else { return }
+      activeFills[key] = nil
+    }
+
+    // A cancelled caller takes the whole fill with it — the task is detached,
+    // so nothing else would — and still reports the cancellation, as it did
+    // when page 1 ran in the caller's own context.
+    let total = try await withTaskCancellationHandler {
+      var total: UInt?
+      for try await value in firstPage { total = value }
+      return total
+    } onCancel: {
+      task.cancel()
+    }
+    try Task.checkCancellation()
     return QueryFillHandle(queryKey: key, totalCount: total, fillTask: task)
   }
+
+  /// Stop the fill that currently owns `key` and wait for it to actually stop.
+  /// Cancellation is cooperative — the loop only checks between pages — so
+  /// returning without the await would leave a writer alive across the caller's
+  /// own write, which is the whole problem being fixed.
+  private func drainFill(for key: QueryKey) async {
+    guard let owner = activeFills[key] else { return }
+    owner.cancel()
+    await owner.value
+    if activeFills[key] == owner { activeFills[key] = nil }
+  }
+
+  /// Whether a fill currently owns this key's `query_order`.
+  private func isFilling(_ key: QueryKey) -> Bool { activeFills[key] != nil }
 
   public func fillLibrary(force: Bool, progress: SyncProgressReporter?) async throws {
     guard force || !LibraryCoverage.isFresh(try? database.libraryCoverageAt(serverID: serverID))
@@ -953,11 +1024,30 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     for (name, filter) in views {
       try Task.checkCancellation()
       let key = QueryKey(serverID: serverID, filter: filter)
+      // A fill owning this key is writing the same `query_order` rows page by
+      // page, and it writes a strictly better ordering than this Tier-0
+      // projection — it carries full document detail, and its page-1 replace has
+      // already re-baselined the key. Interleaving `replaceQueryOrder`'s
+      // delete-all-and-reinsert with the fill's appends silently merges two
+      // orderings into a garbled one, so leave the key to the fill; the next
+      // sweep picks it up.
+      guard !isFilling(key) else {
+        Logger.sync.info(
+          "Membership sweep: '\(name ?? "default", privacy: .public)' is mid-fill; skipping")
+        continue
+      }
       do {
         // Ordered, not the id-set projection: these ids become `query_order`
         // positions verbatim, so the query's own sort has to survive the round
         // trip or the sweep rewrites every cached list to id order.
         let ids = try await wrapped.orderedDocumentIDs(filter: filter)
+        // Re-check after the fetch: that suspension is exactly the window a
+        // fill can start in, and the guard above would then be stale.
+        guard !isFilling(key) else {
+          Logger.sync.info(
+            "Membership sweep: '\(name ?? "default", privacy: .public)' began filling; skipping")
+          continue
+        }
         try database.replaceQueryOrder(queryKey: key, serverID: serverID, orderedIDs: ids)
         try? database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
       } catch is CancellationError {

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -562,6 +562,20 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     }
   }
 
+  /// Whether a failed detail fetch may fall back to the offline cache.
+  ///
+  /// A transport failure means we never got an answer, so the last-known row is
+  /// the best one available. A 403/401 *is* the answer: the user may no longer
+  /// see this document, and serving the cached title, notes and PDF would hide a
+  /// revoked permission behind what looks like an outage. Same predicate as the
+  /// sync skip — there a permission failure is tolerated because the rest of the
+  /// sync stays valid, here it must propagate because it answers the only
+  /// question asked. (404 never reaches this: `ApiRepository.get` maps it to
+  /// `nil`, handled on the success path.)
+  private static func mayServeCache(after error: any Error) -> Bool {
+    !isSkippable(error)
+  }
+
   // MARK: - Element reads (cache)
 
   public func tags() async throws -> [Tag] {
@@ -776,9 +790,10 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       // A full-detail fetch — upgrade the row to Tier-2.
       try database.upsertDocument(fetched, serverID: serverID)
       return fetched
-    } catch {
+    } catch let error where Self.mayServeCache(after: error) {
       // Offline/transient: serve the last-known cached row (Tier-1 or Tier-2)
       // rather than failing the open. Mirrors the element offline-first policy.
+      // A permission failure isn't caught here at all, so it propagates.
       if let cached = try database.document(serverID: serverID, id: id) {
         Logger.shared.info("document(id:) network failed (\(error)); serving cached")
         return cached
@@ -792,7 +807,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       guard let fetched = try await wrapped.document(asn: asn) else { return nil }
       try database.upsertDocument(fetched, serverID: serverID)
       return fetched
-    } catch {
+    } catch let error where Self.mayServeCache(after: error) {
       if let cached = try database.document(serverID: serverID, asn: asn) {
         Logger.shared.info("document(asn:) network failed (\(error)); serving cached")
         return cached
@@ -994,7 +1009,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       let fetched = try await wrapped.metadata(documentId: documentId)
       try database.setFileMetadata(fetched, serverID: serverID, versionID: versionID)
       return fetched
-    } catch {
+    } catch let error where Self.mayServeCache(after: error) {
       if let cached = try database.fileMetadata(serverID: serverID, versionID: versionID) {
         Logger.shared.info("metadata(documentId:) network failed (\(error)); serving cached")
         return cached
@@ -1008,7 +1023,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       let fetched = try await wrapped.notes(documentId: documentId)
       try database.setNotes(fetched, serverID: serverID, documentID: documentId)
       return fetched
-    } catch {
+    } catch let error where Self.mayServeCache(after: error) {
       // `nil` (never cached) is distinct from `[]` (cached, no notes): only the
       // former propagates the network error.
       if let cached = try database.notes(serverID: serverID, documentID: documentId) {

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -168,6 +168,15 @@ public struct StoredConnection: Equatable, Identifiable, Sendable {
       return result.absoluteString
     #endif
   }
+
+  /// A log-friendly identifier: the server's friendly name (falling back to the
+  /// privacy-aware ``redactedLabel`` when it has none) alongside its UUID, so
+  /// multi-server sync logs say *which* server without a lookup. Safe to log
+  /// `.public` — ``redactedLabel`` self-redacts in release.
+  public var logLabel: String {
+    let name = friendlyName.flatMap { $0.isEmpty ? nil : $0 } ?? redactedLabel
+    return "\(name) [\(id.uuidString)]"
+  }
 }
 
 @MainActor

--- a/AppShared/Sources/AppShared/Networking/NetworkMonitor.swift
+++ b/AppShared/Sources/AppShared/Networking/NetworkMonitor.swift
@@ -61,17 +61,3 @@ public final class NetworkMonitor {
     monitor.cancel()
   }
 }
-
-extension NetworkMonitor {
-  /// Whether the *proactive* sweeps (library fill, detail fill) may run right
-  /// now. Interactive work the user asked for is never gated on this.
-  ///
-  /// Low Data Mode (`isConstrained`) always wins: it is an explicit instruction
-  /// from the user to the whole system, not a guess about the link, so a
-  /// per-server "sync over cellular" opt-in does not override it. `isExpensive`
-  /// — cellular, or a personal hotspot — is what the opt-in is for.
-  public func allowsProactiveSync(syncOverCellular: Bool) -> Bool {
-    if isConstrained { return false }
-    return syncOverCellular || !isExpensive
-  }
-}

--- a/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
+++ b/AppShared/Sources/AppShared/Networking/QueryFillHandle.swift
@@ -17,9 +17,9 @@ public struct QueryFillHandle: Sendable {
   /// Server-reported total from page 1 (the count pill's number), if known.
   public let totalCount: UInt?
 
-  private let fillTask: Task<Void, Never>
+  private let fillTask: Task<Void, any Error>
 
-  public init(queryKey: QueryKey, totalCount: UInt?, fillTask: Task<Void, Never>) {
+  public init(queryKey: QueryKey, totalCount: UInt?, fillTask: Task<Void, any Error>) {
     self.queryKey = queryKey
     self.totalCount = totalCount
     self.fillTask = fillTask
@@ -30,9 +30,14 @@ public struct QueryFillHandle: Sendable {
     fillTask.cancel()
   }
 
-  /// Await the background fill completing — primarily for tests and callers that
-  /// want the whole view local before proceeding.
-  public func awaitCompletion() async {
-    await fillTask.value
+  /// Await the background fill completing, rethrowing whatever stopped it early.
+  ///
+  /// A fill that dies partway — a dropped connection on page 2, the app being
+  /// suspended, a newer fill taking the key over — leaves the cached order
+  /// truncated. Swallowing that here is what let a caller treat a 250-row order
+  /// as the whole 3000-row query, so the error reaches the caller's own
+  /// handling instead.
+  public func awaitCompletion() async throws {
+    try await fillTask.value
   }
 }

--- a/AppShared/Sources/AppShared/Networking/RepositoryFactory.swift
+++ b/AppShared/Sources/AppShared/Networking/RepositoryFactory.swift
@@ -1,0 +1,38 @@
+//
+//  RepositoryFactory.swift
+//  AppShared
+//
+//  The single place that assembles the per-server repository stack
+//  `CachingRepository(NeedsAuthRepository(ApiRepository))`. Both the app shell
+//  (for the active, displayed connection) and the multi-server `SyncEngine` (for
+//  every inactive connection) build through here, so the layering — cache
+//  outermost, 401 → needs-auth interception underneath — is byte-identical for
+//  every server.
+//
+
+import Foundation
+import Networking
+import Persistence
+
+/// Build the caching repository stack for a stored connection.
+///
+/// The connection's token may be `nil` (a config-synced-but-uncredentialed
+/// server whose credential hasn't arrived yet); the stack still builds, and the
+/// first authenticated call 401s into per-server needs-auth via
+/// ``NeedsAuthRepository``. Callers that want to avoid the doomed round-trip
+/// should short-circuit on a missing token *before* calling this.
+@MainActor
+public func makeCachingRepository(
+  for stored: StoredConnection,
+  database: Database,
+  manager: ConnectionManager,
+  mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
+  let connection = try stored.connection
+  let api = await ApiRepository(connection: connection, mode: mode)
+  let needsAuth = NeedsAuthRepository(
+    wrapping: api, serverID: stored.id, connectionManager: manager)
+  // Caching outermost: reads come from the GRDB cache, while sync's network
+  // calls still flow through the needs-auth 401 interception.
+  return CachingRepository(wrapping: needsAuth, database: database, serverID: stored.id)
+}

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -210,22 +210,52 @@ public final class SyncEngine {
       try await NetworkTransfer.$category.withValue(.sync) {
         try await backend.syncElements()
       }
-      try await NetworkTransfer.$category.withValue(.reconcile) {
-        try await backend.reconcileDocumentDeletions()
-        try await backend.reconcileDocumentChanges()
-        try await backend.reconcileSavedViewMembership()
+      // Each reconcile sweep carries its own catch, as on the active path
+      // (`DocumentStore.reconcileDocuments`): the deletion sweep is the most
+      // failure-prone of the three — it fetches the server's entire live id set
+      // — and under one shared `try` its failure took the freshness delta, the
+      // membership rebuild *and* the heavy fill down with it. Cancellation is
+      // the exception: it means the pass as a whole is unwanted, so it stops
+      // the remaining sweeps instead of being logged and stepped over.
+      var failed = false
+      var cancelled = false
+      func sweep(_ label: String, _ body: () async throws -> Void) async {
+        guard !cancelled else { return }
+        do {
+          try await body()
+        } catch {
+          guard !error.isCancellationError else {
+            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+            cancelled = true
+            return
+          }
+          Logger.sync.info(
+            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+          failed = true
+        }
+      }
+      await NetworkTransfer.$category.withValue(.reconcile) {
+        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+        await sweep("changes") { try await backend.reconcileDocumentChanges() }
+        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
       }
 
       // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
-      if runHeavyFill {
+      if runHeavyFill, !cancelled {
         try await NetworkTransfer.$category.withValue(.fill) {
           try await backend.fillLibrary(force: false)
           try await backend.fillDocumentDetails()
         }
       }
 
-      // Advance the throttle only on a fully successful pass, so an interrupted
-      // sweep retries next trigger.
+      // Advance the throttle only on a *fully* successful pass — a sweep that
+      // failed or was called off partway retries on the next trigger.
+      guard !failed, !cancelled else {
+        Logger.sync.info(
+          "Inactive server \(stored.logLabel, privacy: .public) partially synced; throttle not advanced"
+        )
+        return
+      }
       lastSweep[id] = Date()
       Logger.sync.info("Inactive server \(stored.logLabel, privacy: .public) synced")
     } catch {

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -138,6 +138,10 @@ public final class SyncEngine {
       "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (unmetered: \(unmetered), userInitiated: \(userInitiated))"
     )
     for action in actions {
+      // Re-read per iteration: the action list was computed before the first
+      // `await`, so a server the user switched to mid-sweep would otherwise be
+      // swept here while `DocumentStore` drives it on the same server.
+      guard action.serverID != manager.activeConnectionId else { continue }
       guard let stored = manager.connections[action.serverID] else { continue }
       await runAction(action, stored: stored)
     }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -134,10 +134,14 @@ public final class SyncEngine {
       throttle: inactiveThrottle,
       unmetered: unmetered)
 
+    Logger.sync.info(
+      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (unmetered: \(unmetered), userInitiated: \(userInitiated))"
+    )
     for action in actions {
       guard let stored = manager.connections[action.serverID] else { continue }
       await runAction(action, stored: stored)
     }
+    Logger.sync.info("Inactive sweep complete")
   }
 
   private func handleConnectionsChanged() {
@@ -151,6 +155,9 @@ public final class SyncEngine {
     let added = SyncPlan.newlyAdded(
       current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
     knownServerIDs = current
+    if !added.isEmpty {
+      Logger.sync.info("Observed \(added.count) new server(s); kicking initial sync")
+    }
     for id in added {
       guard let stored = manager.connections[id] else { continue }
       // Throttle-exempt initial sync for a freshly-appeared server.
@@ -169,6 +176,8 @@ public final class SyncEngine {
       // Config-synced-but-uncredentialed: mark per-server needs-auth and make no
       // network call. Deterministic and cheap; when the token later lands, the
       // next sweep picks it up. The 401 path stays a backstop for a rejected token.
+      Logger.sync.info(
+        "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
       manager.markNeedsAuth(for: stored.id)
       return
     }
@@ -189,6 +198,9 @@ public final class SyncEngine {
   /// ephemeral per-server backend. The whole body is caught so a per-server
   /// failure (offline, rethrown 401, …) never escapes to sibling servers.
   private func performServerSync(_ stored: StoredConnection, runHeavyFill: Bool) async {
+    let id = stored.id
+    Logger.sync.info(
+      "Syncing inactive server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
     do {
       let backend = try await makeCachingRepository(
         for: stored, database: database, manager: manager, mode: mode)
@@ -214,10 +226,11 @@ public final class SyncEngine {
 
       // Advance the throttle only on a fully successful pass, so an interrupted
       // sweep retries next trigger.
-      lastSweep[stored.id] = Date()
+      lastSweep[id] = Date()
+      Logger.sync.info("Inactive server \(stored.logLabel, privacy: .public) synced")
     } catch {
-      Logger.shared.info(
-        "Inactive-server sync failed for \(stored.id, privacy: .private(mask: .hash)) (suppressed): \(error)"
+      Logger.sync.info(
+        "Inactive-server sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)"
       )
     }
   }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -33,9 +33,12 @@ public final class SyncEngine {
   @ObservationIgnored private let database: Database
   @ObservationIgnored private let manager: ConnectionManager
   @ObservationIgnored private let mode: ApiRepository.Mode
-  /// Live "is the link unmetered?" read for the observation-driven initial-sync
-  /// path (the lifecycle-triggered sweep receives the flag as a parameter).
-  @ObservationIgnored private let isUnmetered: @MainActor () -> Bool
+  /// Live raw path cost read for the observation-driven initial-sync path (the
+  /// lifecycle-triggered sweep receives it as a parameter instead). Raw, not a
+  /// decision — each server combines it with its own `syncOverCellular` via
+  /// `SyncCondition`.
+  @ObservationIgnored private let pathCost:
+    @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
 
   /// Last successful sweep per server; drives the throttle. The active server is
   /// never keyed here (never swept by the engine).
@@ -56,12 +59,12 @@ public final class SyncEngine {
   public init(
     database: Database,
     manager: ConnectionManager,
-    isUnmetered: @escaping @MainActor () -> Bool,
+    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool),
     mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
   ) {
     self.database = database
     self.manager = manager
-    self.isUnmetered = isUnmetered
+    self.pathCost = pathCost
     self.mode = mode
   }
 
@@ -104,13 +107,16 @@ public final class SyncEngine {
   /// failure never affects the others. Coalesces concurrent callers.
   ///
   /// `userInitiated` bypasses the per-server throttle (explicit "sync now").
-  public func syncInactiveServers(unmetered: Bool, userInitiated: Bool = false) async {
+  public func syncInactiveServers(
+    isExpensive: Bool, isConstrained: Bool, userInitiated: Bool = false
+  ) async {
     if let sweepTask {
       return await sweepTask.value
     }
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
-      await runSweep(unmetered: unmetered, userInitiated: userInitiated)
+      await runSweep(
+        isExpensive: isExpensive, isConstrained: isConstrained, userInitiated: userInitiated)
     }
     sweepTask = task
     await task.value
@@ -119,12 +125,13 @@ public final class SyncEngine {
 
   // MARK: - Sweep
 
-  private func runSweep(unmetered: Bool, userInitiated: Bool) async {
+  private func runSweep(isExpensive: Bool, isConstrained: Bool, userInitiated: Bool) async {
     let snapshots = manager.connections.values.map { conn in
       SyncPlan.ServerSnapshot(
         id: conn.id,
         hasToken: hasToken(conn),
-        isEntireLibrary: conn.offlineBrowsingMode == .entireLibrary)
+        isEntireLibrary: conn.offlineBrowsingMode == .entireLibrary,
+        syncOverCellular: conn.syncOverCellular)
     }
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
@@ -132,10 +139,11 @@ public final class SyncEngine {
       lastSweep: userInitiated ? [:] : lastSweep,
       now: Date(),
       throttle: inactiveThrottle,
-      unmetered: unmetered)
+      isExpensive: isExpensive,
+      isConstrained: isConstrained)
 
     Logger.sync.info(
-      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (unmetered: \(unmetered), userInitiated: \(userInitiated))"
+      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
     )
     for action in actions {
       // Re-read per iteration: the action list was computed before the first
@@ -165,10 +173,14 @@ public final class SyncEngine {
     for id in added {
       guard let stored = manager.connections[id] else { continue }
       // Throttle-exempt initial sync for a freshly-appeared server.
+      let cost = pathCost()
+      let condition = SyncCondition(
+        isExpensive: cost.isExpensive, isConstrained: cost.isConstrained,
+        syncOverCellular: stored.syncOverCellular)
       let action = SyncServerAction(
         serverID: stored.id,
         needsAuthOnly: !hasToken(stored),
-        runHeavyFill: isUnmetered() && stored.offlineBrowsingMode == .entireLibrary)
+        runHeavyFill: condition.allowsProactiveSync && stored.offlineBrowsingMode == .entireLibrary)
       Task { @MainActor [weak self] in await self?.runAction(action, stored: stored) }
     }
   }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -1,0 +1,233 @@
+//
+//  SyncEngine.swift
+//  AppShared
+//
+//  Stage 10 (multi-server sync): keeps every *inactive* configured server's
+//  offline cache warm. The active server is deliberately NOT touched here — it
+//  is driven by `DocumentStore` (its own `CachingRepository` instance), so the
+//  engine skips `activeConnectionId` to avoid two instances racing the same
+//  `query_order` rows. "Active-first" therefore falls out for free: the store
+//  syncs the active server on the same lifecycle trigger, and the engine sweeps
+//  the rest.
+//
+//  Scheduling stays on app-lifecycle triggers (launch / foreground /
+//  active-change); true `BGProcessingTask` execution is Stage 11's. When that
+//  lands, `runSweep`'s server enumeration should move from `manager.connections`
+//  (main-actor) to an off-main `database.allConnections()` read.
+//
+//  The interesting decisions (active exclusion, throttle, uncredentialed
+//  degrade, heavy-fill gating, new-server diff) live in the pure, unit-tested
+//  `DataModel.SyncPlan`; this type is the imperative shell that executes them.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+@Observable
+public final class SyncEngine {
+  @ObservationIgnored private let database: Database
+  @ObservationIgnored private let manager: ConnectionManager
+  @ObservationIgnored private let mode: ApiRepository.Mode
+  /// Live "is the link unmetered?" read for the observation-driven initial-sync
+  /// path (the lifecycle-triggered sweep receives the flag as a parameter).
+  @ObservationIgnored private let isUnmetered: @MainActor () -> Bool
+
+  /// Last successful sweep per server; drives the throttle. The active server is
+  /// never keyed here (never swept by the engine).
+  @ObservationIgnored private var lastSweep: [UUID: Date] = [:]
+  /// Per-server in-flight sync, so an observation-driven initial sync and a
+  /// lifecycle sweep for the same server coalesce onto one task.
+  @ObservationIgnored private var inFlight: [UUID: Task<Void, Never>] = [:]
+  /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
+  @ObservationIgnored private var sweepTask: Task<Void, Never>?
+  /// Server IDs seen at the last observation tick, to detect newly-added ones.
+  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
+  @ObservationIgnored private var observationTask: Task<Void, Never>?
+
+  /// Background warmth cadence for inactive servers — deliberately looser than
+  /// the active path's 300 s reconcile throttle; these servers aren't on screen.
+  @ObservationIgnored private let inactiveThrottle: TimeInterval = 900
+
+  public init(
+    database: Database,
+    manager: ConnectionManager,
+    isUnmetered: @escaping @MainActor () -> Bool,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+  ) {
+    self.database = database
+    self.manager = manager
+    self.isUnmetered = isUnmetered
+    self.mode = mode
+  }
+
+  deinit {
+    observationTask?.cancel()
+  }
+
+  // MARK: - Public API
+
+  /// Begin observing the `server` table (via `manager.connections`, which is the
+  /// sole projection of it). A newly-appeared, non-active server triggers a
+  /// throttle-exempt initial sync.
+  ///
+  /// This is wired to the *observation*, not the "Add server" UI action, so a
+  /// Stage-12 UBKVS `server` upsert flows into the initial-sync path for free.
+  /// Removed servers need no work — the `server` row delete FK-cascades the whole
+  /// cache; the engine just drops their throttle/in-flight bookkeeping.
+  public func start() {
+    guard observationTask == nil else { return }
+    // Seed with the current set so the observation only reacts to *new* servers;
+    // the servers present at launch are handled by the explicit sweep below.
+    knownServerIDs = Set(manager.connections.keys)
+    observationTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+          _ = self?.manager.connections.keys
+        } onChange: {
+          continuation.yield()
+          continuation.finish()
+        }
+        self?.handleConnectionsChanged()
+        for await _ in stream { break }
+      }
+    }
+  }
+
+  /// Sweep every inactive server once, sequentially (active-first is implicit —
+  /// active is excluded and driven by the store), each isolated so one server's
+  /// failure never affects the others. Coalesces concurrent callers.
+  ///
+  /// `userInitiated` bypasses the per-server throttle (explicit "sync now").
+  public func syncInactiveServers(unmetered: Bool, userInitiated: Bool = false) async {
+    if let sweepTask {
+      return await sweepTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await runSweep(unmetered: unmetered, userInitiated: userInitiated)
+    }
+    sweepTask = task
+    await task.value
+    sweepTask = nil
+  }
+
+  // MARK: - Sweep
+
+  private func runSweep(unmetered: Bool, userInitiated: Bool) async {
+    let snapshots = manager.connections.values.map { conn in
+      SyncPlan.ServerSnapshot(
+        id: conn.id,
+        hasToken: hasToken(conn),
+        isEntireLibrary: conn.offlineBrowsingMode == .entireLibrary)
+    }
+    let actions = SyncPlan.inactiveActions(
+      connections: snapshots,
+      activeID: manager.activeConnectionId,
+      lastSweep: userInitiated ? [:] : lastSweep,
+      now: Date(),
+      throttle: inactiveThrottle,
+      unmetered: unmetered)
+
+    for action in actions {
+      guard let stored = manager.connections[action.serverID] else { continue }
+      await runAction(action, stored: stored)
+    }
+  }
+
+  private func handleConnectionsChanged() {
+    let current = Set(manager.connections.keys)
+    // Drop bookkeeping for servers whose rows vanished (cache already cascaded).
+    for id in knownServerIDs.subtracting(current) {
+      inFlight[id]?.cancel()
+      inFlight[id] = nil
+      lastSweep[id] = nil
+    }
+    let added = SyncPlan.newlyAdded(
+      current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
+    knownServerIDs = current
+    for id in added {
+      guard let stored = manager.connections[id] else { continue }
+      // Throttle-exempt initial sync for a freshly-appeared server.
+      let action = SyncServerAction(
+        serverID: stored.id,
+        needsAuthOnly: !hasToken(stored),
+        runHeavyFill: isUnmetered() && stored.offlineBrowsingMode == .entireLibrary)
+      Task { @MainActor [weak self] in await self?.runAction(action, stored: stored) }
+    }
+  }
+
+  // MARK: - Per-server execution
+
+  private func runAction(_ action: SyncServerAction, stored: StoredConnection) async {
+    if action.needsAuthOnly {
+      // Config-synced-but-uncredentialed: mark per-server needs-auth and make no
+      // network call. Deterministic and cheap; when the token later lands, the
+      // next sweep picks it up. The 401 path stays a backstop for a rejected token.
+      manager.markNeedsAuth(for: stored.id)
+      return
+    }
+    if let existing = inFlight[stored.id] {
+      return await existing.value
+    }
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await performServerSync(stored, runHeavyFill: action.runHeavyFill)
+    }
+    inFlight[stored.id] = task
+    await task.value
+    inFlight[stored.id] = nil
+  }
+
+  /// Mirrors the active path's sequence (`DocumentStore.sync` + `reconcileDocuments`
+  /// + `fillLibraryIfEnabled` + `fillDocumentDetailsIfEnabled`) against an
+  /// ephemeral per-server backend. The whole body is caught so a per-server
+  /// failure (offline, rethrown 401, …) never escapes to sibling servers.
+  private func performServerSync(_ stored: StoredConnection, runHeavyFill: Bool) async {
+    do {
+      let backend = try await makeCachingRepository(
+        for: stored, database: database, manager: manager, mode: mode)
+
+      // Cheap tier (always, regardless of metered-ness): element sync + the
+      // reconcile sweeps (the last two self-gate on *Entire library*).
+      try await NetworkTransfer.$category.withValue(.sync) {
+        try await backend.syncElements()
+      }
+      try await NetworkTransfer.$category.withValue(.reconcile) {
+        try await backend.reconcileDocumentDeletions()
+        try await backend.reconcileDocumentChanges()
+        try await backend.reconcileSavedViewMembership()
+      }
+
+      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
+      if runHeavyFill {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillLibrary(force: false)
+          try await backend.fillDocumentDetails()
+        }
+      }
+
+      // Advance the throttle only on a fully successful pass, so an interrupted
+      // sweep retries next trigger.
+      lastSweep[stored.id] = Date()
+    } catch {
+      Logger.shared.info(
+        "Inactive-server sync failed for \(stored.id, privacy: .private(mask: .hash)) (suppressed): \(error)"
+      )
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// True only when a non-empty credential is present. `try? … ?? nil` flattens
+  /// the double optional so a Keychain read error (`.none`) and an absent token
+  /// (`.some(nil)`) both read as "no token" → per-server needs-auth degrade.
+  private func hasToken(_ stored: StoredConnection) -> Bool {
+    ((try? stored.token) ?? nil) != nil
+  }
+}

--- a/AppShared/Sources/AppShared/Utilities/Logging.swift
+++ b/AppShared/Sources/AppShared/Utilities/Logging.swift
@@ -11,6 +11,11 @@ import os
 extension Logger {
   public static let shared = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "General")
   public static let api = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "API")
+  /// Offline sync/fill/reconcile — the active server (DocumentStore /
+  /// CachingRepository) and every inactive server (SyncEngine). Filter with
+  /// `log stream --predicate 'category == "Sync"'` to watch the whole
+  /// multi-server sync in isolation.
+  public static let sync = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "Sync")
   public static let migration = Logger(
     subsystem: Bundle.main.bundleIdentifier!, category: "Migration")
   public static let biometric = Logger(

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -125,23 +125,21 @@ public struct ConnectionsView: View {
       connectionManager.setExtraHeaders(extraHeaders)
       if let stored = connectionManager.storedConnection {
         Task {
-          // Rebuild the *whole* stack through the shared factory, exactly as the
-          // app shell and the SyncEngine do, so this path cannot drift from
-          // them. Both layers matter here: the needs-auth decoration because a
-          // bare repository 401s without ever flipping the flag (and 401s are
-          // suppressed on the assumption the connection banner covers them), and
-          // the caching wrapper because the store detaches its ElementStore
-          // projection from any repository that fronts no database — installing
-          // an uncached repository here would blank every element read site
-          // until the next relaunch.
-          guard
-            let repository = try? await makeCachingRepository(
-              for: stored, database: database, manager: connectionManager)
-          else {
-            Logger.shared.error("Could not rebuild repository after extra header change")
-            return
+          // Rebuild the *whole* stack, exactly as the app shell and the SyncEngine
+          // do, so this path cannot drift from them. Both layers matter here: the
+          // needs-auth decoration because a bare repository 401s without ever
+          // flipping the flag (and 401s are suppressed on the assumption the
+          // connection banner covers them), and the caching wrapper because the
+          // store detaches its ElementStore projection from any repository that
+          // fronts no database. `activate` owns that assembly, so this call site
+          // can no longer get it wrong.
+          do {
+            try await store.activate(
+              connection: stored, database: database, manager: connectionManager)
+          } catch {
+            Logger.shared.error(
+              "Could not rebuild repository after extra header change: \(error)")
           }
-          store.set(repository: repository)
         }
       }
     }

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -123,25 +123,25 @@ public struct ConnectionsView: View {
     if existing != extraHeaders {
       Logger.shared.info("Active connection extra headers have changed")
       connectionManager.setExtraHeaders(extraHeaders)
-      if let stored = connectionManager.storedConnection,
-        let connection = connectionManager.connection
-      {
+      if let stored = connectionManager.storedConnection {
         Task {
-          let api = await ApiRepository(
-            connection: connection, mode: Bundle.main.appConfiguration.mode)
-          // Rebuild the *whole* stack the app shell installs, not just the API
-          // layer. The needs-auth decoration is required because a bare
-          // repository 401s without ever flipping the flag, and 401s are
-          // suppressed on the assumption the connection banner covers them.
-          // The caching wrapper is required because the store detaches its
-          // ElementStore projection from any repository that fronts no
-          // database — installing an uncached repository here would blank every
-          // element read site until the next relaunch.
-          let needsAuth = NeedsAuthRepository(
-            wrapping: api, serverID: stored.id, connectionManager: connectionManager)
-          store.set(
-            repository: CachingRepository(
-              wrapping: needsAuth, database: database, serverID: stored.id))
+          // Rebuild the *whole* stack through the shared factory, exactly as the
+          // app shell and the SyncEngine do, so this path cannot drift from
+          // them. Both layers matter here: the needs-auth decoration because a
+          // bare repository 401s without ever flipping the flag (and 401s are
+          // suppressed on the assumption the connection banner covers them), and
+          // the caching wrapper because the store detaches its ElementStore
+          // projection from any repository that fronts no database — installing
+          // an uncached repository here would blank every element read site
+          // until the next relaunch.
+          guard
+            let repository = try? await makeCachingRepository(
+              for: stored, database: database, manager: connectionManager)
+          else {
+            Logger.shared.error("Could not rebuild repository after extra header change")
+            return
+          }
+          store.set(repository: repository)
         }
       }
     }

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -33,8 +33,10 @@ public struct OfflineSyncView: View {
 
   private var unmetered: Bool {
     guard let networkMonitor else { return true }
-    return networkMonitor.allowsProactiveSync(
-      syncOverCellular: connectionManager.activeSyncOverCellular)
+    return SyncCondition(
+      isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
+      syncOverCellular: connectionManager.activeSyncOverCellular
+    ).allowsProactiveSync
   }
 
   /// Suggest the greedy mode only when it is actually cheap. A new server starts

--- a/DataModel/Sources/DataModel/SyncCondition.swift
+++ b/DataModel/Sources/DataModel/SyncCondition.swift
@@ -1,0 +1,35 @@
+//
+//  SyncCondition.swift
+//  DataModel
+//
+
+/// Whether the proactive sync sweeps (the entire-library fill, a multi-server
+/// warm sweep) may run right now, on one server. The single place this
+/// decision is made — every caller (foreground, background, per-server sweep)
+/// constructs one of these and reads ``allowsProactiveSync`` rather than
+/// re-deriving the formula, which is what let it drift out of sync across
+/// call sites before.
+///
+/// Interactive work the user asked for (opening a document, pull-to-refresh,
+/// search, "Sync now") is never gated on this.
+public struct SyncCondition: Equatable, Sendable {
+  /// The network path is metered (cellular, or a personal hotspot).
+  public var isExpensive: Bool
+  /// Low Data Mode is on for the current network.
+  public var isConstrained: Bool
+  /// This server's own opt-in to proactive syncing on a metered link.
+  public var syncOverCellular: Bool
+
+  public init(isExpensive: Bool, isConstrained: Bool, syncOverCellular: Bool) {
+    self.isExpensive = isExpensive
+    self.isConstrained = isConstrained
+    self.syncOverCellular = syncOverCellular
+  }
+
+  /// Low Data Mode always wins: it's an explicit instruction from the user to
+  /// the whole system, not a guess about the link, so the per-server opt-in
+  /// does not override it. The opt-in is what `isExpensive` alone is for.
+  public var allowsProactiveSync: Bool {
+    isConstrained ? false : (syncOverCellular || !isExpensive)
+  }
+}

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -1,0 +1,105 @@
+//
+//  SyncPlan.swift
+//  DataModel
+//
+
+import Foundation
+
+/// One server's resolved sync intent for a multi-server sweep.
+///
+/// `SyncPlan` produces these; the imperative `SyncEngine` (in `AppShared`, which
+/// has no test target) executes them. Keeping the *decision* here makes the
+/// interesting logic — active exclusion, throttle, uncredentialed degrade,
+/// heavy-fill gating — unit-testable cross-platform, mirroring how
+/// `OfflineLibrarySize` backs `OfflineBrowsingMode.default(forDocumentCount:)`.
+public struct SyncServerAction: Equatable, Sendable {
+  public let serverID: UUID
+
+  /// The server has no stored credential yet (config-synced-but-uncredentialed,
+  /// e.g. a Stage-12 UBKVS `server` row whose iCloud-Keychain token hasn't
+  /// arrived). Execute by marking per-server needs-auth and making **no**
+  /// network call — never fail the whole engine.
+  public let needsAuthOnly: Bool
+
+  /// Run the heavy proactive fill (`fillLibrary` + `fillDocumentDetails`) in
+  /// addition to the always-run cheap tier (`syncElements` + reconcile). Only
+  /// true on an unmetered path for an *Entire library* server. Implies a token
+  /// is present (`needsAuthOnly == false`).
+  public let runHeavyFill: Bool
+
+  public init(serverID: UUID, needsAuthOnly: Bool, runHeavyFill: Bool) {
+    self.serverID = serverID
+    self.needsAuthOnly = needsAuthOnly
+    self.runHeavyFill = runHeavyFill
+  }
+}
+
+/// Pure planning for the multi-server (inactive-server) sync sweep.
+public enum SyncPlan {
+  /// A dependency-free snapshot of one configured server, as the engine sees it
+  /// at sweep time. `isEntireLibrary` is `AppShared.OfflineBrowsingMode ==
+  /// .entireLibrary` flattened to a `Bool` so this stays in `DataModel` (which
+  /// does not know `OfflineBrowsingMode`).
+  public struct ServerSnapshot: Equatable, Sendable {
+    public let id: UUID
+    public let hasToken: Bool
+    public let isEntireLibrary: Bool
+
+    public init(id: UUID, hasToken: Bool, isEntireLibrary: Bool) {
+      self.id = id
+      self.hasToken = hasToken
+      self.isEntireLibrary = isEntireLibrary
+    }
+  }
+
+  /// The ordered set of actions for a sweep of every **inactive** server.
+  ///
+  /// - The active server is excluded (it is driven by `DocumentStore`, never by
+  ///   the engine — this is what prevents a two-instance double-fill race).
+  /// - Uncredentialed servers always yield a `needsAuthOnly` action (cheap,
+  ///   throttle-exempt, so a freshly-arrived token is picked up on the very next
+  ///   sweep).
+  /// - Credentialed servers are dropped while their last successful sweep is
+  ///   still within `throttle`; otherwise they yield a sync action whose
+  ///   `runHeavyFill` is gated on `unmetered && isEntireLibrary`.
+  /// - Ordering is stable (by `id`) for deterministic, testable behavior.
+  public static func inactiveActions(
+    connections: [ServerSnapshot],
+    activeID: UUID?,
+    lastSweep: [UUID: Date],
+    now: Date,
+    throttle: TimeInterval,
+    unmetered: Bool
+  ) -> [SyncServerAction] {
+    connections
+      .filter { $0.id != activeID }
+      .sorted { $0.id.uuidString < $1.id.uuidString }
+      .compactMap { server in
+        guard server.hasToken else {
+          // Uncredentialed: mark needs-auth every sweep (no network, no throttle).
+          return SyncServerAction(serverID: server.id, needsAuthOnly: true, runHeavyFill: false)
+        }
+        if let last = lastSweep[server.id], now.timeIntervalSince(last) < throttle {
+          return nil  // still fresh — skip the network sweep
+        }
+        return SyncServerAction(
+          serverID: server.id,
+          needsAuthOnly: false,
+          runHeavyFill: unmetered && server.isEntireLibrary)
+      }
+  }
+
+  /// Server IDs that appeared since the last observation tick and warrant an
+  /// initial (throttle-exempt) sync. The active server is excluded — it is
+  /// synced by `DocumentStore` when it becomes active, so the engine must not
+  /// double-drive it even on first appearance.
+  public static func newlyAdded(
+    current: Set<UUID>, known: Set<UUID>, activeID: UUID?
+  ) -> Set<UUID> {
+    var added = current.subtracting(known)
+    if let activeID {
+      added.remove(activeID)
+    }
+    return added
+  }
+}

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -44,11 +44,15 @@ public enum SyncPlan {
     public let id: UUID
     public let hasToken: Bool
     public let isEntireLibrary: Bool
+    /// This server's own opt-in to proactive syncing on a metered link — see
+    /// ``SyncCondition``.
+    public let syncOverCellular: Bool
 
-    public init(id: UUID, hasToken: Bool, isEntireLibrary: Bool) {
+    public init(id: UUID, hasToken: Bool, isEntireLibrary: Bool, syncOverCellular: Bool) {
       self.id = id
       self.hasToken = hasToken
       self.isEntireLibrary = isEntireLibrary
+      self.syncOverCellular = syncOverCellular
     }
   }
 
@@ -61,7 +65,10 @@ public enum SyncPlan {
   ///   sweep).
   /// - Credentialed servers are dropped while their last successful sweep is
   ///   still within `throttle`; otherwise they yield a sync action whose
-  ///   `runHeavyFill` is gated on `unmetered && isEntireLibrary`.
+  ///   `runHeavyFill` is gated on `isEntireLibrary &&` that server's own
+  ///   ``SyncCondition/allowsProactiveSync`` — each server's own
+  ///   `syncOverCellular` opt-in applies to *that* server only, not the whole
+  ///   sweep.
   /// - Ordering is stable (by `id`) for deterministic, testable behavior.
   public static func inactiveActions(
     connections: [ServerSnapshot],
@@ -69,7 +76,8 @@ public enum SyncPlan {
     lastSweep: [UUID: Date],
     now: Date,
     throttle: TimeInterval,
-    unmetered: Bool
+    isExpensive: Bool,
+    isConstrained: Bool
   ) -> [SyncServerAction] {
     connections
       .filter { $0.id != activeID }
@@ -82,10 +90,13 @@ public enum SyncPlan {
         if let last = lastSweep[server.id], now.timeIntervalSince(last) < throttle {
           return nil  // still fresh — skip the network sweep
         }
+        let condition = SyncCondition(
+          isExpensive: isExpensive, isConstrained: isConstrained,
+          syncOverCellular: server.syncOverCellular)
         return SyncServerAction(
           serverID: server.id,
           needsAuthOnly: false,
-          runHeavyFill: unmetered && server.isEntireLibrary)
+          runHeavyFill: condition.allowsProactiveSync && server.isEntireLibrary)
       }
   }
 

--- a/DataModel/Tests/DataModelTests/SyncConditionTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncConditionTests.swift
@@ -1,0 +1,41 @@
+//
+//  SyncConditionTests.swift
+//  DataModel
+//
+
+import Testing
+
+@testable import DataModel
+
+@Suite
+struct SyncConditionTests {
+  @Test("An unmetered link always allows proactive sync, opt-in or not")
+  func unmeteredAlwaysAllowed() {
+    #expect(
+      SyncCondition(isExpensive: false, isConstrained: false, syncOverCellular: false)
+        .allowsProactiveSync)
+    #expect(
+      SyncCondition(isExpensive: false, isConstrained: false, syncOverCellular: true)
+        .allowsProactiveSync)
+  }
+
+  @Test("An expensive link requires the opt-in")
+  func expensiveRequiresOptIn() {
+    #expect(
+      !SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: false)
+        .allowsProactiveSync)
+    #expect(
+      SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: true)
+        .allowsProactiveSync)
+  }
+
+  @Test("Low Data Mode always wins, regardless of the opt-in or link cost")
+  func constrainedAlwaysWins() {
+    #expect(
+      !SyncCondition(isExpensive: false, isConstrained: true, syncOverCellular: true)
+        .allowsProactiveSync)
+    #expect(
+      !SyncCondition(isExpensive: true, isConstrained: true, syncOverCellular: true)
+        .allowsProactiveSync)
+  }
+}

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -16,9 +16,12 @@ struct SyncPlanTests {
   private static let c = UUID(uuidString: "00000000-0000-0000-0000-0000000000CC")!
 
   private func snapshot(
-    _ id: UUID, hasToken: Bool = true, isEntireLibrary: Bool = false
+    _ id: UUID, hasToken: Bool = true, isEntireLibrary: Bool = false,
+    syncOverCellular: Bool = false
   ) -> SyncPlan.ServerSnapshot {
-    .init(id: id, hasToken: hasToken, isEntireLibrary: isEntireLibrary)
+    .init(
+      id: id, hasToken: hasToken, isEntireLibrary: isEntireLibrary,
+      syncOverCellular: syncOverCellular)
   }
 
   private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
@@ -28,7 +31,8 @@ struct SyncPlanTests {
   func activeExcluded() {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.a), snapshot(Self.b)],
-      activeID: Self.a, lastSweep: [:], now: now, throttle: throttle, unmetered: true)
+      activeID: Self.a, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: false, isConstrained: false)
     #expect(actions.map(\.serverID) == [Self.b])
   }
 
@@ -36,7 +40,8 @@ struct SyncPlanTests {
   func stableOrdering() {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.c), snapshot(Self.a), snapshot(Self.b)],
-      activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: true)
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: false, isConstrained: false)
     #expect(actions.map(\.serverID) == [Self.a, Self.b, Self.c])
   }
 
@@ -46,7 +51,7 @@ struct SyncPlanTests {
       connections: [snapshot(Self.a), snapshot(Self.b)],
       activeID: nil,
       lastSweep: [Self.a: now.addingTimeInterval(-(throttle - 1))],
-      now: now, throttle: throttle, unmetered: true)
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
     #expect(actions.map(\.serverID) == [Self.b])
   }
 
@@ -56,7 +61,7 @@ struct SyncPlanTests {
       connections: [snapshot(Self.a)],
       activeID: nil,
       lastSweep: [Self.a: now.addingTimeInterval(-(throttle + 1))],
-      now: now, throttle: throttle, unmetered: true)
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
     #expect(actions.map(\.serverID) == [Self.a])
   }
 
@@ -67,30 +72,56 @@ struct SyncPlanTests {
       activeID: nil,
       // Even "recently swept" it must re-emit so a freshly-arrived token is caught.
       lastSweep: [Self.a: now],
-      now: now, throttle: throttle, unmetered: true)
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
     #expect(
       actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, runHeavyFill: false)])
   }
 
-  @Test("Heavy fill requires both unmetered and entireLibrary")
+  @Test("Heavy fill requires both an allowed link and entireLibrary")
   func heavyFillGating() {
-    func heavy(unmetered: Bool, entire: Bool) -> Bool {
+    func heavy(isExpensive: Bool, entire: Bool) -> Bool {
       SyncPlan.inactiveActions(
         connections: [snapshot(Self.a, isEntireLibrary: entire)],
-        activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: unmetered
+        activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+        isExpensive: isExpensive, isConstrained: false
       ).first!.runHeavyFill
     }
-    #expect(heavy(unmetered: true, entire: true))
-    #expect(!heavy(unmetered: true, entire: false))
-    #expect(!heavy(unmetered: false, entire: true))
-    #expect(!heavy(unmetered: false, entire: false))
+    #expect(heavy(isExpensive: false, entire: true))
+    #expect(!heavy(isExpensive: false, entire: false))
+    #expect(!heavy(isExpensive: true, entire: true))
+    #expect(!heavy(isExpensive: true, entire: false))
+  }
+
+  @Test(
+    "A server's own syncOverCellular opts it into the heavy fill on an expensive link; a sibling without the opt-in stays cheap-only in the same sweep"
+  )
+  func perServerCellularOptIn() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [
+        snapshot(Self.a, isEntireLibrary: true, syncOverCellular: true),
+        snapshot(Self.b, isEntireLibrary: true, syncOverCellular: false),
+      ],
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: true, isConstrained: false)
+    #expect(actions.first(where: { $0.serverID == Self.a })?.runHeavyFill == true)
+    #expect(actions.first(where: { $0.serverID == Self.b })?.runHeavyFill == false)
+  }
+
+  @Test("Low Data Mode blocks the heavy fill even for a server opted into cellular")
+  func lowDataModeOverridesOptIn() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a, isEntireLibrary: true, syncOverCellular: true)],
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: true, isConstrained: true)
+    #expect(actions.first?.runHeavyFill == false)
   }
 
   @Test("Metered entireLibrary still runs the cheap tier (action present, heavy off)")
   func meteredStillSweepsCheap() {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.a, isEntireLibrary: true)],
-      activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: false)
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: true, isConstrained: false)
     #expect(actions.count == 1)
     #expect(actions.first?.needsAuthOnly == false)
     #expect(actions.first?.runHeavyFill == false)

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -1,0 +1,111 @@
+//
+//  SyncPlanTests.swift
+//  DataModel
+//
+
+import Foundation
+import Testing
+
+@testable import DataModel
+
+@Suite
+struct SyncPlanTests {
+  // Stable, ordered UUIDs so `sorted(by: uuidString)` is predictable in asserts.
+  private static let a = UUID(uuidString: "00000000-0000-0000-0000-0000000000AA")!
+  private static let b = UUID(uuidString: "00000000-0000-0000-0000-0000000000BB")!
+  private static let c = UUID(uuidString: "00000000-0000-0000-0000-0000000000CC")!
+
+  private func snapshot(
+    _ id: UUID, hasToken: Bool = true, isEntireLibrary: Bool = false
+  ) -> SyncPlan.ServerSnapshot {
+    .init(id: id, hasToken: hasToken, isEntireLibrary: isEntireLibrary)
+  }
+
+  private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+  private let throttle: TimeInterval = 900
+
+  @Test("The active server is never in the inactive action list")
+  func activeExcluded() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a), snapshot(Self.b)],
+      activeID: Self.a, lastSweep: [:], now: now, throttle: throttle, unmetered: true)
+    #expect(actions.map(\.serverID) == [Self.b])
+  }
+
+  @Test("Inactive servers are ordered deterministically by id")
+  func stableOrdering() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.c), snapshot(Self.a), snapshot(Self.b)],
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: true)
+    #expect(actions.map(\.serverID) == [Self.a, Self.b, Self.c])
+  }
+
+  @Test("A recently-swept credentialed server is skipped")
+  func throttledSkipped() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a), snapshot(Self.b)],
+      activeID: nil,
+      lastSweep: [Self.a: now.addingTimeInterval(-(throttle - 1))],
+      now: now, throttle: throttle, unmetered: true)
+    #expect(actions.map(\.serverID) == [Self.b])
+  }
+
+  @Test("A stale (past-throttle) credentialed server is included")
+  func staleIncluded() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a)],
+      activeID: nil,
+      lastSweep: [Self.a: now.addingTimeInterval(-(throttle + 1))],
+      now: now, throttle: throttle, unmetered: true)
+    #expect(actions.map(\.serverID) == [Self.a])
+  }
+
+  @Test("An uncredentialed server yields a needsAuthOnly action, throttle-exempt")
+  func uncredentialedNeedsAuthOnly() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a, hasToken: false)],
+      activeID: nil,
+      // Even "recently swept" it must re-emit so a freshly-arrived token is caught.
+      lastSweep: [Self.a: now],
+      now: now, throttle: throttle, unmetered: true)
+    #expect(
+      actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, runHeavyFill: false)])
+  }
+
+  @Test("Heavy fill requires both unmetered and entireLibrary")
+  func heavyFillGating() {
+    func heavy(unmetered: Bool, entire: Bool) -> Bool {
+      SyncPlan.inactiveActions(
+        connections: [snapshot(Self.a, isEntireLibrary: entire)],
+        activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: unmetered
+      ).first!.runHeavyFill
+    }
+    #expect(heavy(unmetered: true, entire: true))
+    #expect(!heavy(unmetered: true, entire: false))
+    #expect(!heavy(unmetered: false, entire: true))
+    #expect(!heavy(unmetered: false, entire: false))
+  }
+
+  @Test("Metered entireLibrary still runs the cheap tier (action present, heavy off)")
+  func meteredStillSweepsCheap() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [snapshot(Self.a, isEntireLibrary: true)],
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle, unmetered: false)
+    #expect(actions.count == 1)
+    #expect(actions.first?.needsAuthOnly == false)
+    #expect(actions.first?.runHeavyFill == false)
+  }
+
+  @Test("newlyAdded returns only genuinely new, non-active ids")
+  func newlyAddedDiff() {
+    let added = SyncPlan.newlyAdded(
+      current: [Self.a, Self.b, Self.c], known: [Self.a], activeID: Self.b)
+    #expect(added == [Self.c])
+  }
+
+  @Test("A newly-added server that is the active one is not swept by the engine")
+  func newlyAddedExcludesActive() {
+    let added = SyncPlan.newlyAdded(current: [Self.a], known: [], activeID: Self.a)
+    #expect(added.isEmpty)
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -62,7 +62,8 @@ extension Database {
         }
         try setQueryMeta(
           db, serverID: serverID, queryKey: queryKey,
-          totalCount: totalCount, orderStale: false)
+          totalCount: totalCount, orderStale: false,
+          stamp: replaceAll ? .cleared : .unchanged)
       }
     }
   }
@@ -89,7 +90,7 @@ extension Database {
         }
         try setQueryMeta(
           db, serverID: serverID, queryKey: queryKey,
-          totalCount: UInt(orderedIDs.count), orderStale: false)
+          totalCount: UInt(orderedIDs.count), orderStale: false, stamp: .unchanged)
       }
     }
   }
@@ -338,6 +339,42 @@ extension Database {
     }
   }
 
+  /// Record that the fill owning this query paged it all the way to the end, so
+  /// the cached order is the query's complete membership.
+  ///
+  /// Called only on a clean finish — not on cancellation, not on a failed page.
+  /// The absence of the stamp is what tells the next pass the order is truncated
+  /// and has to be redone; without it an interrupted fill was silently
+  /// indistinguishable from a complete one.
+  public func markQueryFillComplete(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) {
+    try wrapping("markQueryFillComplete") {
+      try writer.write { db in
+        let meta =
+          try QueryMetaRow
+          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+          .fetchOne(db)
+        try setQueryMeta(
+          db, serverID: serverID, queryKey: queryKey,
+          totalCount: meta?.totalCount, orderStale: meta?.orderStale ?? false,
+          stamp: .completed)
+      }
+    }
+  }
+
+  /// When this query's order was last filled to completion, or `nil` if it never
+  /// was (or was truncated since by a page-1 replace).
+  public func queryFillCompletedAt(queryKey: QueryKey, serverID: UUID) throws(DatabaseError)
+    -> Date?
+  {
+    try wrapping("queryFillCompletedAt") {
+      try writer.read { db in
+        try QueryMetaRow
+          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+          .fetchOne(db)?.filledAt
+      }
+    }
+  }
+
   /// Server total, locally-present count (reflects deletion gaps), and
   /// order-stale flag for a cached query.
   public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus {
@@ -433,13 +470,43 @@ extension Database {
       .deleteAll(db)
   }
 
+  /// What a `query_meta` write does to the `filled_at` stamp.
+  ///
+  /// The stamp means *"the fill that owns this key paged it to the end"*. It
+  /// used to be set on every `writeQueryPage`, i.e. it meant "a page was
+  /// written" — which is why a fill interrupted on page 2 left a 250-row order
+  /// carrying the server's full 3000 as `total_count` and a fresh `filled_at`,
+  /// indistinguishable from a complete one.
+  enum FillStamp {
+    /// Page 1 of a fill: `replaceAll` has just deleted the key's whole order,
+    /// so it is known-incomplete until the fill says otherwise.
+    case cleared
+    /// A later page, or a membership rewrite — leave whatever is recorded.
+    case unchanged
+    /// The fill's paging loop reached the end of the query.
+    case completed
+  }
+
   private func setQueryMeta(
     _ db: GRDB.Database, serverID: UUID, queryKey: QueryKey,
-    totalCount: UInt?, orderStale: Bool
+    totalCount: UInt?, orderStale: Bool, stamp: FillStamp
   ) throws {
+    let filledAt: Date?
+    switch stamp {
+    case .cleared: filledAt = nil
+    case .completed: filledAt = Date()
+    case .unchanged:
+      // A record `upsert` rewrites every column, so carrying the stamp forward
+      // has to be explicit. Same transaction as the caller's write, so no other
+      // writer can slip in between the read and the upsert.
+      filledAt =
+        try QueryMetaRow
+        .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+        .fetchOne(db)?.filledAt
+    }
     try QueryMetaRow(
       serverId: serverID, queryKey: queryKey.rawValue,
-      totalCount: totalCount, orderStale: orderStale, filledAt: Date()
+      totalCount: totalCount, orderStale: orderStale, filledAt: filledAt
     ).upsert(db)
   }
 }

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -281,6 +281,74 @@ struct DocumentCacheTests {
       ])
   }
 
+  // MARK: - Fill completion
+
+  @Test("a fill is not complete until it says so, and page 1 un-completes the key")
+  func fillCompletionStamp() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "fill")
+
+    // Page 1 truncated the key's order down to what it just wrote, so the key
+    // is incomplete no matter what it was before.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 4, replaceAll: true)
+    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+
+    // An appended page is still not a completed fill — this is the case that
+    // used to be indistinguishable from one.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(2, "B")],
+      startPosition: 1, totalCount: 4, replaceAll: false)
+    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+
+    try database.markQueryFillComplete(queryKey: key, serverID: server)
+    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) != nil)
+
+    // A new fill's page 1 wipes the order, so the completion goes with it.
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(3, "C")],
+      startPosition: 0, totalCount: 9, replaceAll: true)
+    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+  }
+
+  @Test("marking a fill complete keeps the recorded total and stale flag")
+  func fillCompletionPreservesMeta() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "fill")
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
+      startPosition: 0, totalCount: 7, replaceAll: true)
+    try database.markQueriesOrderStale(containing: 1, serverID: server)
+    try database.markQueryFillComplete(queryKey: key, serverID: server)
+
+    let status = try database.queryStatus(queryKey: key, serverID: server)
+    #expect(status.totalCount == 7)
+    #expect(status.orderStale)
+  }
+
+  @Test("a membership rewrite leaves the completion stamp alone")
+  func replaceQueryOrderKeepsFillStamp() async throws {
+    let server = UUID()
+    let database = try database(server)
+    let key = QueryKey(sentinel: "view")
+    try database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
+
+    try database.writeQueryPage(
+      queryKey: key, serverID: server, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 1, replaceAll: true)
+    try database.markQueryFillComplete(queryKey: key, serverID: server)
+    let stamped = try #require(try database.queryFillCompletedAt(queryKey: key, serverID: server))
+
+    // The sweep writes a complete ordering of its own, so it neither claims nor
+    // revokes the fill's completion.
+    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [2, 1])
+    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == stamped)
+  }
+
   // MARK: - Order staleness
 
   @Test("markQueriesOrderStale flips the flag only for queries containing the doc")

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -88,18 +88,21 @@ struct ShareView: View {
   private func refreshConnection() {
     Logger.api.info("Connection info changed, reloading!")
 
-    if let conn = connectionManager.connection {
-      Logger.api.trace("Valid connection from connection manager: \(String(describing: conn))")
+    if let stored = connectionManager.storedConnection {
+      Logger.api.trace("Valid connection from connection manager: \(stored.logLabel)")
       Task {
         store.events.emit(.repositoryWillChange)
         // Caching outermost, over the extension's own DB, so the store's
-        // ElementStore projection observes the writes its sync performs.
-        let api = await ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode)
-        let needsAuth = NeedsAuthRepository(
-          wrapping: api, serverID: conn.serverID, connectionManager: connectionManager)
-        let repository = CachingRepository(
-          wrapping: needsAuth, database: database, serverID: conn.serverID)
-        store.set(repository: repository)
+        // ElementStore projection observes the writes its sync performs. The
+        // store owns that assembly (see `DocumentStore.activate`), so the
+        // extension can't drift from the app's layering.
+        do {
+          try await store.activate(
+            connection: stored, database: database, manager: connectionManager)
+        } catch {
+          Logger.api.error("Could not build repository for active connection: \(error)")
+          return
+        }
         storeReady = true
         try? await store.sync()
       }

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -18,3 +18,4 @@
 - Documents that belong to a list but aren't downloaded yet appear as placeholder rows instead of being missing
 - A saved view that can't be downloaded for offline use no longer blocks the rest of the offline sync; the Offline & Sync screen now lists any views that failed to sync
 - Opening a document while the server is unreachable no longer removes it from your document list
+- All of your configured servers now stay synced for offline browsing in the background, not just the one you're currently viewing, so switching servers shows your documents right away

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -19,3 +19,7 @@
 - A saved view that can't be downloaded for offline use no longer blocks the rest of the offline sync; the Offline & Sync screen now lists any views that failed to sync
 - Opening a document while the server is unreachable no longer removes it from your document list
 - All of your configured servers now stay synced for offline browsing in the background, not just the one you're currently viewing, so switching servers shows your documents right away
+- An offline download that is interrupted, by losing connection or by the app being backgrounded, is now retried instead of leaving a list stuck partway while reporting it as fully downloaded
+- Background sync and an open document list downloading at the same time no longer leave gaps in a cached list
+- A document you no longer have permission to view is no longer served from the offline cache as though the server were unreachable
+- A failed cleanup of documents deleted on the server no longer stops the rest of the offline refresh

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -24,6 +24,10 @@ struct MainView: View {
 
   @State private var manager: ConnectionManager
 
+  // Keeps every *inactive* server's offline cache warm (Stage 10). The active
+  // server stays on the DocumentStore path; the engine skips it.
+  @State private var syncEngine: SyncEngine
+
   // Shared GRDB database, threaded into each connection's CachingRepository.
   private let database: Database
 
@@ -50,9 +54,20 @@ struct MainView: View {
     // Route network byte counts into the persisted transfer meter.
     TransferStatistics.install()
     self.database = database
-    _manager = State(wrappedValue: ConnectionManager(database: database))
+    let manager = ConnectionManager(database: database)
+    _manager = State(wrappedValue: manager)
     let errorController = ErrorController()
     let networkMonitor = NetworkMonitor()
+    // Same unmetered semantics as `isUnmetered` below, read live so the engine's
+    // observation-driven initial sync gates on the current link.
+    _syncEngine = State(
+      wrappedValue: SyncEngine(
+        database: database,
+        manager: manager,
+        isUnmetered: { [weak networkMonitor] in
+          guard let networkMonitor else { return false }
+          return !networkMonitor.isExpensive && !networkMonitor.isConstrained
+        }))
     errorController.suppressBannerCoveredErrors(networkMonitor: networkMonitor)
     _errorController = StateObject(wrappedValue: errorController)
     _networkMonitor = State(initialValue: networkMonitor)
@@ -177,13 +192,18 @@ struct MainView: View {
       }
 
       Logger.api.info("Valid connection from connection manager: \(String(describing: conn))")
-      let api = await ApiRepository(connection: conn, mode: Bundle.main.appConfiguration.mode)
-      let needsAuth = NeedsAuthRepository(
-        wrapping: api, serverID: conn.serverID, connectionManager: manager)
-      // Caching outermost: reads come from the GRDB cache, while sync's network
-      // calls still flow through the needs-auth 401 interception.
-      let repository = CachingRepository(
-        wrapping: needsAuth, database: database, serverID: conn.serverID)
+      // Build the active server's stack through the shared factory (identical to
+      // the per-server stacks the SyncEngine builds for inactive servers).
+      guard let stored = manager.storedConnection,
+        let repository = try? await makeCachingRepository(
+          for: stored, database: database, manager: manager)
+      else {
+        Logger.api.error("Could not build repository for active connection")
+        storeReady = false
+        showLoginScreen = true
+        showLoadingScreen = false
+        return
+      }
       if let store {
         await sleep(.seconds(0.1))
         store.events.emit(.repositoryWillChange)
@@ -344,12 +364,21 @@ struct MainView: View {
       Logger.shared.notice("Checking login status")
       await refreshConnection(animated: initialDisplay)
       initialDisplay = false
+
+      // Begin observing the server table for newly-added servers, and warm every
+      // inactive server's cache (the active server was just synced above).
+      syncEngine.start()
+      Task { await syncEngine.syncInactiveServers(unmetered: isUnmetered) }
     }
 
     .onEvent(from: manager.events) { event in
       switch event {
       case .connectionChange(let animated):
-        Task { await refreshConnection(animated: animated) }
+        Task {
+          await refreshConnection(animated: animated)
+          // The just-deactivated server is now inactive: sweep it (and the rest).
+          await syncEngine.syncInactiveServers(unmetered: isUnmetered)
+        }
       case .logout:
         showLoginScreen = true
       }
@@ -374,12 +403,16 @@ struct MainView: View {
         // (when "Entire library" is on) tops up the proactive fill — a no-op once
         // the coverage marker is fresh. The initial launch sync is handled by
         // refreshConnection.
-        if !initialDisplay, let store {
-          Task {
-            try? await store.sync()
-            await store.fillLibraryIfEnabled(unmetered: isUnmetered)
-            await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+        if !initialDisplay {
+          if let store {
+            Task {
+              try? await store.sync()
+              await store.fillLibraryIfEnabled(unmetered: isUnmetered)
+              await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+            }
           }
+          // Warm the inactive servers alongside the active refresh.
+          Task { await syncEngine.syncInactiveServers(unmetered: isUnmetered) }
         }
 
         Task { await biometricLockManager.unlockIfEnabled() }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -192,39 +192,51 @@ struct MainView: View {
       }
 
       Logger.api.info("Valid connection from connection manager: \(String(describing: conn))")
-      // Build the active server's stack through the shared factory (identical to
-      // the per-server stacks the SyncEngine builds for inactive servers).
-      guard let stored = manager.storedConnection,
-        let repository = try? await makeCachingRepository(
-          for: stored, database: database, manager: manager)
-      else {
-        Logger.api.error("Could not build repository for active connection")
+      guard let stored = manager.storedConnection else {
+        Logger.api.error("Active connection has no stored connection record")
         storeReady = false
         showLoginScreen = true
         showLoadingScreen = false
         return
       }
-      if let store {
+
+      // The store assembles the active server's stack itself (identical to the
+      // per-server stacks the SyncEngine builds for inactive servers), so both the
+      // reuse and the first-launch path go through one entry point. A fresh store
+      // starts on `NullRepository` and is only published once `activate` succeeds —
+      // otherwise a failed login would leave a detached store installed.
+      let isNewStore = store == nil
+      let target = store ?? DocumentStore(repository: NullRepository())
+
+      if !isNewStore {
         await sleep(.seconds(0.1))
-        store.events.emit(.repositoryWillChange)
+        target.events.emit(.repositoryWillChange)
         await sleep(.seconds(0.3))
-        store.set(repository: repository)
-        storeReady = true
-        try? await store.sync()
-        store.startTaskPolling()
-        kickLibraryFill(store)
-        await sleep(.seconds(0.3))
-        showLoadingScreen = false
-      } else {
-        let newStore = DocumentStore(repository: repository)
-        store = newStore
-        observeFriendlyName(on: newStore)
-        storeReady = true
-        try? await newStore.sync()
-        newStore.startTaskPolling()
-        kickLibraryFill(newStore)
-        showLoadingScreen = false
       }
+
+      do {
+        try await target.activate(connection: stored, database: database, manager: manager)
+      } catch {
+        Logger.api.error("Could not build repository for active connection: \(error)")
+        storeReady = false
+        showLoginScreen = true
+        showLoadingScreen = false
+        return
+      }
+
+      if isNewStore {
+        store = target
+        observeFriendlyName(on: target)
+      }
+
+      storeReady = true
+      try? await target.sync()
+      target.startTaskPolling()
+      kickLibraryFill(target)
+      if !isNewStore {
+        await sleep(.seconds(0.3))
+      }
+      showLoadingScreen = false
       showLoginScreen = false
     } else {
       storeReady = false

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -58,15 +58,16 @@ struct MainView: View {
     _manager = State(wrappedValue: manager)
     let errorController = ErrorController()
     let networkMonitor = NetworkMonitor()
-    // Same unmetered semantics as `isUnmetered` below, read live so the engine's
-    // observation-driven initial sync gates on the current link.
+    // Raw path cost, read live so the engine's observation-driven initial
+    // sync gates on the current link — same source `isUnmetered` below reads,
+    // combined per-server via `SyncCondition` rather than folded here.
     _syncEngine = State(
       wrappedValue: SyncEngine(
         database: database,
         manager: manager,
-        isUnmetered: { [weak networkMonitor] in
-          guard let networkMonitor else { return false }
-          return !networkMonitor.isExpensive && !networkMonitor.isConstrained
+        pathCost: { [weak networkMonitor] in
+          guard let networkMonitor else { return (isExpensive: true, isConstrained: true) }
+          return (networkMonitor.isExpensive, networkMonitor.isConstrained)
         }))
     errorController.suppressBannerCoveredErrors(networkMonitor: networkMonitor)
     _errorController = StateObject(wrappedValue: errorController)
@@ -159,12 +160,16 @@ struct MainView: View {
     }
   }
 
-  /// The gate for the heavy proactive fills (cheap reconcile sweeps run
-  /// regardless). Wi‑Fi‑ish by default, unless the active server has been opted
-  /// in to cellular; Low Data Mode always wins. See
-  /// `NetworkMonitor.allowsProactiveSync(syncOverCellular:)`.
+  /// The gate for the *active* server's heavy proactive fill (cheap reconcile
+  /// sweeps run regardless). Wi‑Fi‑ish by default, unless the active server has
+  /// been opted in to cellular; Low Data Mode always wins. See `SyncCondition`.
+  /// The inactive-server sweep resolves this per-server itself — pass it raw
+  /// path cost (`networkMonitor.isExpensive`/`.isConstrained`), not this.
   private var isUnmetered: Bool {
-    networkMonitor.allowsProactiveSync(syncOverCellular: manager.activeSyncOverCellular)
+    SyncCondition(
+      isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
+      syncOverCellular: manager.activeSyncOverCellular
+    ).allowsProactiveSync
   }
 
   /// Fire-and-forget the proactive *Entire library* fill (no-op when disabled,
@@ -380,7 +385,10 @@ struct MainView: View {
       // Begin observing the server table for newly-added servers, and warm every
       // inactive server's cache (the active server was just synced above).
       syncEngine.start()
-      Task { await syncEngine.syncInactiveServers(unmetered: isUnmetered) }
+      Task {
+        await syncEngine.syncInactiveServers(
+          isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
+      }
     }
 
     .onEvent(from: manager.events) { event in
@@ -389,7 +397,8 @@ struct MainView: View {
         Task {
           await refreshConnection(animated: animated)
           // The just-deactivated server is now inactive: sweep it (and the rest).
-          await syncEngine.syncInactiveServers(unmetered: isUnmetered)
+          await syncEngine.syncInactiveServers(
+            isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
         }
       case .logout:
         showLoginScreen = true
@@ -424,7 +433,10 @@ struct MainView: View {
             }
           }
           // Warm the inactive servers alongside the active refresh.
-          Task { await syncEngine.syncInactiveServers(unmetered: isUnmetered) }
+          Task {
+            await syncEngine.syncInactiveServers(
+              isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
+          }
         }
 
         Task { await biometricLockManager.unlockIfEnabled() }


### PR DESCRIPTION
This pull request introduces several improvements to the `DocumentStore` and `CachingRepository` classes, focusing on safer repository management, more robust query filling, and clearer logging. The most significant changes are the introduction of a single entry point for activating repositories, a fix for interleaving query fills, and enhanced logging for sync and fill operations.

**Repository management improvements:**
- Replaced the public `set(repository:)` method with a new `activate(connection:database:manager:mode:reload:)` method in `DocumentStore`, ensuring that only properly assembled, caching repositories can be installed. The actual repository swap logic is now private, enforcing this invariant and preventing UI breakage from accidental bare repository assignment.

**Query fill robustness:**
- Added an `activeFills` tracking mechanism in `CachingRepository` to prevent interleaving fills on the same query key. Before starting a new fill, any existing fill for the key is cancelled and awaited, ensuring that only one writer owns the `query_order` at a time. This fixes issues where overlapping fills could leave query ordering in an inconsistent state. [[1]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR172-R178) [[2]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR298-R419)
- Refactored the query fill logic so that the background paging task claims ownership from the very first write, and cancellation is handled cooperatively to avoid partial or conflicting writes.

**Sync and fill logging improvements:**
- Replaced most uses of `Logger.shared` with `Logger.sync` for all sync- and fill-related log messages, making logs easier to filter and interpret. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L472-R498) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L487-R509) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L497-R519) [[4]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L506-R537) [[5]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L885-R939) [[6]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L910-R962) [[7]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feR438-R448) [[8]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL365-R486) [[9]](diffhunk://#diff-8d55fb15fbb2a18b28da6f85fd2ca2f25674f8a8af4c8950bce9367743ec85feL379-R495)
- Added a `serverLogLabel` property to `CachingRepository` for friendlier and more informative log messages, including the server's display name and UUID.

**Reconcile and fill behavior:**
- Improved the reconcile process in `DocumentStore` by isolating each sweep (deletions, changes, membership) in its own `do` block. This ensures that a failure in one sweep does not prevent others from running, except in the case of cancellation, which halts the process. The `lastReconcileAt` timestamp is now only updated if at least one sweep succeeded and the process was not cancelled.

These changes make repository activation safer, query fills more reliable, and logging more consistent and useful for debugging and monitoring.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync  👈
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->

