### PR TITLE
fix: show cached PDF immediately while document metadata refreshes

### DIFF
--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -5383,6 +5383,18 @@
         }
       }
     },
+    "documentDetailRefresh" : {
+      "comment" : "Toolbar button on the iPad document detail view that reloads the document from the server.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
+          }
+        }
+      }
+    },
     "documentDuplicateAsn" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/AppShared/Sources/AppShared/Views/PDFKitView.swift
+++ b/AppShared/Sources/AppShared/Views/PDFKitView.swift
@@ -51,7 +51,24 @@ public struct PDFKitView: UIViewRepresentable {
     self.pageIndex = pageIndex
   }
 
-  public func updateUIView(_: PDFKit.PDFView, context _: Context) {}
+  // PDFView keeps whatever document `makeUIView` gave it, so without this a
+  // SwiftUI update that swaps in a different `PDFDocument` at the same tree
+  // position — a re-download after a server-side version bump, or the
+  // archived/original switch — silently keeps rendering the old file.
+  //
+  // Identity, not equality: `PDFDocument` has no meaningful `==`, and
+  // `PDFDocument.loadBackground` always constructs a fresh instance, so `!==`
+  // is precisely "this is a different load". Guarding on it also keeps the
+  // update a no-op for the unrelated passes (scrolling, layout, size-class
+  // changes) that would otherwise reassign the document — which resets the
+  // user's scroll position — on every frame.
+  public func updateUIView(_ uiView: PDFKit.PDFView, context _: Context) {
+    guard uiView.document !== document else { return }
+    uiView.document = document
+    if let pageIndex, let page = document.page(at: pageIndex) {
+      uiView.go(to: page)
+    }
+  }
 
   public func makeUIView(context _: Context) -> PDFKit.PDFView {
     let view = PDFKit.PDFView()

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -29,3 +29,4 @@
 - Opening a document whose PDF is already cached now shows it immediately, even on a slow connection, instead of waiting behind a loading spinner
 - Pulling to refresh an open document now picks up a new version added on the server, instead of continuing to show the previous one until you close and reopen it
 - Pulling to refresh a document that has a new version on the server now finishes refreshing its notes, metadata and suggestions, instead of stopping partway and showing an "Unexpected error"
+- On iPad you can now refresh an open document from the toolbar, picking up a new version or changed details without closing and reopening it

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -27,3 +27,4 @@
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
 - Switching a server to "Entire library" now starts downloading document notes and file metadata straight away, instead of waiting until the next time you reopen the app
 - Opening a document whose PDF is already cached now shows it immediately, even on a slow connection, instead of waiting behind a loading spinner
+- Pulling to refresh an open document now picks up a new version added on the server, instead of continuing to show the previous one until you close and reopen it

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -28,3 +28,4 @@
 - Switching a server to "Entire library" now starts downloading document notes and file metadata straight away, instead of waiting until the next time you reopen the app
 - Opening a document whose PDF is already cached now shows it immediately, even on a slow connection, instead of waiting behind a loading spinner
 - Pulling to refresh an open document now picks up a new version added on the server, instead of continuing to show the previous one until you close and reopen it
+- Pulling to refresh a document that has a new version on the server now finishes refreshing its notes, metadata and suggestions, instead of stopping partway and showing an "Unexpected error"

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -26,3 +26,4 @@
 - Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
 - Switching a server to "Entire library" now starts downloading document notes and file metadata straight away, instead of waiting until the next time you reopen the app
+- Opening a document whose PDF is already cached now shows it immediately, even on a slow connection, instead of waiting behind a loading spinner

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -87,6 +87,14 @@ class DocumentDetailModel {
   /// `modified`. The three enrichments — file-metadata, notes, edit suggestions —
   /// only need the document id, so they run concurrently afterwards.
   ///
+  /// The PDF itself doesn't wait for that metadata round-trip, though: on a
+  /// fresh open, `loadDocument` fires a provisional download off the
+  /// already-known (possibly stale) `document` in parallel with the metadata
+  /// refresh, so a cached PDF renders immediately on a slow connection instead
+  /// of sitting behind a blurred thumbnail. Once metadata comes back, if the
+  /// version/`modified` actually moved, a second download replaces the
+  /// provisional PDF with the current one.
+  ///
   /// Each step always logs its failure. Whether it's *surfaced* is the caller's
   /// choice via `onError`: an on-appear load (`.task`) passes nothing and stays
   /// silent (the load isn't user-initiated, and the one critical failure — the
@@ -141,11 +149,17 @@ class DocumentDetailModel {
   }
 
   func loadDocument(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
-    // Resolve the fresh document FIRST so the download path can validate
-    // the ContentStore cache against the server's current `modified`
-    // timestamp. If we kicked off both in parallel, a stale `modified`
-    // could validate an out-of-date cached PDF before the metadata refresh
-    // landed — surfacing old content alongside fresh metadata.
+    let priorDocument = document
+    let isFreshOpen = if case .initial = download { true } else { false }
+
+    // Fire the provisional PDF load off the already-known document right away
+    // — its own cache check (ContentStore, keyed on `currentVersionID` +
+    // `modified`) is what decides whether this is an instant hit or a real
+    // download, so starting it here rather than after the metadata round-trip
+    // is what lets a cached PDF appear immediately on a slow connection.
+    let provisionalDownload: Task<Void, Never>? =
+      isFreshOpen ? Task { await runDownload(for: priorDocument) } : nil
+
     do {
       if let updated = try await store.document(id: document.id) {
         document = updated
@@ -156,45 +170,69 @@ class DocumentDetailModel {
       onError?(error)
     }
 
-    switch download {
-    case .initial:
-      let setLoading = Task {
+    guard isFreshOpen else { return }
+    await provisionalDownload?.value
+
+    // Nothing changed server-side since the provisional load — it already
+    // reflects current content, no need to re-fetch.
+    guard
+      document.currentVersionID != priorDocument.currentVersionID
+        || document.modified != priorDocument.modified
+    else { return }
+
+    await runDownload(for: document)
+  }
+
+  private func runDownload(for document: Document) async {
+    let isFreshOpen = if case .initial = download { true } else { false }
+
+    let setLoading =
+      isFreshOpen
+      ? Task {
         try? await Task.sleep(for: .seconds(0.5))
         guard !Task.isCancelled else { return }
         download = .loading
+      } : nil
+    // Cancel the delayed `.loading` flip on *every* exit path. Without this
+    // the error path leaves `setLoading` pending, and 0.5s later it overwrites
+    // the just-set `.error` back to `.loading` — pinning the preview's loading
+    // overlay on screen even though the download already failed.
+    defer { setLoading?.cancel() }
+    do {
+      let url = try await store.repository.download(
+        document: document,
+        original: false,
+        progress: { @Sendable value in
+          Task { @MainActor in
+            self.downloadProgress = value
+          }
+        })
+
+      if case .loaded(let existingURL, _) = download, existingURL == url {
+        // Re-validation after the metadata refresh resolved to the same
+        // cached file the provisional load already rendered — nothing to do.
+        return
       }
-      // Cancel the delayed `.loading` flip on *every* exit path. Without this
-      // the error path leaves `setLoading` pending, and 0.5s later it overwrites
-      // the just-set `.error` back to `.loading` — pinning the preview's loading
-      // overlay on screen even though the download already failed.
-      defer { setLoading.cancel() }
-      do {
-        let url = try await store.repository.download(
-          document: document,
-          original: false,
-          progress: { @Sendable value in
-            Task { @MainActor in
-              self.downloadProgress = value
-            }
-          })
 
-        guard let pdfDocument = await PDFDocument.loadBackground(url: url) else {
-          download = .error
-          break
-        }
+      guard let pdfDocument = await PDFDocument.loadBackground(url: url) else {
+        if case .loaded = download {} else { download = .error }
+        return
+      }
 
-        download = .loaded(url: url, document: pdfDocument)
+      download = .loaded(url: url, document: pdfDocument)
 
-        // Start downloading the original in the background
-        Task { await downloadOriginal() }
-      } catch is CancellationError {
-      } catch {
+      // Start downloading the original in the background
+      Task { await downloadOriginal() }
+    } catch is CancellationError {
+    } catch {
+      if case .loaded = download {
+        // The provisional PDF is already on screen; keep showing it rather
+        // than clobbering it with an error from the post-metadata re-check.
+        Logger.shared.error("Unable to refresh document preview after metadata update: \(error)")
+      } else {
         download = .error
         Logger.shared.error("Unable to get document downloaded for preview rendering: \(error)")
       }
-
-    default:
-      break
     }
   }
 

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -90,6 +90,11 @@ class DocumentDetailModel {
 
   var metadata: Metadata?
 
+  /// The in-flight load, owned by the model rather than by whichever view task
+  /// happened to start it. See `startLoad(onError:)`.
+  @ObservationIgnored
+  private var loadTask: Task<Void, Never>?
+
   init(
     store: DocumentStore, connection: Connection?, document: Document
   ) {
@@ -110,6 +115,38 @@ class DocumentDetailModel {
     } catch {
       Logger.shared.error("Error refreshing UI settings from document detail: \(error)")
     }
+  }
+
+  /// Run `load` in a task owned by the model rather than by the caller's.
+  ///
+  /// A load must not be a structured child of the task that starts it, because
+  /// both of the view's entry points have a lifetime shorter than the work:
+  /// `.refreshable`'s task belongs to the pull gesture, and SwiftUI ends it when
+  /// the scroll view's content changes underneath it. A refresh that picks up a
+  /// new document version does exactly that — `loadDocument` swaps in the new
+  /// PDF, the preview inside the scroll view is replaced, the refresh session
+  /// ends, and the still-running metadata/notes/suggestions legs are cancelled
+  /// mid-flight. The refresh cancels itself, and the user gets a "cancelled"
+  /// toast for a refresh that silently didn't finish.
+  ///
+  /// An unstructured `Task` doesn't inherit cancellation (only priority and
+  /// actor isolation), so the legs survive the gesture ending. View *dismissal*
+  /// is still a real cancellation boundary — the view calls `cancelLoad()` on
+  /// disappear — so a load whose result nobody will see still stops promptly,
+  /// rather than surfacing a toast over whatever screen came next.
+  func startLoad(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
+    // Latest wins: a pull-to-refresh supersedes an on-appear load still running.
+    loadTask?.cancel()
+    let task = Task { await self.load(onError: onError) }
+    loadTask = task
+    await task.value
+  }
+
+  /// Stop the in-flight load. The detail view calls this on dismissal — see
+  /// ``startLoad(onError:)`` for why the load outlives the task that started it.
+  func cancelLoad() {
+    loadTask?.cancel()
+    loadTask = nil
   }
 
   /// Load everything a freshly-opened (or pulled-to-refresh) document needs from

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -19,10 +19,26 @@ enum DocumentDownloadState: Equatable {
   case loaded(url: URL, document: PDFDocument)
   case error
 
+  // `.loaded` compares its payload, not just its case. SwiftUI uses the `==` of
+  // a view's Equatable stored properties when it diffs, and
+  // `IntegratedDocumentPreview` takes this value as a stored property — so
+  // treating every `.loaded` as equal made swapping one document for another (a
+  // re-download after a server-side version bump) invisible: the preview
+  // subtree was never re-evaluated, and the new `PDFDocument` never reached
+  // `PDFKitView`.
+  //
+  // It also silently disabled `.task(id: downloadState)` and
+  // `.animation(value: downloadState)` across a `.loaded` → `.loaded` change.
+  //
+  // `PDFDocument` is a non-Equatable class, which is presumably why this was
+  // hand-rolled; identity is the right comparison for it, since
+  // `loadBackground` constructs a fresh instance per load.
   static func == (lhs: DocumentDownloadState, rhs: DocumentDownloadState) -> Bool {
     switch (lhs, rhs) {
-    case (.initial, .initial), (.loading, .loading), (.loaded, .loaded), (.error, .error):
+    case (.initial, .initial), (.loading, .loading), (.error, .error):
       true
+    case (.loaded(let lURL, let lDocument), .loaded(let rURL, let rDocument)):
+      lURL == rURL && lDocument === rDocument
     default:
       false
     }

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -29,6 +29,23 @@ enum DocumentDownloadState: Equatable {
   }
 }
 
+/// Accumulates the errors thrown across one `DocumentDetailModel.load()` pass so
+/// duplicates can be collapsed before they reach the caller's `onError`. Keyed on
+/// `String(describing:)`: connectivity failures against the same host produce
+/// equal `RequestError.other` values (identical description), so a server-wide
+/// outage dedupes to a single entry, while distinct failures keep distinct keys.
+@MainActor
+private final class LoadErrorCollector {
+  private var seen: Set<String> = []
+  private(set) var distinct: [any Error] = []
+
+  func add(_ error: any Error) {
+    if seen.insert(String(describing: error)).inserted {
+      distinct.append(error)
+    }
+  }
+}
+
 @MainActor
 @Observable
 class DocumentDetailModel {
@@ -101,12 +118,33 @@ class DocumentDetailModel {
   /// PDF — already shows via `download == .error`); a pull-to-refresh passes a
   /// handler so failures toast. Offline-connectivity errors are dropped by
   /// `ErrorController.shouldSuppress`, so a parallel offline refresh won't spam.
+  ///
+  /// The four steps each hit the network independently, so a server-wide outage
+  /// would otherwise fire `onError` once per step — three or four identical
+  /// "could not connect" toasts for a single pull. To avoid that, failures are
+  /// collected across the whole pass and each *distinct* error is surfaced once:
+  /// a common outage collapses to one toast, while genuinely different failures
+  /// (e.g. a permission error on a single endpoint) still each show.
   func load(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
-    await loadDocument(onError: onError)
-    async let metadata: Void = loadMetadata(onError: onError)
-    async let notes: Void = loadNotes(onError: onError)
-    async let suggestions: Void = loadSuggestionsQuietly(onError: onError)
+    let collector = onError == nil ? nil : LoadErrorCollector()
+    let collect: (@MainActor @Sendable (any Error) -> Void)?
+    if let collector {
+      collect = { @MainActor @Sendable error in collector.add(error) }
+    } else {
+      collect = nil
+    }
+
+    await loadDocument(onError: collect)
+    async let metadata: Void = loadMetadata(onError: collect)
+    async let notes: Void = loadNotes(onError: collect)
+    async let suggestions: Void = loadSuggestionsQuietly(onError: collect)
     _ = await (metadata, notes, suggestions)
+
+    if let onError, let collector {
+      for error in collector.distinct {
+        onError(error)
+      }
+    }
   }
 
   func loadMetadata(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -6,6 +6,7 @@
 //
 
 import AppShared
+import Common
 import DataModel
 import Foundation
 import Networking
@@ -170,7 +171,7 @@ class DocumentDetailModel {
   func loadMetadata(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
     do {
       metadata = try await store.repository.metadata(documentId: document.id)
-    } catch is CancellationError {
+    } catch let error where error.isCancellationError {
     } catch {
       Logger.shared.error("Error loading document metadata: \(error)")
       onError?(error)
@@ -185,7 +186,7 @@ class DocumentDetailModel {
   func loadNotes(onError: (@MainActor @Sendable (any Error) -> Void)? = nil) async {
     do {
       _ = try await store.notes(for: document)
-    } catch is CancellationError {
+    } catch let error where error.isCancellationError {
     } catch {
       Logger.shared.error("Error loading document notes: \(error)")
       onError?(error)
@@ -199,7 +200,7 @@ class DocumentDetailModel {
   private func loadSuggestionsQuietly(onError: (@MainActor @Sendable (any Error) -> Void)?) async {
     do {
       try await loadSuggestions()
-    } catch is CancellationError {
+    } catch let error where error.isCancellationError {
     } catch {
       Logger.shared.error("Error loading document suggestions: \(error)")
       onError?(error)
@@ -222,7 +223,7 @@ class DocumentDetailModel {
       if let updated = try await store.document(id: document.id) {
         document = updated
       }
-    } catch is CancellationError {
+    } catch let error where error.isCancellationError {
     } catch {
       Logger.shared.error("Error updating document with full perms for editing: \(error)")
       onError?(error)
@@ -290,7 +291,7 @@ class DocumentDetailModel {
 
       // Start downloading the original in the background
       Task { await downloadOriginal() }
-    } catch is CancellationError {
+    } catch let error where error.isCancellationError {
     } catch {
       if case .loaded = download {
         // The provisional PDF is already on screen; keep showing it rather

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -108,9 +108,13 @@ class DocumentDetailModel {
   /// fresh open, `loadDocument` fires a provisional download off the
   /// already-known (possibly stale) `document` in parallel with the metadata
   /// refresh, so a cached PDF renders immediately on a slow connection instead
-  /// of sitting behind a blurred thumbnail. Once metadata comes back, if the
-  /// version/`modified` actually moved, a second download replaces the
-  /// provisional PDF with the current one.
+  /// of sitting behind a blurred thumbnail.
+  ///
+  /// Once metadata comes back — on *every* load, not just a fresh open — the
+  /// resolved document's version/`modified` is compared against what was on
+  /// screen, and a changed one triggers a re-download. That is what makes a
+  /// pull-to-refresh pick up a version added server-side while the detail view
+  /// was open.
   ///
   /// Each step always logs its failure. Whether it's *surfaced* is the caller's
   /// choice via `onError`: an on-appear load (`.task`) passes nothing and stays
@@ -208,11 +212,20 @@ class DocumentDetailModel {
       onError?(error)
     }
 
-    guard isFreshOpen else { return }
+    // Only the *provisional* download is fresh-open-only; on a refresh there
+    // is nothing to wait for (`provisionalDownload` is nil) because the PDF is
+    // already on screen.
     await provisionalDownload?.value
 
-    // Nothing changed server-side since the provisional load — it already
-    // reflects current content, no need to re-fetch.
+    // Nothing changed server-side — the PDF on screen (provisional or from a
+    // previous load) already reflects current content, no need to re-fetch.
+    //
+    // The version check is what makes a server-side version bump visible: it
+    // has to run on every load, not just a fresh open, or a document versioned
+    // while the detail view is open keeps rendering the old file until the view
+    // is closed and reopened. `runDownload` is safe to call here — its delayed
+    // `.loading` flip is itself gated on `isFreshOpen`, so the new PDF swaps in
+    // without blanking the preview.
     guard
       document.currentVersionID != priorDocument.currentVersionID
         || document.modified != priorDocument.modified

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -665,7 +665,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     }
     .refreshable {
       let model = viewModel
-      async let load: () = model.load(onError: { errorController.push(error: $0) })
+      async let load: () = model.startLoad(onError: { errorController.push(error: $0) })
       // Only on pull-to-refresh, not inside `load()`: refreshing permissions
       // means a full element sync, which is not what opening a document should
       // cost.
@@ -788,7 +788,14 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
     }
 
     .task {
-      await viewModel.load()
+      await viewModel.startLoad()
+    }
+
+    // The load outlives the task that starts it (see `startLoad`), so dismissal
+    // has to end it explicitly — otherwise it keeps running for a view nobody
+    // is looking at, and can toast over the screen that replaced it.
+    .onDisappear {
+      viewModel.cancelLoad()
     }
 
     .onChange(of: routeManager.pendingRoute, initial: true, handlePendingRoute)

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -86,6 +86,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
   // someone opens it on iPad. SceneStorage so the open/closed state
   // persists across app launches per scene.
   @SceneStorage("DocumentDetailEditInspectorVisible") private var showEditInspector = true
+  @State private var isRefreshing = false
   @State private var showDeleteConfirmation = false
   @State private var deleted = false
   @State private var sharedFile: NamedShareItem?
@@ -752,6 +753,30 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         }
       }
       if horizontalSizeClass == .regular {
+        // The regular layout's primary surface is a PDFKit view, not a scroll
+        // view, so `.refreshable` has nothing to bind to and would be a silent
+        // no-op — this button is the iPad's only way to reach the refresh path
+        // (picking up a new server-side version, notes and metadata).
+        ToolbarItem(placement: .topBarTrailing) {
+          Button {
+            Task {
+              isRefreshing = true
+              await viewModel.startLoad(onError: { errorController.push(error: $0) })
+              isRefreshing = false
+            }
+          } label: {
+            if isRefreshing {
+              ProgressView()
+            } else {
+              Label(localized: .app(.documentDetailRefresh), systemImage: "arrow.clockwise")
+                .labelStyle(.iconOnly)
+            }
+          }
+          .disabled(isRefreshing)
+          // Explicit, because the in-progress branch renders no label at all —
+          // without this VoiceOver would announce nothing while refreshing.
+          .accessibilityLabel(Text(.app(.documentDetailRefresh)))
+        }
         ToolbarItem(placement: .topBarTrailing) {
           Button {
             showEditInspector.toggle()


### PR DESCRIPTION
This pull request significantly improves the document detail view's refresh and PDF loading behavior, especially around picking up new versions and providing immediate feedback to users. The main changes ensure that cached PDFs are shown instantly, refreshing an open document updates all relevant data, and iPad users can now refresh from the toolbar. Additionally, error handling is improved to avoid duplicate error toasts and to ensure that background tasks are properly managed.

**Document loading and refresh improvements:**

* Cached PDFs are now displayed immediately when opening a document, even on slow connections, instead of waiting behind a loading spinner.
* Pull-to-refresh and toolbar refresh now pick up new PDF versions, notes, and metadata from the server without requiring the user to close and reopen the document. ( [[1]](diffhunk://#diff-1d9d269fef243f887f3cba163da17436ab549f448550927d7e82f01ae6695138L668-R669) [[2]](diffhunk://#diff-1d9d269fef243f887f3cba163da17436ab549f448550927d7e82f01ae6695138R756-R779)
* On iPad, a new toolbar button allows users to refresh an open document, with an accessible label and progress indicator. [[1]](diffhunk://#diff-436ebe670cf1bc8e284b340bcb6e6b490b0a1b5ca655420c0f2d91b0fa1a7e07R5386-R5397) [[2]](diffhunk://#diff-1d9d269fef243f887f3cba163da17436ab549f448550927d7e82f01ae6695138R756-R779)

**Error handling and task management:**

* Errors during refresh are now deduplicated so that only distinct failures show toasts, preventing multiple identical error messages during a server outage. ([swift-paperless/ViewModel/DocumentDetailModel.swiftR23-R65](diffhunk://#diff-a25456c60451be78aec488c706d66c1519b51117b9d340fd2b14daf4b85e0190R23-R65), Fa366385L158R158)
* The document loading process is now managed by the view model, ensuring that background tasks are properly cancelled when the view disappears, preventing stray toasts or wasted work. [[1]](diffhunk://#diff-a25456c60451be78aec488c706d66c1519b51117b9d340fd2b14daf4b85e0190R93-R97) [[2]](diffhunk://#diff-a25456c60451be78aec488c706d66c1519b51117b9d340fd2b14daf4b85e0190R120-R151) [[3]](diffhunk://#diff-1d9d269fef243f887f3cba163da17436ab549f448550927d7e82f01ae6695138L791-R823)

**Technical and code quality improvements:**

* The Equatable implementation for `DocumentDownloadState` now compares PDF document identity, ensuring that SwiftUI properly updates the preview when a new PDF is loaded.
* The `PDFKitView` now only updates the displayed PDF when the underlying `PDFDocument` instance actually changes, preserving scroll position and avoiding unnecessary reloads.

**Changelog and localization:**

* The changelog is updated to reflect these improvements.
* A new localization string is added for the iPad refresh toolbar button.