### PR TITLE
fix: Enable pymdownx.superfences/highlight so docs code blocks render

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,12 @@ markdown_extensions:
   - pymdownx.snippets:
   - attr_list
   - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
 
 extra_css:
   - extra.css


### PR DESCRIPTION
The zensical migration kept mkdocs.yml's minimal markdown_extensions list, which never had superfences/highlight enabled. Without them, fenced code blocks (e.g. in maintenance.md) were parsed as inline <code> spans instead of real code blocks.