### PR TITLE
fix: iOS 27 compilation and general sheet zoom transitions

### DIFF
--- a/AppShared/Sources/AppShared/Model/DocumentTypealias.swift
+++ b/AppShared/Sources/AppShared/Model/DocumentTypealias.swift
@@ -1,0 +1,13 @@
+//
+//  DocumentTypealias.swift
+//  swift-paperless
+//
+//  SwiftUI in SDK 27 declares its own top-level `Document` type, which makes
+//  unqualified `Document` ambiguous in files importing both SwiftUI and
+//  DataModel. A same-module typealias wins unqualified lookup, so all uses in
+//  this module keep resolving to the DataModel type.
+//
+
+import DataModel
+
+public typealias Document = DataModel.Document

--- a/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
+++ b/AppShared/Sources/AppShared/Views/CustomFields/CustomFieldEditView.swift
@@ -433,7 +433,7 @@ private func getDocument(store: DocumentStore) async throws -> Document? {
           permissions: .full {
             $0.set(.view, to: !store.permissions.test(.view, for: .customField), for: .customField)
           })
-        try await store.fetchAll()
+        try? await store.fetchAll()
       }
     }
   }

--- a/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
+++ b/AppShared/Sources/AppShared/Views/Document/Detail/DocumentNoteView.swift
@@ -104,7 +104,8 @@ public struct DocumentNoteView: View {
         try await store.deleteNote(from: document, id: note.id)
         notes = notes.filter { $0.id != note.id }
         document.notes.count = notes.count
-      } catch let error where !error.isCancellationError {
+      } catch let error where error.isCancellationError {
+      } catch {
         Logger.shared.error("Error deleting note from document: \(error)")
         errorController.push(error: error)
       }

--- a/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
+++ b/AppShared/Sources/AppShared/Views/Filter/CommonPickerFilterView.swift
@@ -371,7 +371,6 @@ where
             dismiss()
           } catch {
             errorController.push(error: error)
-            throw error
           }
         }
 

--- a/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
+++ b/AppShared/Sources/AppShared/Views/PermissionsEditView.swift
@@ -213,26 +213,22 @@ public struct PermissionsEditView<Object>: View where Object: PermissionsModel {
   }
 
   private func initialize() async {
-    do {
-      // update users and groups just in case
-      try await withThrowingTaskGroup(of: Void.self) { group in
-        // Weird workaround for compiler warning
-        group.addTask { Task { @MainActor in try await store.fetchAllUsers() } }
-        group.addTask { Task { @MainActor in try await store.fetchAllGroups() } }
+    // update users and groups just in case
+    let users = Task { await fetch { try await store.fetchAllUsers() } }
+    let groups = Task { await fetch { try await store.fetchAllGroups() } }
+    await users.value
+    await groups.value
+  }
 
-        while !group.isEmpty {
-          do {
-            try await group.next()
-          } catch is PermissionsError {
-            Logger.shared.debug(
-              "Permissions error fetching users and groups for permissions edit, suppressing")
-          } catch let error where error.isCancellationError {
-            Logger.shared.debug(
-              "Cancellation error fetching users and groups for permissions edit, suppressing")
-            continue
-          }
-        }
-      }
+  private func fetch(_ operation: () async throws -> Void) async {
+    do {
+      try await operation()
+    } catch is PermissionsError {
+      Logger.shared.debug(
+        "Permissions error fetching users and groups for permissions edit, suppressing")
+    } catch let error where error.isCancellationError {
+      Logger.shared.debug(
+        "Cancellation error fetching users and groups for permissions edit, suppressing")
     } catch {
       Logger.shared.error("Error loading users / groups for permissions editing: \(error)")
     }

--- a/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ManageView.swift
@@ -136,7 +136,6 @@ public struct ManageView<Manager>: View where Manager: ManagerProtocol {
             dismiss()
           } catch {
             errorController.push(error: error)
-            throw error
           }
         }
 

--- a/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagSelectionView.swift
@@ -42,7 +42,6 @@ public struct DocumentTagEditView<D>: View where D: DocumentProtocol {
             dismiss()
           } catch {
             errorController.push(error: error)
-            throw error
           }
         }
       })

--- a/Networking/Sources/Networking/DocumentTypealias.swift
+++ b/Networking/Sources/Networking/DocumentTypealias.swift
@@ -1,0 +1,13 @@
+//
+//  DocumentTypealias.swift
+//  swift-paperless
+//
+//  SwiftUI in SDK 27 declares its own top-level `Document` type, which makes
+//  unqualified `Document` ambiguous in files importing both SwiftUI and
+//  DataModel. A same-module typealias wins unqualified lookup, so all uses in
+//  this module keep resolving to the DataModel type.
+//
+
+import DataModel
+
+public typealias Document = DataModel.Document

--- a/swift-paperless/Utilities/DocumentTypealias.swift
+++ b/swift-paperless/Utilities/DocumentTypealias.swift
@@ -1,0 +1,13 @@
+//
+//  DocumentTypealias.swift
+//  swift-paperless
+//
+//  SwiftUI in SDK 27 declares its own top-level `Document` type, which makes
+//  unqualified `Document` ambiguous in files importing both SwiftUI and
+//  DataModel. A same-module typealias wins unqualified lookup, so all uses in
+//  this module keep resolving to the DataModel type.
+//
+
+import DataModel
+
+typealias Document = DataModel.Document

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -858,9 +858,9 @@ extension View {
   ///
   /// The zoom transition matching the field's pill is applied here, on the
   /// presented root, rather than inside `content()`: the deferred content is
-  /// not mounted during the first frame, and iOS 27 resolves the presentation
-  /// transition at presentation time — a transition modifier that only
-  /// appears after the deferral tick is ignored.
+  /// not mounted during the first frame, and both iOS 26 and iOS 27 resolve
+  /// the presentation transition at presentation time — a transition
+  /// modifier that only appears after the deferral tick is ignored.
   fileprivate func editPopover<Content: View>(
     forFieldEdit field: FieldEdit,
     active: Binding<FieldEdit?>,

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -42,6 +42,20 @@ private enum FieldEdit: Identifiable, Hashable {
     case .notes: return nil
     }
   }
+
+  var transitionID: TransitionID {
+    switch self {
+    case .title: .title
+    case .tags: .tags
+    case .asn: .asn
+    case .correspondent: .correspondent
+    case .documentType: .documentType
+    case .date: .date
+    case .storagePath: .storagePath
+    case .owner: .owner
+    case .customFields: .customFields
+    }
+  }
 }
 
 /// Auxiliary presentations that always render as sheets regardless of size
@@ -187,10 +201,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         forFieldEdit: .asn,
         active: $activeFieldEdit,
         detents: [.fraction(0.25), .medium],
-        popoverSize: CGSize(width: 380, height: 240)
+        popoverSize: CGSize(width: 380, height: 240),
+        transitionNamespace: namespace
       ) {
         AsnEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.asn, in: namespace)
       }
 
       EditableAspect(
@@ -202,9 +216,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         namespace: namespace,
         enabled: canChange
       )
-      .editPopover(forFieldEdit: .correspondent, active: $activeFieldEdit) {
+      .editPopover(
+        forFieldEdit: .correspondent, active: $activeFieldEdit, transitionNamespace: namespace
+      ) {
         CorrespondentEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.correspondent, in: namespace)
       }
 
       EditableAspect(
@@ -216,9 +231,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         namespace: namespace,
         enabled: canChange
       )
-      .editPopover(forFieldEdit: .documentType, active: $activeFieldEdit) {
+      .editPopover(
+        forFieldEdit: .documentType, active: $activeFieldEdit, transitionNamespace: namespace
+      ) {
         DocumentTypeEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.documentType, in: namespace)
       }
 
       EditableAspect(
@@ -234,10 +250,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         forFieldEdit: .date,
         active: $activeFieldEdit,
         detents: [.fraction(0.25), .medium],
-        popoverSize: CGSize(width: 380, height: 440)
+        popoverSize: CGSize(width: 380, height: 440),
+        transitionNamespace: namespace
       ) {
         DateEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.date, in: namespace)
       }
 
       EditableAspect(
@@ -249,9 +265,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         namespace: namespace,
         enabled: canChange
       )
-      .editPopover(forFieldEdit: .storagePath, active: $activeFieldEdit) {
+      .editPopover(
+        forFieldEdit: .storagePath, active: $activeFieldEdit, transitionNamespace: namespace
+      ) {
         StoragePathEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.storagePath, in: namespace)
       }
 
       EditableAspect(
@@ -269,10 +286,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       .editPopover(
         forFieldEdit: .owner,
         active: $activeFieldEdit,
-        detents: [.medium, .large]
+        detents: [.medium, .large],
+        transitionNamespace: namespace
       ) {
         OwnerEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.owner, in: namespace)
       }
 
       EditableAspect(
@@ -283,9 +300,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         namespace: namespace,
         enabled: canChange
       )
-      .editPopover(forFieldEdit: .customFields, active: $activeFieldEdit) {
+      .editPopover(
+        forFieldEdit: .customFields, active: $activeFieldEdit, transitionNamespace: namespace
+      ) {
         CustomFieldsEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.customFields, in: namespace)
       }
     }
   }
@@ -581,10 +599,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
       .editPopover(
         forFieldEdit: .title,
         active: $activeFieldEdit,
-        popoverSize: CGSize(width: 480, height: 240)
+        popoverSize: CGSize(width: 480, height: 240),
+        transitionNamespace: namespace
       ) {
         TitleEditSheet(viewModel: viewModel)
-          .sheetZoomTransition(sourceID: TransitionID.title, in: namespace)
       }
 
       readOnlyExplanation
@@ -613,10 +631,10 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
         .editPopover(
           forFieldEdit: .tags,
           active: $activeFieldEdit,
-          detents: [.medium, .large]
+          detents: [.medium, .large],
+          transitionNamespace: namespace
         ) {
           TagsEditSheet(viewModel: viewModel)
-            .sheetZoomTransition(sourceID: TransitionID.tags, in: namespace)
         }
       }
     }
@@ -837,11 +855,18 @@ extension View {
   ///
   /// `popoverSize` only affects the popover layer — sheets ignore it and
   /// honour the supplied detents instead.
+  ///
+  /// The zoom transition matching the field's pill is applied here, on the
+  /// presented root, rather than inside `content()`: the deferred content is
+  /// not mounted during the first frame, and iOS 27 resolves the presentation
+  /// transition at presentation time — a transition modifier that only
+  /// appears after the deferral tick is ignored.
   fileprivate func editPopover<Content: View>(
     forFieldEdit field: FieldEdit,
     active: Binding<FieldEdit?>,
     detents: Set<PresentationDetent> = [.medium, .large],
     popoverSize: CGSize = CGSize(width: 420, height: 520),
+    transitionNamespace: Namespace.ID,
     @ViewBuilder content: @escaping () -> Content
   ) -> some View {
     let isPresented = Binding(
@@ -861,6 +886,7 @@ extension View {
       // host takes over. Deferring the first render of `content()` past
       // that frame keeps those modifiers from running in the wrong scope.
       DeferredPopoverContent(size: popoverSize, content: content)
+        .sheetZoomTransition(sourceID: field.transitionID, in: transitionNamespace)
         #if !targetEnvironment(macCatalyst)
           .presentationDetents(detents)
           .presentationCompactAdaptation(.sheet)

--- a/swift-paperless/Views/Document/DocumentView.swift
+++ b/swift-paperless/Views/Document/DocumentView.swift
@@ -171,6 +171,9 @@ struct DocumentView: View {
             await clear()
             navPath.append(NavigationState.detail(document: document))
           }
+        } catch {
+          Logger.shared.error("Error opening document from route: \(error)")
+          errorController.push(error: error)
         }
       case .setFilter(let filter):
         routeManager.pendingRoute = nil

--- a/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
+++ b/swift-paperless/Views/Filter/CustomFieldQueryDisplayView.swift
@@ -105,10 +105,20 @@ private struct ExprView: View {
   }
 }
 
-extension EnvironmentValues {
-  @Entry fileprivate var getCustomFieldById: (UInt) -> CustomField? = {
-    _ in nil
+// Not a closure: closures in the environment defeat value comparison and
+// invalidate every reader on each update. The store reference compares by
+// identity, so this stays stable across body evaluations.
+private struct CustomFieldLookup {
+  var store: DocumentStore?
+
+  @MainActor
+  func callAsFunction(_ id: UInt) -> CustomField? {
+    store?.customFields[id]
   }
+}
+
+extension EnvironmentValues {
+  @Entry fileprivate var getCustomFieldById = CustomFieldLookup(store: nil)
 }
 
 struct CustomFieldQueryDisplayView: View {
@@ -127,10 +137,6 @@ struct CustomFieldQueryDisplayView: View {
     query = CustomFieldQuery.expr(expr)
   }
 
-  private func customField(_ id: UInt) -> CustomField? {
-    store.customFields[id]
-  }
-
   var body: some View {
     Group {
       switch query {
@@ -142,7 +148,7 @@ struct CustomFieldQueryDisplayView: View {
         Text(.customFields(.anyCustomFieldQuery))
       }
     }
-    .environment(\.getCustomFieldById, customField)
+    .environment(\.getCustomFieldById, CustomFieldLookup(store: store))
   }
 }
 

--- a/swift-paperless/Views/Login/CredentialsStageView.swift
+++ b/swift-paperless/Views/Login/CredentialsStageView.swift
@@ -6,6 +6,7 @@
 //
 
 import AppShared
+import AuthenticationServices
 import Networking
 import NukeUI
 import SwiftUI


### PR DESCRIPTION
## Summary

Gets the app building and behaving correctly against the iOS 27 SDK.

- **Basic compilation under iOS 27** — add a shared `DocumentTypealias` and adjust view code (permissions editing, custom field query display, notes, filters) so the app and `AppShared` build cleanly.
- **Sheet zoom transitions** — move the zoom transition off the deferred sheet content and onto the presented root via a `transitionNamespace` parameter on `editPopover`. It resolves the presentation transition at presentation time, when the deferred content is not yet mounted, so a transition modifier applied inside `content()` was being ignored.
