### PR TITLE
fix: don't corrupt uploaded document bytes with an extra CRLF

### DIFF
--- a/Networking/Sources/Networking/Api/MultiPartFormDataRequest.swift
+++ b/Networking/Sources/Networking/Api/MultiPartFormDataRequest.swift
@@ -68,7 +68,9 @@ struct MultiPartFormDataRequest {
   }
 
   func addTo(request: inout URLRequest) {
-    body.append("\r\n")
+    // Each `add` call already terminates its part with the trailing CRLF
+    // that RFC 2046 requires before the next boundary delimiter, so the
+    // closing boundary must not prepend another one.
     body.append("--\(boundary)--")
 
     request.httpMethod = "POST"

--- a/Networking/Tests/NetworkingTests/MultiPartFormDataRequestTest.swift
+++ b/Networking/Tests/NetworkingTests/MultiPartFormDataRequestTest.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import Networking
+
+@Suite struct MultiPartFormDataRequestTest {
+
+  // Regression test for https://github.com/paulgessinger/swift-paperless/issues/624:
+  // uploaded documents ended up 2 bytes larger than the original file because an
+  // extra CRLF was written before the closing boundary.
+  @Test func documentPartPreservesExactFileBytes() throws {
+    // Binary-ish payload so this doesn't depend on the content being valid UTF-8.
+    let fileData = Data([0x25, 0x50, 0x44, 0x46, 0x0D, 0x0A, 0x48, 0x45, 0x4C, 0x4C, 0x4F])
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("pdf")
+    try fileData.write(to: tempURL)
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+
+    let mp = MultiPartFormDataRequest()
+    mp.add(name: "title", string: "My Document")
+    try mp.add(name: "document", url: tempURL, filename: "file.pdf")
+
+    var request = URLRequest(url: URL(string: "https://example.com")!)
+    mp.addTo(request: &request)
+
+    let body = try #require(request.httpBody)
+    let contentType = try #require(request.value(forHTTPHeaderField: "Content-Type"))
+    let boundary = try #require(contentType.components(separatedBy: "boundary=").last)
+
+    // Mirrors RFC 2046: a part's raw octets run from right after the blank
+    // line ending its headers up to (but not including) the CRLF that starts
+    // the next "--boundary" delimiter.
+    let headerEnd = Data("\r\n\r\n".utf8)
+    let delimiter = Data("\r\n--\(boundary)".utf8)
+
+    let headerMarker = Data("name=\"document\"".utf8)
+    let headerMarkerRange = try #require(body.range(of: headerMarker))
+    let contentStart = try #require(
+      body.range(of: headerEnd, in: headerMarkerRange.upperBound..<body.endIndex)
+    ).upperBound
+    let contentEnd = try #require(
+      body.range(of: delimiter, in: contentStart..<body.endIndex)
+    ).lowerBound
+
+    let extracted = Data(body[contentStart..<contentEnd])
+    #expect(extracted == fileData)
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Fixed uploaded documents being saved with an extra 2 bytes (CRLF), which caused checksum mismatches and failed deduplication in Paperless-ngx


### PR DESCRIPTION
## Summary
- `MultiPartFormDataRequest.addTo()` prepended an extra `\r\n` before the closing multipart boundary, even though every `add()` call already terminates its part with the CRLF that RFC 2046 requires there.
- That duplicate CRLF got parsed by the server as trailing content of the last part in the request — typically the uploaded document itself — so uploaded files ended up 2 bytes larger than the original, breaking paperless-ngx's checksum-based deduplication.
- Removed the redundant CRLF so the closing boundary directly follows the CRLF already appended by the preceding part.

Fixes #624

## Test plan
- [x] Added `Networking/Tests/NetworkingTests/MultiPartFormDataRequestTest.swift`, which builds a real multipart body and parses the `document` part's raw octets per RFC 2046 framing; it reproducibly failed against the old code (13 bytes vs. 11 expected, extra `\r\n`) and passes after the fix.
- [x] `swift test --package-path Networking` — all 121 tests pass.