### PR TITLE
feat: Background sync

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -48,7 +48,10 @@ extension DocumentStore {
       preconditionFailure("Preview database seed failed: \(error)")
     }
     let caching = CachingRepository(wrapping: wrapped, database: database, serverID: serverID)
-    let store = DocumentStore(repository: caching)
+    // Wrapped in a session like every other store: previews exercise the same
+    // ownership path production does, and there is no `init(repository:)` for
+    // production code to reach for.
+    let store = DocumentStore(session: ServerSession(serverID: serverID, repository: caching))
     store.elementStore.refreshUISettings(from: database, serverID: serverID)
     Task { try? await store.sync() }
     return store

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -102,10 +102,11 @@ public final class DocumentStore: Sendable {
   /// When the document reconcile sweep (R2/R3δ/membership) last **succeeded**.
   /// `nil` until the first successful reconcile this session.
   ///
-  /// Observed (not `@ObservationIgnored`) because the Offline & Sync screen
-  /// renders it: untracked storage would leave the row reading "Never" until
-  /// some other observed property happened to fire.
-  public private(set) var lastReconcileAt: Date?
+  /// Owned by the session, not mirrored into stored state here: the session's
+  /// own stamp is observed, so a view reading this through the store still
+  /// repaints when a sweep lands — including a sweep the *scheduler* ran, which
+  /// the store used never to hear about.
+  public var lastReconcileAt: Date? { session?.lastReconcileSuccess }
 
   /// When the active server's library was last fully filled (`nil` if never).
   /// A stored, observed mirror of `server_sync_state.library_coverage_at` —
@@ -175,20 +176,6 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var taskUpdateTask: Task<Void, Never>?
 
-  // The in-flight element sync, if any. Concurrent `sync` callers join this one
-  // task instead of each firing their own `syncElements` (the launch flurry of
-  // sync / fetchUISettings / scenePhase triggers shares a single network
-  // pass). Only ever touched on the main actor.
-  @ObservationIgnored
-  private var syncTask: Task<Void, Error>?
-
-  // The in-flight proactive library fill. Held so it can be cancelled when the
-  // repository is replaced, and so a second request joins it rather than
-  // starting a parallel pass over the same queries. Only touched on the main
-  // actor.
-  @ObservationIgnored
-  private var libraryFillTask: Task<Void, Never>?
-
   // Observes the active server's `library_coverage_at` into `libraryCoverageAt`.
   // Re-pointed alongside the element projection whenever the repository changes.
   @ObservationIgnored
@@ -201,14 +188,6 @@ public final class DocumentStore: Sendable {
   // Observes the active server's cached document count into `cachedDocumentCount`.
   @ObservationIgnored
   private var documentCountObservationTask: Task<Void, Never>?
-
-  // When the reconcile last *ran*, which is what the throttle needs — it has to
-  // advance on every attempt or a failing server would re-sweep its whole id set
-  // on every foreground. `lastReconcileAt` is the separate, user-facing stamp and
-  // only advances on success.
-  @ObservationIgnored
-  private var lastDocumentReconcile: Date?
-  private let reconcileThrottle: TimeInterval = 300
 
   // MARK: Methods
 
@@ -231,10 +210,12 @@ public final class DocumentStore: Sendable {
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
+    session?.progress = { [weak self] activity, stage in
+      self?.report(activity, for: stage)
+    }
   }
 
   deinit {
-    libraryFillTask?.cancel()
     taskUpdateTask?.cancel()
     coverageObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
@@ -366,21 +347,24 @@ public final class DocumentStore: Sendable {
   /// that needs to swap repositories should route through here so the invariant
   /// below keeps covering it.
   private func install(session: ServerSession, reload: Bool) {
-    // The backstop against installing a non-caching repository is gone because
-    // it is now unrepresentable: a session only ever yields a `CachingBackend`.
+    // Nothing is cancelled here any more, and that is the point.
     //
-    // The cancel-on-swap below, however, is still load-bearing *in this commit*.
-    // The store — not the session — still owns the element sync and the fill, so
-    // an in-flight one belongs to the outgoing backend: it writes the old
-    // server's rows, and `runSyncElements` would let the caller's follow-up sync
-    // join it (both `activate` callers do `activate` → `sync()`) and return
-    // without ever fetching the new server's cache. Once the sequence moves onto
-    // the session, that work is simply an *inactive* session's work and should
-    // keep running, and this goes away.
-    syncTask?.cancel()
-    syncTask = nil
-    libraryFillTask?.cancel()
-    libraryFillTask = nil
+    // The store used to cancel the in-flight element sync and library fill on
+    // every swap, because it owned them: they wrote the *outgoing* server's rows
+    // and a follow-up `sync()` would join them and return without ever fetching
+    // the new server's cache. Now that work belongs to the outgoing *session* —
+    // it is simply an inactive server's work, keyed to that server, and there is
+    // no way for the incoming server's sync to join it. So it keeps running, and
+    // switching servers mid-fill no longer throws away the pages already paid
+    // for.
+    //
+    // The progress hook does move, though: the outgoing session must stop
+    // reporting into this store's `syncActivities`, or the Offline & Sync screen
+    // would show the previous server's stages.
+    self.session?.progress = nil
+    session.progress = { [weak self] activity, stage in
+      self?.report(activity, for: stage)
+    }
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()
@@ -528,18 +512,18 @@ public final class DocumentStore: Sendable {
   public func sync(userInitiated: Bool = false) async throws {
     Logger.sync.notice("Sync store (userInitiated: \(userInitiated))")
     do {
-      try await runSyncElements()
+      try await session?.syncElements()
       lastSyncError = nil
       Logger.sync.info("Sync store complete")
       // Reconcile remote deletes alongside the element sync (throttled,
       // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
       let userInitiated = userInitiated
-      Task { [weak self] in await self?.reconcileDocuments(userInitiated: userInitiated) }
+      Task { [weak self] in await self?.session?.reconcileDocuments(force: userInitiated) }
     } catch {
-      // A cancellation is never the user's problem to see: either the caller's
-      // own task went away, or `install(session:)` retired this sync on a
-      // connection switch. Drop it before the userInitiated rethrow so neither
-      // case toasts.
+      // A cancellation is never the user's problem to see: the caller's own task
+      // went away. (A connection switch no longer retires it — that sync belongs
+      // to the outgoing session and runs on.) Drop it before the userInitiated
+      // rethrow so it doesn't toast.
       if error.isCancellationError {
         Logger.sync.debug("Element sync cancelled")
         return
@@ -553,38 +537,6 @@ public final class DocumentStore: Sendable {
       }
       Logger.sync.error("Background sync failed (suppressed): \(error)")
     }
-  }
-
-  /// Run (or join) the single in-flight `syncElements`. Returns when it
-  /// completes; throws its error to every joined caller (who each decide what to
-  /// do with it). A no-op without a caching backend.
-  private func runSyncElements() async throws {
-    if let syncTask {
-      Logger.sync.debug("Joining in-flight element sync")
-      return try await syncTask.value
-    }
-    guard let backend = session?.backend else {
-      // No DB-backed repository (e.g. NullRepository before login). Nothing to
-      // sync; the projection is empty until a caching repository is set.
-      Logger.sync.info("Sync skipped: repository is not a caching backend")
-      return
-    }
-    Logger.sync.debug("Starting element sync")
-    let task = Task { [weak self] in
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements { self?.report($0, for: .elementSync) }
-      }
-    }
-    syncTask = task
-    defer {
-      // Retract only what we installed. `install(session:)` can retire this sync
-      // mid-flight and a replacement can already own `syncTask` by the time we
-      // resume; clearing it blindly would break the replacement's coalescing.
-      if syncTask == task {
-        syncTask = nil
-      }
-    }
-    try await task.value
   }
 
   public func document(id: UInt) async throws -> Document? {
@@ -879,123 +831,28 @@ extension DocumentStore {
     return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
   }
 
-  /// Throttled remote-delete reconcile: drop cached documents that no longer
-  /// exist on the server (so they disappear from every offline list). Soft-fail
-  /// (background); kicked from `sync()`. `userInitiated` bypasses the throttle.
+  /// Throttled remote-delete reconcile on the active server, run by its session:
+  /// drop cached documents that no longer exist on the server (so they disappear
+  /// from every offline list), fold in the changed-metadata delta, then rebuild
+  /// saved-view membership. Soft-fail (background); kicked from `sync()`.
+  /// `userInitiated` bypasses the throttle.
   public func reconcileDocuments(userInitiated: Bool = false) async {
-    guard let backend = session?.backend else { return }
-    if !userInitiated, let last = lastDocumentReconcile,
-      Date().timeIntervalSince(last) < reconcileThrottle
-    {
-      return
-    }
-    lastDocumentReconcile = Date()
-    report(SyncActivity(stage: .reconcile), for: .reconcile)
-    defer { report(nil, for: .reconcile) }
-
-    // Each sweep carries its own catch. The delete sweep is the most
-    // failure-prone of the three — it fetches the server's entire live id set —
-    // and under one shared `do` its failure took the freshness delta *and* the
-    // membership rebuild down with it, so a single flaky request cost the whole
-    // reconcile. Cancellation is the exception: it means the pass as a whole is
-    // unwanted (a repository swap, a background time budget running out), so it
-    // stops the remaining sweeps instead of being logged and stepped over.
-    var succeeded = 0
-    var cancelled = false
-
-    func sweep(_ label: String, _ body: () async throws -> Void) async {
-      guard !cancelled else { return }
-      do {
-        try await body()
-        succeeded += 1
-      } catch {
-        guard !error.isCancellationError else {
-          Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-          cancelled = true
-          return
-        }
-        Logger.sync.info("Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-      }
-    }
-
-    // Deletes first (correctness), then the changed-metadata delta (freshness),
-    // then the saved-view membership sweep (so newly-matched docs — now landed
-    // at detail by the delta — appear in every offline list). The last two are
-    // no-ops unless *Entire library* is enabled.
-    await NetworkTransfer.$category.withValue(.reconcile) {
-      await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-      await sweep("changes") {
-        try await backend.reconcileDocumentChanges { [weak self] in
-          // The delta finishing doesn't end the reconcile — the membership
-          // sweep runs after it — so fall back to the bare stage.
-          self?.report($0 ?? SyncActivity(stage: .reconcile), for: .reconcile)
-        }
-      }
-      await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-    }
-
-    // A pass in which *something* refreshed counts: a server that fails every
-    // sweep must not display a fresh "last refreshed" while nothing is actually
-    // being refreshed, but one failing sweep shouldn't erase the two that
-    // worked. Same policy as `fillLibrary`'s coverage marker. A cancelled pass
-    // stamps nothing — it didn't finish, it was called off.
-    if succeeded > 0, !cancelled {
-      lastReconcileAt = Date()
-    }
+    await session?.reconcileDocuments(force: userInitiated)
   }
 
-  /// Proactive *Entire library* fill, gated by the setting and an unmetered link.
+  /// Proactive *Entire library* fill on the active server, run by its session.
   /// Foreground-only; soft-fail (offline-tolerant). `force` ignores the freshness
   /// marker (e.g. the user just enabled the setting). A no-op when the setting is
-  /// *Recently browsed*, the link is metered, or there's no caching backend.
+  /// *Recently browsed*, the link is metered, or there is no active server.
   public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    guard unmetered, let backend = session?.backend,
-      backend.offlineBrowsingMode == .entireLibrary
-    else { return }
-
-    // Join an in-flight fill rather than starting a second pass over the same
-    // queries. Nothing dedupes these otherwise, and there are five triggers —
-    // launch, foreground, the mode picker, Sync now, and the background run.
-    // `force` is not lost by joining: a fill only runs at all when the coverage
-    // marker is stale or forced, so one is already doing the work.
-    if let existing = libraryFillTask {
-      await existing.value
-      return
-    }
-
-    let task = Task { [weak self] in
-      do {
-        try await backend.fillLibrary(force: force) { [weak self] in
-          self?.report($0, for: .libraryFill)
-        }
-      } catch is CancellationError {
-        Logger.sync.info("Proactive library fill cancelled")
-      } catch {
-        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
-      }
-    }
-    libraryFillTask = task
-    await task.value
-    // Only clear our own: a cancel-and-restart may have installed a newer one
-    // while we were awaiting.
-    if libraryFillTask == task {
-      libraryFillTask = nil
-    }
+    await session?.fillLibrary(unmetered: unmetered, force: force)
   }
 
-  /// Proactive *Entire library* per-document detail fill (notes + file-metadata),
-  /// gated by the setting and an unmetered link. Run after `fillLibraryIfEnabled`
-  /// so the document rows to walk are already on disk. Idempotent and resumable
-  /// (driven off what's still missing), so it needs no `force`. Soft-fail.
+  /// Proactive *Entire library* per-document detail fill (notes + file-metadata)
+  /// on the active server, run by its session. Run after `fillLibraryIfEnabled`
+  /// so the document rows to walk are already on disk. Soft-fail.
   public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    guard unmetered, let backend = session?.backend,
-      backend.offlineBrowsingMode == .entireLibrary
-    else { return }
-    do {
-      try await backend.fillDocumentDetails { [weak self] in self?.report($0, for: .detailFill) }
-    } catch {
-      Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
-    }
+    await session?.fillDocumentDetails(unmetered: unmetered)
   }
 
   /// The server's total for the default document list, from the cached query

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -100,6 +100,12 @@ public final class DocumentStore: Sendable {
   /// read wouldn't be tracked by the observation.
   public private(set) var libraryCoverageAt: Date?
 
+  /// When the active server's element sync last completed successfully (`nil`
+  /// if never) — an observed mirror of `server_sync_state.last_sync_at`, so
+  /// the Offline & Sync screen's freshness row survives restarts and reflects
+  /// background runs, not just this store's in-memory activity.
+  public private(set) var lastSyncAt: Date?
+
   /// Views (saved or default) whose proactive offline fill the server most
   /// recently rejected — observed from `query_sync_error` for the active server
   /// so the Offline & Sync screen can warn that they aren't fully cached.
@@ -166,6 +172,10 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var coverageObservationTask: Task<Void, Never>?
 
+  // Observes the active server's `last_sync_at` into `lastSyncAt`.
+  @ObservationIgnored
+  private var lastSyncObservationTask: Task<Void, Never>?
+
   // Observes the active server's recorded per-view sync failures into `syncErrors`.
   @ObservationIgnored
   private var syncErrorObservationTask: Task<Void, Never>?
@@ -200,6 +210,7 @@ public final class DocumentStore: Sendable {
   deinit {
     taskUpdateTask?.cancel()
     coverageObservationTask?.cancel()
+    lastSyncObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
     documentCountObservationTask?.cancel()
   }
@@ -210,6 +221,7 @@ public final class DocumentStore: Sendable {
   /// login) detaches the projection.
   private func wireElementStore() {
     coverageObservationTask?.cancel()
+    lastSyncObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
     documentCountObservationTask?.cancel()
     if let backend = session?.backend {
@@ -222,6 +234,14 @@ public final class DocumentStore: Sendable {
           for try await date in stream { self?.libraryCoverageAt = date }
         } catch {
           Logger.shared.debug("Coverage observation ended: \(error)")
+        }
+      }
+      let lastSync = backend.database.observeLastSyncAt(serverID: backend.serverID)
+      lastSyncObservationTask = Task { [weak self] in
+        do {
+          for try await date in lastSync { self?.lastSyncAt = date }
+        } catch {
+          Logger.shared.debug("Last-sync observation ended: \(error)")
         }
       }
       let errors = backend.database.observeQuerySyncErrors(serverID: backend.serverID)
@@ -243,6 +263,7 @@ public final class DocumentStore: Sendable {
     } else {
       elementStore.reset()
       libraryCoverageAt = nil
+      lastSyncAt = nil
       syncErrors = []
       cachedDocumentCount = 0
     }

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -145,7 +145,30 @@ public final class DocumentStore: Sendable {
 
   public let semaphore = AsyncSemaphore(value: 1)
 
-  public private(set) var repository: any Repository
+  /// The registry this store activates through, or `nil` for a fixture store
+  /// pinned to one session. Holding the registry — rather than a `Database` and
+  /// a `ConnectionManager` to assemble stacks from — is what stops the store
+  /// becoming a *second* owner of a server the registry already drives.
+  @ObservationIgnored
+  private let registry: ServerSessionRegistry?
+
+  /// The session driving this store, or `nil` before login.
+  ///
+  /// Deliberately *not* `@ObservationIgnored`: ``repository`` is computed from
+  /// it, so every view that read the outgoing server's repository has to be
+  /// invalidated when this changes.
+  private var session: ServerSession?
+
+  /// Stands in for "no active server". Held rather than constructed per access
+  /// so ``repository`` keeps a stable identity while the store is serverless.
+  @ObservationIgnored
+  private let nullRepository = NullRepository()
+
+  /// The active server's repository, owned by its ``ServerSession`` rather than
+  /// by this store. Before login there is no session, and this reads as
+  /// `NullRepository` — which detaches the element projection, exactly as it
+  /// always has.
+  public var repository: any Repository { session?.repository ?? nullRepository }
 
   public private(set) var imagePipeline: ImagePipeline
 
@@ -189,9 +212,24 @@ public final class DocumentStore: Sendable {
 
   // MARK: Methods
 
-  public init(repository: some Repository) {
-    self.repository = repository
-    self.imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+  /// The production store: it activates onto servers by asking `registry` for
+  /// their sessions, so neither the app nor the extension can end up driving a
+  /// server the registry already owns.
+  public convenience init(registry: ServerSessionRegistry) {
+    self.init(registry: registry, session: nil)
+  }
+
+  /// A store pinned to one session, for previews and tests. It cannot activate
+  /// onto another server — there is no registry to ask — which is the right
+  /// shape for a fixture.
+  public convenience init(session: ServerSession) {
+    self.init(registry: nil, session: session)
+  }
+
+  private init(registry: ServerSessionRegistry?, session: ServerSession?) {
+    self.registry = registry
+    self.session = session
+    imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
   }
 
@@ -211,7 +249,7 @@ public final class DocumentStore: Sendable {
     coverageObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
     documentCountObservationTask?.cancel()
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       elementStore.repoint(database: backend.database, serverID: backend.serverID)
       // Source-of-truth: observe the coverage timestamp rather than reading it
       // imperatively, so it tracks fills *and* a cache wipe (which clears it).
@@ -292,7 +330,7 @@ public final class DocumentStore: Sendable {
   /// swap. That is only the task list and the last sync error now: documents
   /// aren't held in memory under source-of-truth (the list observes the DB
   /// directly), and the element projection is owned by `elementStore` and
-  /// re-pointed by `wireElementStore()`. `private` because `set(repository:)` is
+  /// re-pointed by `wireElementStore()`. `private` because `install(session:)` is
   /// the one caller — a swap is the only moment this is the right thing to do.
   private func clear() {
     tasks = []
@@ -301,53 +339,50 @@ public final class DocumentStore: Sendable {
 
   /// Point the store at `connection` — the only supported way to put it on a server.
   ///
-  /// The store assembles the stack itself, through ``makeCachingRepository``, so a
-  /// caller cannot hand it a bare uncached repository. That mistake detaches the
-  /// element projection and blanks every element read site until the next relaunch,
-  /// and it shipped once already from `ConnectionsView.updateExtraHeaders`; keeping
-  /// the assembly in here is what makes it unrepresentable rather than merely
-  /// discouraged.
+  /// The stack is assembled by the server's ``ServerSession``, so a caller cannot
+  /// hand the store a bare uncached repository. That mistake detaches the element
+  /// projection and blanks every element read site until the next relaunch, and it
+  /// shipped once already from `ConnectionsView.updateExtraHeaders`; routing every
+  /// activation through the session that owns the server is what makes it
+  /// unrepresentable rather than merely discouraged — and is also what stops two
+  /// owners driving the same server at once.
   public func activate(
     connection: StoredConnection,
-    database: Database,
-    manager: ConnectionManager,
-    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode,
     reload: Bool = true
   ) async throws {
-    let repository = try await makeCachingRepository(
-      for: connection, database: database, manager: manager, mode: mode)
-    install(repository: repository, reload: reload)
+    guard let registry else {
+      preconditionFailure("activate(connection:) called on a store built without a registry")
+    }
+    let session = registry.session(for: connection.id)
+    // Build before installing, not lazily on first use: `repository` reads
+    // straight off the session, and a store published on a session that has not
+    // assembled its stack yet would render one pass against `NullRepository`.
+    try await session.prepareRepository(for: connection)
+    install(session: session, reload: reload)
   }
 
   /// The single chokepoint for swapping the live repository. Private on purpose:
   /// see ``activate(connection:database:manager:mode:reload:)``. Any future path
   /// that needs to swap repositories should route through here so the invariant
   /// below keeps covering it.
-  private func install(repository: some Repository, reload: Bool) {
-    // A repository that doesn't front the DB detaches the element projection (see
-    // `wireElementStore()`). That is legitimate before login, but only via `init`;
-    // replacing a *live* repository with a bare one is always a bug. Unreachable
-    // today — `activate` is the only caller — so this is a backstop, not a guard
-    // against anything currently in the tree.
-    if !(repository is any CachingBackend) {
-      Logger.shared.fault(
-        "Installing non-caching repository \(String(describing: type(of: repository)), privacy: .public) on a live store; element projection will stay detached until relaunch"
-      )
-    }
-    // An element sync in flight belongs to the *outgoing* backend: it writes the
-    // old server's rows, and `runSyncElements` would let the caller's follow-up
-    // sync join it (both `activate` callers do `activate` → `sync()`) and return
-    // without ever fetching the new server's cache. Nothing here is worth
-    // keeping, so cancel rather than detach.
+  private func install(session: ServerSession, reload: Bool) {
+    // The backstop against installing a non-caching repository is gone because
+    // it is now unrepresentable: a session only ever yields a `CachingBackend`.
+    //
+    // The cancel-on-swap below, however, is still load-bearing *in this commit*.
+    // The store — not the session — still owns the element sync and the fill, so
+    // an in-flight one belongs to the outgoing backend: it writes the old
+    // server's rows, and `runSyncElements` would let the caller's follow-up sync
+    // join it (both `activate` callers do `activate` → `sync()`) and return
+    // without ever fetching the new server's cache. Once the sequence moves onto
+    // the session, that work is simply an *inactive* session's work and should
+    // keep running, and this goes away.
     syncTask?.cancel()
     syncTask = nil
-    // The fill belongs to the outgoing backend too: it pages the *old* server
-    // into the old server's rows. Left running it would keep spending network
-    // and main-actor write transactions on a connection the user has left.
     libraryFillTask?.cancel()
     libraryFillTask = nil
-    self.repository = repository
-    imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+    self.session = session
+    imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()
     if reload {
       events.emit(.repositoryChanged)
@@ -477,7 +512,7 @@ public final class DocumentStore: Sendable {
   /// permissions (offline-first) instead of aborting the launch load.
   public func fetchUISettings() async throws {
     try await sync()
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       elementStore.refreshUISettings(from: backend.database, serverID: backend.serverID)
     }
   }
@@ -502,7 +537,7 @@ public final class DocumentStore: Sendable {
       Task { [weak self] in await self?.reconcileDocuments(userInitiated: userInitiated) }
     } catch {
       // A cancellation is never the user's problem to see: either the caller's
-      // own task went away, or `set(repository:)` retired this sync on a
+      // own task went away, or `install(session:)` retired this sync on a
       // connection switch. Drop it before the userInitiated rethrow so neither
       // case toasts.
       if error.isCancellationError {
@@ -528,7 +563,7 @@ public final class DocumentStore: Sendable {
       Logger.sync.debug("Joining in-flight element sync")
       return try await syncTask.value
     }
-    guard let backend = repository as? any CachingBackend else {
+    guard let backend = session?.backend else {
       // No DB-backed repository (e.g. NullRepository before login). Nothing to
       // sync; the projection is empty until a caching repository is set.
       Logger.sync.info("Sync skipped: repository is not a caching backend")
@@ -542,7 +577,7 @@ public final class DocumentStore: Sendable {
     }
     syncTask = task
     defer {
-      // Retract only what we installed. `set(repository:)` can retire this sync
+      // Retract only what we installed. `install(session:)` can retire this sync
       // mid-flight and a replacement can already own `syncTask` by the time we
       // resume; clearing it blindly would break the replacement's coalescing.
       if syncTask == task {
@@ -812,14 +847,14 @@ extension DocumentStore {
   /// the list can subscribe to whatever is already cached (offline-first) before
   /// — or independently of — the network fill. `nil` without a caching backend.
   public func documentQueryKey(filter: FilterState) -> QueryKey? {
-    guard let backend = repository as? any CachingBackend else { return nil }
+    guard let backend = session?.backend else { return nil }
     return QueryKey(serverID: backend.serverID, filter: filter)
   }
 
   /// Eager full-fill of a list: await page 1 + count, then background-page the
   /// rest. The returned handle carries the `QueryKey` the list then observes.
   public func fillDocumentQuery(filter: FilterState) async throws -> QueryFillHandle {
-    guard let backend = repository as? any CachingBackend else {
+    guard let backend = session?.backend else {
       throw CachingRepositoryError.cacheMiss
     }
     return try await backend.fillQuery(filter: filter)
@@ -831,7 +866,7 @@ extension DocumentStore {
   public func observeDocumentPrefix(
     queryKey: QueryKey, limit: Int
   ) -> AsyncThrowingStream<[DocumentEntry], Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeDocumentPrefix(
       queryKey: queryKey, serverID: backend.serverID, limit: limit)
   }
@@ -840,7 +875,7 @@ extension DocumentStore {
   public func observeQueryStatus(
     queryKey: QueryKey
   ) -> AsyncThrowingStream<QueryStatus, Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
   }
 
@@ -848,7 +883,7 @@ extension DocumentStore {
   /// exist on the server (so they disappear from every offline list). Soft-fail
   /// (background); kicked from `sync()`. `userInitiated` bypasses the throttle.
   public func reconcileDocuments(userInitiated: Bool = false) async {
-    guard let backend = repository as? any CachingBackend else { return }
+    guard let backend = session?.backend else { return }
     if !userInitiated, let last = lastDocumentReconcile,
       Date().timeIntervalSince(last) < reconcileThrottle
     {
@@ -914,7 +949,7 @@ extension DocumentStore {
   /// marker (e.g. the user just enabled the setting). A no-op when the setting is
   /// *Recently browsed*, the link is metered, or there's no caching backend.
   public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    guard unmetered, let backend = repository as? any CachingBackend,
+    guard unmetered, let backend = session?.backend,
       backend.offlineBrowsingMode == .entireLibrary
     else { return }
 
@@ -953,7 +988,7 @@ extension DocumentStore {
   /// so the document rows to walk are already on disk. Idempotent and resumable
   /// (driven off what's still missing), so it needs no `force`. Soft-fail.
   public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    guard unmetered, let backend = repository as? any CachingBackend,
+    guard unmetered, let backend = session?.backend,
       backend.offlineBrowsingMode == .entireLibrary
     else { return }
     do {
@@ -984,7 +1019,7 @@ extension DocumentStore {
   /// Live single document by id, for detail/preview surfaces that must repaint on
   /// mutation/sync.
   public func observeDocument(id: UInt) -> AsyncThrowingStream<Document?, Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeDocument(serverID: backend.serverID, id: id)
   }
 
@@ -1000,7 +1035,7 @@ extension DocumentStore {
   /// keeping the configured server connections. The live observations repaint
   /// empty immediately; the next sync / list open refills from the network.
   public func wipeLocalCache() throws {
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       try backend.database.clearCache()
     }
     // Downloaded originals/archives/thumbnails (app-group blob store). Rooted at

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -786,7 +786,7 @@ public final class DocumentStore: Sendable {
   }
 }
 
-// MARK: - Document cache surface (Stage 8)
+// MARK: - Document cache surface
 
 /// The GRDB-free surface the document list and detail views reach for. Each
 /// method resolves the active `CachingBackend` (the production/preview stack) and

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -848,6 +848,14 @@ extension DocumentStore {
     await session?.runProactiveFill(unmetered: unmetered, force: force)
   }
 
+  /// Stop the active server's in-flight proactive fill, if any — e.g. the caller
+  /// is about to reclaim cache the fill would otherwise keep writing back into
+  /// (leaving *Entire library* on the same server). Scoped to that server's
+  /// session, so it cannot reach into another server's work.
+  public func cancelProactiveFill() {
+    session?.cancelProactiveFill()
+  }
+
   /// The server's total for the default document list, from the cached query
   /// status — no request. `nil` when there's no caching backend, or when that
   /// list hasn't been fetched yet and so has no recorded total.

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -839,19 +839,13 @@ extension DocumentStore {
     await session?.reconcileDocuments(force: userInitiated)
   }
 
-  /// Proactive *Entire library* fill on the active server, run by its session.
-  /// Foreground-only; soft-fail (offline-tolerant). `force` ignores the freshness
-  /// marker (e.g. the user just enabled the setting). A no-op when the setting is
-  /// *Recently browsed*, the link is metered, or there is no active server.
-  public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    await session?.fillLibrary(unmetered: unmetered, force: force)
-  }
-
-  /// Proactive *Entire library* per-document detail fill (notes + file-metadata)
-  /// on the active server, run by its session. Run after `fillLibraryIfEnabled`
-  /// so the document rows to walk are already on disk. Soft-fail.
-  public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    await session?.fillDocumentDetails(unmetered: unmetered)
+  /// Proactive *Entire library* fill on the active server, run by its session:
+  /// the library fill followed by the per-document detail fill, as one pass.
+  /// Soft-fail (offline-tolerant). `force` ignores the library fill's freshness
+  /// marker (e.g. the user just enabled the setting). A no-op when the setting
+  /// is *Recently browsed*, the link is metered, or there is no active server.
+  public func runProactiveFill(unmetered: Bool, force: Bool = false) async {
+    await session?.runProactiveFill(unmetered: unmetered, force: force)
   }
 
   /// The server's total for the default document list, from the cached query

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -75,29 +75,14 @@ public final class DocumentStore: Sendable {
   /// User-initiated syncs rethrow instead (the caller toasts, as before).
   public private(set) var lastSyncError: (any DisplayableError)?
 
-  /// Every sync stage running right now, in a fixed order; empty when idle.
-  /// Drives the stage rows and progress bars on the Offline & Sync screen.
+  /// Every sync stage running right now on the active server, in a fixed order;
+  /// empty when idle. Drives the stage rows and progress bars on the Offline &
+  /// Sync screen.
   ///
-  /// A list rather than one "current" stage because they genuinely overlap:
-  /// `sync()` starts the reconcile in its own task and returns, so a reconcile
-  /// is usually still running when the library fill begins. Publishing one of
-  /// them meant whichever finished first blanked the screen to "Idle" while the
-  /// other carried on — and, because progress is reported coarsely, it stayed
-  /// blank until the survivor reached its next checkpoint.
-  public private(set) var syncActivities: [SyncActivity] = []
-
-  // One entry per sweep currently running. Keyed by stage because each sweep
-  // owns exactly one, and because a sweep reporting "done" says only *that* —
-  // it can't say which stage it was, so the key has to come from the call site.
-  @ObservationIgnored
-  private var activeStages: [SyncActivity.Stage: SyncActivity] = [:]
-
-  /// Fold one sweep's progress into the published activity. `nil` retires the
-  /// stage; the screen keeps showing whatever else is still running.
-  private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
-    activeStages[stage] = activity
-    syncActivities = activeStages.values.sortedForDisplay
-  }
+  /// Owned by the session, so this is a plain projection: the screen now repaints
+  /// for work the *scheduler* started on this server too, which it could not do
+  /// while the only reporter was this store.
+  public var syncActivities: [SyncActivity] { session?.syncActivities ?? [] }
 
   /// When the document reconcile sweep (R2/R3δ/membership) last **succeeded**.
   /// `nil` until the first successful reconcile this session.
@@ -210,9 +195,6 @@ public final class DocumentStore: Sendable {
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
-    session?.progress = { [weak self] activity, stage in
-      self?.report(activity, for: stage)
-    }
   }
 
   deinit {
@@ -358,13 +340,9 @@ public final class DocumentStore: Sendable {
     // switching servers mid-fill no longer throws away the pages already paid
     // for.
     //
-    // The progress hook does move, though: the outgoing session must stop
-    // reporting into this store's `syncActivities`, or the Offline & Sync screen
-    // would show the previous server's stages.
-    self.session?.progress = nil
-    session.progress = { [weak self] activity, stage in
-      self?.report(activity, for: stage)
-    }
+    // Progress needs no unwiring either: each session publishes its own stages,
+    // so pointing the store at a new one *is* switching which server's progress
+    // the Offline & Sync screen shows.
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()

--- a/AppShared/Sources/AppShared/Model/OfflineBrowsingMode.swift
+++ b/AppShared/Sources/AppShared/Model/OfflineBrowsingMode.swift
@@ -9,7 +9,7 @@ import Foundation
 /// How aggressively the offline cache fills a given server's documents.
 ///
 /// - `recentlyBrowsed`: only queries the user actually opens are cached
-///   (Stage 8 on-open fill).
+///   (the on-open fill).
 /// - `entireLibrary`: a proactive fill caches every saved view and the default
 ///   list, so the whole library browses offline even if never opened.
 ///

--- a/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
+++ b/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
@@ -1,0 +1,173 @@
+//
+//  BackgroundSyncCoordinator.swift
+//  AppShared
+//
+//  Stage 11 (background sync): the bridge between the app shell's BGTask
+//  handlers (app target only — AppShared stays extension-safe and never
+//  imports BackgroundTasks) and the sync machinery.
+//
+//  The invariant this type exists to protect: **at most one
+//  `CachingRepository` per server executes at any time.** A BGTask fires
+//  in-process, and the process may or may not already contain the UI object
+//  graph:
+//
+//  - *Warm* (app was foregrounded, then suspended): iOS resumes the same
+//    process, including any suspended in-flight sync tasks. The handler must
+//    therefore drive the *registered* live objects — same instances, so their
+//    single-flight guards coalesce everything and the invariant holds by
+//    identity. The active server goes through the registered `DocumentStore`,
+//    the rest through the registered `SyncEngine` (active excluded, as in the
+//    foreground).
+//  - *Cold background launch* (nothing registered): no scene connected, no
+//    graph exists — the coordinator builds a headless stack and lets the
+//    engine sweep `scope: .all`, safe because it is provably the process's
+//    only `CachingRepository` owner.
+//  - *Foregrounds mid-headless-run*: `register()` cancels-and-awaits the
+//    headless run before the UI graph's own sync kicks, closing the one
+//    remaining overlap window.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+public final class BackgroundSyncCoordinator {
+  public static let shared = BackgroundSyncCoordinator()
+
+  private struct UIGraph {
+    let database: Database
+    let manager: ConnectionManager
+    let syncEngine: SyncEngine
+    let store: DocumentStore?
+  }
+
+  private var registered: UIGraph?
+  private var headlessTask: Task<Bool, Never>?
+
+  private init() {}
+
+  /// Hand the live UI object graph to the coordinator. Called from the app
+  /// shell whenever the graph (re)wires itself — repeat calls just refresh the
+  /// references. Cancels-and-awaits any in-flight headless run first, so two
+  /// stacks never execute concurrently.
+  public func register(
+    database: Database, manager: ConnectionManager, syncEngine: SyncEngine, store: DocumentStore?
+  ) async {
+    if let headlessTask {
+      Logger.sync.info("UI graph registering; cancelling in-flight headless background sync")
+      headlessTask.cancel()
+      _ = await headlessTask.value
+    }
+    registered = UIGraph(database: database, manager: manager, syncEngine: syncEngine, store: store)
+  }
+
+  public func unregister() {
+    registered = nil
+  }
+
+  /// Scheduling input: whether any configured server wants the heavy
+  /// processing task. `nil` when no UI graph is registered — callers should
+  /// submit the request anyway (the handler no-ops cheaply) rather than open
+  /// a headless database just to decide.
+  public func hasEntireLibraryServer() -> Bool? {
+    registered.map { graph in
+      graph.manager.connections.values.contains { $0.offlineBrowsingMode == .entireLibrary }
+    }
+  }
+
+  /// The `BGAppRefreshTask` body: cheap tier (elements + reconcile sweeps),
+  /// all servers. Returns whether the run completed uncancelled.
+  public func runRefresh() async -> Bool {
+    await run(tier: .cheap)
+  }
+
+  /// The `BGProcessingTask` body: cheap tier plus the proactive fills where
+  /// mode and network allow.
+  public func runProcessing() async -> Bool {
+    await run(tier: .full)
+  }
+
+  // MARK: - Execution
+
+  private func run(tier: SyncEngine.SyncTier) async -> Bool {
+    let cost = await NetworkPathProbe.currentCost()
+    guard let graph = registered else {
+      return await runHeadless(tier: tier, cost: cost)
+    }
+    Logger.sync.info(
+      "Background run (tier: \(String(describing: tier), privacy: .public), registered graph, isExpensive: \(cost.isExpensive), isConstrained: \(cost.isConstrained))"
+    )
+    // Active server first, via its own store (mirrors the foreground order);
+    // `sync()` fire-and-forgets a reconcile, so the explicit call either runs
+    // it or joins-by-throttle — the trailing engine sweep gives it time either
+    // way.
+    if let store = graph.store {
+      try? await store.sync()
+      await store.reconcileDocuments()
+      if tier == .full {
+        let condition = SyncCondition(
+          isExpensive: cost.isExpensive, isConstrained: cost.isConstrained,
+          syncOverCellular: graph.manager.activeSyncOverCellular)
+        await store.fillLibraryIfEnabled(unmetered: condition.allowsProactiveSync)
+        await store.fillDocumentDetailsIfEnabled(unmetered: condition.allowsProactiveSync)
+      }
+    }
+    await graph.syncEngine.syncServers(
+      scope: .excludingActive(graph.manager.activeConnectionId),
+      tier: tier, isExpensive: cost.isExpensive, isConstrained: cost.isConstrained)
+    let completed = !Task.isCancelled
+    Logger.sync.info("Background run finished (completed: \(completed))")
+    return completed
+  }
+
+  private func runHeadless(
+    tier: SyncEngine.SyncTier, cost: (isExpensive: Bool, isConstrained: Bool)
+  ) async -> Bool {
+    Logger.sync.info(
+      "Background run (tier: \(String(describing: tier), privacy: .public), headless, isExpensive: \(cost.isExpensive), isConstrained: \(cost.isConstrained))"
+    )
+    let task = Task { @MainActor () -> Bool in
+      let database: Database
+      do {
+        database = try Database()
+      } catch {
+        // Includes pre-first-unlock file protection and a failed migration
+        // after an update. Never wipe, never surface UI from back here —
+        // `DatabaseBootstrap` remains the sole migration-failure surface; the
+        // OS reschedule retries later.
+        Logger.sync.error("Headless background sync: cannot open database: \(error)")
+        return false
+      }
+      // The sink is normally installed by the app shell at UI launch; a cold
+      // background launch never got there, and untracked traffic would
+      // undercount the transfer meter.
+      TransferStatistics.install()
+      let manager = ConnectionManager(database: database)
+      // A headless registry: this process has no `DocumentStore`, so these are
+      // the only `ServerSession`s in it and the engine is provably the sole
+      // owner of every server's repository. It is deliberately not `start()`ed —
+      // nothing edits the server table behind a background run.
+      let registry = ServerSessionRegistry(database: database, manager: manager)
+      let engine = SyncEngine(registry: registry, manager: manager, pathCost: { cost })
+      await engine.syncServers(
+        scope: .all, tier: tier, isExpensive: cost.isExpensive, isConstrained: cost.isConstrained)
+      TransferStatistics.shared.persist()
+      let completed = !Task.isCancelled
+      Logger.sync.info("Headless background run finished (completed: \(completed))")
+      return completed
+    }
+    headlessTask = task
+    defer { headlessTask = nil }
+    // Forward outer cancellation (the BGTask expiration handler cancels the
+    // driving task) into the stored task, which `register()` can also cancel.
+    return await withTaskCancellationHandler {
+      await task.value
+    } onCancel: {
+      task.cancel()
+    }
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
+++ b/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
@@ -120,8 +120,7 @@ public final class BackgroundSyncCoordinator {
         let condition = SyncCondition(
           isExpensive: cost.isExpensive, isConstrained: cost.isConstrained,
           syncOverCellular: graph.manager.activeSyncOverCellular)
-        await store.fillLibraryIfEnabled(unmetered: condition.allowsProactiveSync)
-        await store.fillDocumentDetailsIfEnabled(unmetered: condition.allowsProactiveSync)
+        await store.runProactiveFill(unmetered: condition.allowsProactiveSync)
       }
     }
     await graph.syncEngine.syncServers(

--- a/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
+++ b/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
@@ -6,25 +6,24 @@
 //  handlers (app target only — AppShared stays extension-safe and never
 //  imports BackgroundTasks) and the sync machinery.
 //
-//  The invariant this type exists to protect: **at most one
-//  `CachingRepository` per server executes at any time.** A BGTask fires
-//  in-process, and the process may or may not already contain the UI object
-//  graph:
+//  The invariant this type has to respect: **at most one `CachingRepository`
+//  per server executes at any time.** Within a single object graph that is now
+//  structural — every server's repository belongs to its `ServerSession`, and
+//  concurrent callers coalesce onto that session's single-flights — so both
+//  paths below are just "sweep every server with this engine":
 //
 //  - *Warm* (app was foregrounded, then suspended): iOS resumes the same
-//    process, including any suspended in-flight sync tasks. The handler must
-//    therefore drive the *registered* live objects — same instances, so their
-//    single-flight guards coalesce everything and the invariant holds by
-//    identity. The active server goes through the registered `DocumentStore`,
-//    the rest through the registered `SyncEngine` (active excluded, as in the
-//    foreground).
+//    process, so the handler drives the *registered* engine. Its sweep reaches
+//    the active server too; that used to be forbidden, and is now simply the
+//    same session the on-screen store is using.
 //  - *Cold background launch* (nothing registered): no scene connected, no
-//    graph exists — the coordinator builds a headless stack and lets the
-//    engine sweep `scope: .all`, safe because it is provably the process's
-//    only `CachingRepository` owner.
-//  - *Foregrounds mid-headless-run*: `register()` cancels-and-awaits the
-//    headless run before the UI graph's own sync kicks, closing the one
-//    remaining overlap window.
+//    graph exists, so the coordinator builds a headless stack — its own
+//    `Database`, `ConnectionManager` and `ServerSessionRegistry`. That is the
+//    only difference between the two paths.
+//  - *Foregrounds mid-headless-run*: `register()` still cancels-and-awaits the
+//    headless run. Sessions make ownership structural *within* a graph, and a
+//    headless run is a second graph with its own registry — so this is the one
+//    overlap the type still has to close by hand.
 //
 
 import Common
@@ -44,11 +43,13 @@ public final class BackgroundSyncCoordinator {
   /// a run is still in flight).
   public private(set) var isRunning = false
 
+  /// What a background run needs from the live graph: the engine to sweep with,
+  /// and the manager to read scheduling inputs from. Notably *not* the
+  /// `DocumentStore` — the active server is reached through its session like
+  /// every other server, so the store has nothing to contribute here.
   private struct UIGraph {
-    let database: Database
     let manager: ConnectionManager
     let syncEngine: SyncEngine
-    let store: DocumentStore?
   }
 
   @ObservationIgnored private var registered: UIGraph?
@@ -60,15 +61,13 @@ public final class BackgroundSyncCoordinator {
   /// shell whenever the graph (re)wires itself — repeat calls just refresh the
   /// references. Cancels-and-awaits any in-flight headless run first, so two
   /// stacks never execute concurrently.
-  public func register(
-    database: Database, manager: ConnectionManager, syncEngine: SyncEngine, store: DocumentStore?
-  ) async {
+  public func register(manager: ConnectionManager, syncEngine: SyncEngine) async {
     if let headlessTask {
       Logger.sync.info("UI graph registering; cancelling in-flight headless background sync")
       headlessTask.cancel()
       _ = await headlessTask.value
     }
-    registered = UIGraph(database: database, manager: manager, syncEngine: syncEngine, store: store)
+    registered = UIGraph(manager: manager, syncEngine: syncEngine)
   }
 
   public func unregister() {
@@ -109,23 +108,19 @@ public final class BackgroundSyncCoordinator {
     Logger.sync.info(
       "Background run (tier: \(String(describing: tier), privacy: .public), registered graph, isExpensive: \(cost.isExpensive), isConstrained: \(cost.isConstrained))"
     )
-    // Active server first, via its own store (mirrors the foreground order);
-    // `sync()` fire-and-forgets a reconcile, so the explicit call either runs
-    // it or joins-by-throttle — the trailing engine sweep gives it time either
-    // way.
-    if let store = graph.store {
-      try? await store.sync()
-      await store.reconcileDocuments()
-      if tier == .full {
-        let condition = SyncCondition(
-          isExpensive: cost.isExpensive, isConstrained: cost.isConstrained,
-          syncOverCellular: graph.manager.activeSyncOverCellular)
-        await store.runProactiveFill(unmetered: condition.allowsProactiveSync)
-      }
-    }
+    // One sweep over every server, active included. The hand-rolled
+    // active-server pass that used to lead this — `store.sync()`, then an
+    // explicit `reconcileDocuments()`, then a fill gated on the *active*
+    // server's cellular setting — existed only because the store owned the
+    // active server's repository and the engine was forbidden from touching
+    // it. It was a third copy of the sync sequence, with its own ordering and
+    // its own gate. Now the engine reaches that server through the very session
+    // the store uses, `SyncPlan` applies each server's own cellular setting,
+    // and stalest-first ordering puts the servers that actually need the run
+    // ahead of the one already on screen.
     await graph.syncEngine.syncServers(
-      scope: .excludingActive(graph.manager.activeConnectionId),
-      tier: tier, isExpensive: cost.isExpensive, isConstrained: cost.isConstrained)
+      scope: .all, tier: tier, isExpensive: cost.isExpensive,
+      isConstrained: cost.isConstrained)
     let completed = !Task.isCancelled
     Logger.sync.info("Background run finished (completed: \(completed))")
     return completed

--- a/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
+++ b/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
@@ -2,7 +2,7 @@
 //  BackgroundSyncCoordinator.swift
 //  AppShared
 //
-//  Stage 11 (background sync): the bridge between the app shell's BGTask
+//  Background sync: the bridge between the app shell's BGTask
 //  handlers (app target only — AppShared stays extension-safe and never
 //  imports BackgroundTasks) and the sync machinery.
 //

--- a/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
+++ b/AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift
@@ -35,8 +35,14 @@ import Persistence
 import os
 
 @MainActor
+@Observable
 public final class BackgroundSyncCoordinator {
   public static let shared = BackgroundSyncCoordinator()
+
+  /// Whether a background-task-driven run is currently executing — surfaced on
+  /// the Offline & Sync screen (visible when the user foregrounds the app while
+  /// a run is still in flight).
+  public private(set) var isRunning = false
 
   private struct UIGraph {
     let database: Database
@@ -45,8 +51,8 @@ public final class BackgroundSyncCoordinator {
     let store: DocumentStore?
   }
 
-  private var registered: UIGraph?
-  private var headlessTask: Task<Bool, Never>?
+  @ObservationIgnored private var registered: UIGraph?
+  @ObservationIgnored private var headlessTask: Task<Bool, Never>?
 
   private init() {}
 
@@ -94,6 +100,8 @@ public final class BackgroundSyncCoordinator {
   // MARK: - Execution
 
   private func run(tier: SyncEngine.SyncTier) async -> Bool {
+    isRunning = true
+    defer { isRunning = false }
     let cost = await NetworkPathProbe.currentCost()
     guard let graph = registered else {
       return await runHeadless(tier: tier, cost: cost)

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -61,7 +61,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// resource the user lacks permission for is skipped, not fatal.
   func syncElements(progress: SyncProgressReporter?) async throws
 
-  /// Eager full-fill of a document list (Stage 8 v1): await page 1 (so the first
+  /// Eager full-fill of a document list: await page 1 (so the first
   /// window + an exact count land synchronously), write it as the query's order,
   /// then background-page the rest of the query to the cache. The returned
   /// ``QueryFillHandle`` carries the `QueryKey` the list observes and a cancel
@@ -75,7 +75,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// cap; until users ask for it, every opened view eager-fills in full.
   func fillQuery(filter: FilterState) async throws -> QueryFillHandle
 
-  /// Proactive one-time coverage fill (Stage 9, *Entire library*): page the
+  /// Proactive one-time coverage fill (*Entire library*): page the
   /// default list and every saved view, stamping rows `.full`, so the whole
   /// active-server library browses offline even if never opened. Sequential
   /// (one query's background paging completes before the next starts). Guarded by
@@ -86,7 +86,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// failed advances nothing, so it retries.
   func fillLibrary(force: Bool, progress: SyncProgressReporter?) async throws
 
-  /// Proactive per-document detail fill (Stage 9, *Entire library*): give every
+  /// Proactive per-document detail fill (*Entire library*): give every
   /// cached document its notes and file-metadata so it's fully renderable
   /// offline even if never opened. Zero-note documents are seeded from the
   /// list payload's notes *count* for free (no request); only documents that
@@ -345,7 +345,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         }
 
         // Background-page the rest to disk (append). When this completes the
-        // whole view is local; scrolling then needs no network (v1).
+        // whole view is local; scrolling then needs no network.
         while true {
           // Cancellation ends the fill as an error, not as a quiet `break`.
           // The key is truncated either way, and a silent stop is exactly how

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -286,6 +286,11 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           SyncActivity(stage: .elementSync, completed: completed, total: total))
       }
     }
+
+    // The persisted "fresh as of last successful sync" stamp — the one choke
+    // point covering both the store path and the engine path. Drives
+    // stalest-first background sweep ordering and the Offline & Sync screen.
+    try? database.setLastSyncAt(Date(), serverID: serverID)
   }
 
   /// Fill a query's membership + document rows from the list source, which always

--- a/AppShared/Sources/AppShared/Networking/Error/RequestError+DisplayableError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/RequestError+DisplayableError.swift
@@ -69,6 +69,9 @@ extension RequestError: DisplayableError {
     case .certificate(let detail):
       raw = String(localized: .app(.requestErrorCertificate)) + " " + detail
 
+    case .connectivity(_, let detail):
+      raw = detail
+
     case .other(let detail):
       raw = detail
     }

--- a/AppShared/Sources/AppShared/Networking/Error/RequestError+DisplayableError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/RequestError+DisplayableError.swift
@@ -69,15 +69,25 @@ extension RequestError: DisplayableError {
     case .certificate(let detail):
       raw = String(localized: .app(.requestErrorCertificate)) + " " + detail
 
-    case .connectivity(_, let detail):
-      raw = detail
+    case .connectivity(let code, let detail):
+      // The system's message ("Could not connect to the server.") says what
+      // happened but not what to do about it, and the causes are wildly
+      // different — a stopped server, a typo in the URL, a VPN that dropped.
+      // Spell them out.
+      raw = detail + "\n\n" + Self.connectivityHint(for: code)
 
     case .other(let detail):
       raw = detail
     }
 
-    // Single source strings that might contain markdown markup: use AttributedString to remove them
-    if let str = try? AttributedString(markdown: raw) {
+    // Single source strings that might contain markdown markup: use AttributedString to remove them.
+    // `inlineOnlyPreservingWhitespace` because the default block parse discards
+    // line breaks, which would run a multi-paragraph detail together into one
+    // sentence ("...the server.The server could not be reached...").
+    if let str = try? AttributedString(
+      markdown: raw,
+      options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+    {
       return String(str.characters)
     }
     return raw
@@ -98,6 +108,27 @@ extension RequestError: DisplayableError {
       DocumentationLinks.certificate
     default:
       nil
+    }
+  }
+
+  /// What a transport failure is likely to mean, in terms the user can act on.
+  ///
+  /// The `NSURLError` code is the only thing that distinguishes these cases —
+  /// which is why the repository carries it through rather than flattening the
+  /// failure into a message.
+  public static func connectivityHint(for code: NSURLError) -> String {
+    switch code {
+    case .notConnectedToInternet, .dataNotAllowed, .internationalRoamingOff, .callIsActive:
+      String(localized: .app(.requestErrorConnectivityHintOffline))
+
+    case .cannotFindHost, .dnsLookupFailed, .badURL, .unsupportedURL,
+      .redirectToNonExistentLocation:
+      String(localized: .app(.requestErrorConnectivityHintHostNotFound))
+
+    // Connection refused, timed out, dropped mid-flight, ...: we reached the
+    // network but not a working server at the other end.
+    default:
+      String(localized: .app(.requestErrorConnectivityHintUnreachable))
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/Error/RequestError+PresentableError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/RequestError+PresentableError.swift
@@ -68,9 +68,10 @@ extension RequestError: PresentableError {
       Text(.app(.requestErrorDetailLabel)) + Text(": ")
         + (Text(detail).italic())
 
-    case .connectivity(_, let detail):
+    case .connectivity(let code, let detail):
       Text(detail)
         .bold()
+      Text(Self.connectivityHint(for: code))
 
     case .other(let detail):
       Text(detail)

--- a/AppShared/Sources/AppShared/Networking/Error/RequestError+PresentableError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/RequestError+PresentableError.swift
@@ -68,6 +68,10 @@ extension RequestError: PresentableError {
       Text(.app(.requestErrorDetailLabel)) + Text(": ")
         + (Text(detail).italic())
 
+    case .connectivity(_, let detail):
+      Text(detail)
+        .bold()
+
     case .other(let detail):
       Text(detail)
         .bold()

--- a/AppShared/Sources/AppShared/Networking/NetworkPathProbe.swift
+++ b/AppShared/Sources/AppShared/Networking/NetworkPathProbe.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkPathProbe.swift
+//  AppShared
+//
+//  One-shot network-path cost check for background runs. The long-lived
+//  `NetworkMonitor` is part of the UI object graph and may not exist (or may
+//  not have received a path update yet) when a background task fires in a
+//  cold-launched process, so the coordinator probes the current path directly.
+//
+
+import Foundation
+import Network
+
+public enum NetworkPathProbe {
+  /// The current path's raw cost — `isExpensive`/`isConstrained`, the same
+  /// signal `NetworkMonitor` exposes. Callers combine this with a specific
+  /// server's `syncOverCellular` opt-in via `SyncCondition`; this type makes
+  /// no gating decision itself. Waits for the throwaway monitor's first path
+  /// callback; an unknown path (timeout) reads as both expensive *and*
+  /// constrained, so a heavy fill is conservatively skipped regardless of any
+  /// server's opt-in rather than risked on an unread link.
+  public static func currentCost(timeout: Duration = .seconds(2)) async -> (
+    isExpensive: Bool, isConstrained: Bool
+  ) {
+    let monitor = NWPathMonitor()
+    defer { monitor.cancel() }
+    typealias Cost = (isExpensive: Bool, isConstrained: Bool)
+    let verdicts = AsyncStream<Cost> { continuation in
+      monitor.pathUpdateHandler = { path in
+        continuation.yield((path.isExpensive, path.isConstrained))
+        continuation.finish()
+      }
+    }
+    monitor.start(queue: DispatchQueue(label: "NetworkPathProbe"))
+    return await withTaskGroup(of: Cost.self) { group in
+      group.addTask { await verdicts.first { _ in true } ?? (true, true) }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return (true, true)
+      }
+      let first = await group.next() ?? (true, true)
+      group.cancelAll()
+      return first
+    }
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -121,14 +121,33 @@ public final class ServerSession {
   /// (much longer) throttle before asking.
   @ObservationIgnored private let reconcileThrottle: TimeInterval = 300
 
-  /// Where a running phase reports progress, installed by the store that is
-  /// showing this server. An inactive server leaves it `nil` and reports
-  /// nothing — exactly what the engine's sweeps did when it ran them itself.
-  @ObservationIgnored
-  public var progress: (@MainActor (SyncActivity?, SyncActivity.Stage) -> Void)?
+  /// Every sync stage running right now *for this server*, in a fixed order;
+  /// empty when idle. The Offline & Sync screen renders the active server's,
+  /// through its store.
+  ///
+  /// A list rather than one "current" stage because they genuinely overlap: the
+  /// store's `sync()` starts the reconcile in its own task and returns, so a
+  /// reconcile is usually still running when the library fill begins. Publishing
+  /// one of them meant whichever finished first blanked the screen to "Idle"
+  /// while the other carried on — and, because progress is reported coarsely, it
+  /// stayed blank until the survivor reached its next checkpoint.
+  ///
+  /// Living on the session rather than the store is what makes an *inactive*
+  /// server's progress observable at all: the engine's sweeps used to report
+  /// nowhere, because the only reporter belonged to the active server's store.
+  public private(set) var syncActivities: [SyncActivity] = []
 
+  // One entry per sweep currently running. Keyed by stage because each sweep
+  // owns exactly one, and because a sweep reporting "done" says only *that* —
+  // it can't say which stage it was, so the key has to come from the call site.
+  @ObservationIgnored
+  private var activeStages: [SyncActivity.Stage: SyncActivity] = [:]
+
+  /// Fold one sweep's progress into the published activity. `nil` retires the
+  /// stage; the list keeps showing whatever else is still running.
   private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
-    progress?(activity, stage)
+    activeStages[stage] = activity
+    syncActivities = activeStages.values.sortedForDisplay
   }
 
   public init(

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -413,6 +413,15 @@ public final class ServerSession {
     return completed
   }
 
+  /// Stop the in-flight proactive fill, if any — e.g. the caller is about to
+  /// reclaim cache the fill would otherwise keep writing back into (leaving
+  /// *Entire library* on this server). A no-op when nothing is running; the
+  /// task's own `Task.checkCancellation()` checkpoints (per saved view in
+  /// `fillLibrary`, per document in `fillDocumentDetails`) do the rest.
+  public func cancelProactiveFill() {
+    proactiveFillTask?.cancel()
+  }
+
   private func runFill(backend: any CachingBackend, force: Bool) async -> Bool {
     var completed = true
     do {

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -61,6 +61,14 @@ public final class ServerSession {
   /// `Connection` is kept alongside and compared on each use: a changed URL,
   /// token, identity or extra header rebuilds the stack. (`Connection` is
   /// `Equatable` over exactly the fields `makeCachingRepository` consumes.)
+  ///
+  /// This comparison is load-bearing for re-auth, and only works because
+  /// `StoredConnection.token` reads the Keychain *live* on every access: a
+  /// re-auth writes the new token to the Keychain without changing the
+  /// `StoredConnection` record at all, so a session that compared records rather
+  /// than `Connection`s would keep serving the rejected token forever. The same
+  /// holds for `ConnectionsView.updateExtraHeaders`, which edits headers in
+  /// place.
   @ObservationIgnored private var built:
     (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
 

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -96,8 +96,7 @@ public final class ServerSession {
   @ObservationIgnored private var syncTask: Task<Void, Never>?
   @ObservationIgnored private var elementSyncTask: Task<Void, Error>?
   @ObservationIgnored private var reconcileTask: Task<ReconcileResult, Never>?
-  @ObservationIgnored private var libraryFillTask: Task<Bool, Never>?
-  @ObservationIgnored private var detailFillTask: Task<Bool, Never>?
+  @ObservationIgnored private var proactiveFillTask: Task<Bool, Never>?
 
   public private(set) var state: State = .idle
 
@@ -173,8 +172,7 @@ public final class ServerSession {
     syncTask?.cancel()
     elementSyncTask?.cancel()
     reconcileTask?.cancel()
-    libraryFillTask?.cancel()
-    detailFillTask?.cancel()
+    proactiveFillTask?.cancel()
   }
 
   // MARK: - Repository access
@@ -234,10 +232,8 @@ public final class ServerSession {
     elementSyncTask = nil
     reconcileTask?.cancel()
     reconcileTask = nil
-    libraryFillTask?.cancel()
-    libraryFillTask = nil
-    detailFillTask?.cancel()
-    detailFillTask = nil
+    proactiveFillTask?.cancel()
+    proactiveFillTask = nil
     built = nil
     state = .idle
   }
@@ -376,75 +372,76 @@ public final class ServerSession {
   }
 
   /// Proactive *Entire library* fill, gated by the setting and an unmetered
-  /// link. Soft-fail (offline-tolerant). `force` ignores the freshness marker
-  /// (e.g. the user just enabled the setting).
+  /// link: the library fill (paging every query), then the per-document detail
+  /// fill (notes + file metadata) over whatever the library fill just landed on
+  /// disk. Soft-fail (offline-tolerant). `force` ignores the library fill's
+  /// freshness marker (e.g. the user just enabled the setting); the detail fill
+  /// needs no `force` of its own — it is idempotent and resumable, driven off
+  /// what is still missing.
+  ///
+  /// Single-flighted as *one unit* rather than per stage. Guarding the two
+  /// separately let a second caller start a fresh library fill while the first
+  /// was still in its detail pass, so two passes over "what's still missing"
+  /// each reported their own completed/total into the same stage — read on
+  /// screen as the progress count flickering between two unrelated series.
+  /// There are five triggers that reach the same server: launch, foreground,
+  /// the mode picker, "Sync now", and a background run.
   ///
   /// Returns whether the pass finished — `true` also when there was legitimately
   /// nothing to do, `false` only when it errored or was called off. The composed
   /// sequence needs that distinction to decide whether the server is fully
   /// synced; the store's callers discard it.
   @discardableResult
-  public func fillLibrary(unmetered: Bool, force: Bool = false) async -> Bool {
+  public func runProactiveFill(unmetered: Bool, force: Bool = false) async -> Bool {
     guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
     else { return true }
 
-    // Join an in-flight fill rather than starting a second pass over the same
+    // Join an in-flight pass rather than starting a second one over the same
     // queries. `force` is not lost by joining: a fill only runs at all when the
     // coverage marker is stale or forced, so one is already doing the work.
-    if let libraryFillTask {
-      return await libraryFillTask.value
+    if let proactiveFillTask {
+      return await proactiveFillTask.value
     }
     let task = Task { @MainActor [weak self] in
-      do {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillLibrary(force: force) { self?.report($0, for: .libraryFill) }
-        }
-        return true
-      } catch is CancellationError {
-        Logger.sync.info("Proactive library fill cancelled")
-        return false
-      } catch {
-        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
-        return false
-      }
+      await self?.runFill(backend: backend, force: force) ?? false
     }
-    libraryFillTask = task
+    proactiveFillTask = task
     let completed = await task.value
-    if libraryFillTask == task {
-      libraryFillTask = nil
+    if proactiveFillTask == task {
+      proactiveFillTask = nil
     }
     return completed
   }
 
-  /// Proactive *Entire library* per-document detail fill (notes + file
-  /// metadata). Run after ``fillLibrary(unmetered:force:)`` so the document rows
-  /// to walk are already on disk. Idempotent and resumable (driven off what's
-  /// still missing), so it needs no `force`. Soft-fail.
-  @discardableResult
-  public func fillDocumentDetails(unmetered: Bool) async -> Bool {
-    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
-    else { return true }
-    if let detailFillTask {
-      return await detailFillTask.value
-    }
-    let task = Task { @MainActor [weak self] in
-      do {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillDocumentDetails { self?.report($0, for: .detailFill) }
+  private func runFill(backend: any CachingBackend, force: Bool) async -> Bool {
+    var completed = true
+    do {
+      try await NetworkTransfer.$category.withValue(.fill) {
+        try await backend.fillLibrary(force: force) { [weak self] in
+          self?.report($0, for: .libraryFill)
         }
-        return true
-      } catch is CancellationError {
-        Logger.sync.info("Proactive detail fill cancelled")
-        return false
-      } catch {
-        Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
-        return false
       }
+    } catch is CancellationError {
+      // Cancellation means the whole pass is unwanted — don't chase it with a
+      // detail fill against a backend nobody is waiting on any more.
+      Logger.sync.info("Proactive fill cancelled")
+      return false
+    } catch {
+      Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
+      completed = false
     }
-    detailFillTask = task
-    let completed = await task.value
-    if detailFillTask == task {
-      detailFillTask = nil
+    do {
+      try await NetworkTransfer.$category.withValue(.fill) {
+        try await backend.fillDocumentDetails { [weak self] in
+          self?.report($0, for: .detailFill)
+        }
+      }
+    } catch is CancellationError {
+      Logger.sync.info("Proactive detail fill cancelled")
+      return false
+    } catch {
+      Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
+      completed = false
     }
     return completed
   }
@@ -507,8 +504,7 @@ public final class ServerSession {
       // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
       var filled = true
       if runHeavyFill, !reconcile.cancelled {
-        filled = await fillLibrary(unmetered: true, force: false)
-        filled = await fillDocumentDetails(unmetered: true) && filled
+        filled = await runProactiveFill(unmetered: true, force: false)
       }
 
       // Advance the stamp only on a *fully* successful pass — a pass that failed

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -84,9 +84,20 @@ public final class ServerSession {
   @ObservationIgnored private var built:
     (connection: Connection, repository: any Repository & CachingBackend)?
 
-  /// In-flight sync, so concurrent callers coalesce onto one pass rather than
-  /// running a second one against the same server.
+  // In-flight work, one single-flight per phase.
+  //
+  // Per *phase* rather than one per session, because the two callers want
+  // different things: the store drives phases individually (pull-to-refresh
+  // wants the element sync back, not a full server sweep), while the scheduler
+  // runs the composed sequence. Sharing the per-phase tasks is what lets both
+  // callers hit the same session concurrently and coalesce — which in turn is
+  // what let the engine's "skip the active server" guard go away, since there
+  // is no longer a second owner to stay out of the way of.
   @ObservationIgnored private var syncTask: Task<Void, Never>?
+  @ObservationIgnored private var elementSyncTask: Task<Void, Error>?
+  @ObservationIgnored private var reconcileTask: Task<ReconcileResult, Never>?
+  @ObservationIgnored private var libraryFillTask: Task<Bool, Never>?
+  @ObservationIgnored private var detailFillTask: Task<Bool, Never>?
 
   public private(set) var state: State = .idle
 
@@ -94,6 +105,31 @@ public final class ServerSession {
   /// on a clean pass, so an interrupted or partially-failed one retries on the
   /// next trigger rather than being throttled away.
   public private(set) var lastSuccessfulSync: Date?
+
+  /// When the reconcile last *ran*. Advances on every attempt, deliberately —
+  /// it gates the sub-throttle below, and a server that fails every sweep must
+  /// not refetch its whole live id set on each of the seventeen on-appear
+  /// triggers. Distinct from ``lastReconcileSuccess`` for exactly that reason.
+  @ObservationIgnored private var lastReconcileAttempt: Date?
+
+  /// When the reconcile last refreshed *something*. The user-facing "last
+  /// refreshed" stamp the Offline & Sync screen renders, so it is observed.
+  public private(set) var lastReconcileSuccess: Date?
+
+  /// Keeps the active server's on-appear triggers off the wire. Bypassed by
+  /// pull-to-refresh and by the scheduler, which has already applied its own
+  /// (much longer) throttle before asking.
+  @ObservationIgnored private let reconcileThrottle: TimeInterval = 300
+
+  /// Where a running phase reports progress, installed by the store that is
+  /// showing this server. An inactive server leaves it `nil` and reports
+  /// nothing — exactly what the engine's sweeps did when it ran them itself.
+  @ObservationIgnored
+  public var progress: (@MainActor (SyncActivity?, SyncActivity.Stage) -> Void)?
+
+  private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
+    progress?(activity, stage)
+  }
 
   public init(
     serverID: UUID,
@@ -116,6 +152,10 @@ public final class ServerSession {
 
   deinit {
     syncTask?.cancel()
+    elementSyncTask?.cancel()
+    reconcileTask?.cancel()
+    libraryFillTask?.cancel()
+    detailFillTask?.cancel()
   }
 
   // MARK: - Repository access
@@ -171,13 +211,228 @@ public final class ServerSession {
   public func invalidate() {
     syncTask?.cancel()
     syncTask = nil
+    elementSyncTask?.cancel()
+    elementSyncTask = nil
+    reconcileTask?.cancel()
+    reconcileTask = nil
+    libraryFillTask?.cancel()
+    libraryFillTask = nil
+    detailFillTask?.cancel()
+    detailFillTask = nil
     built = nil
     state = .idle
   }
 
-  // MARK: - Sync
+  // MARK: - Phases
 
-  /// Run (or join) this server's sync pass.
+  /// Run (or join) this server's element sync.
+  ///
+  /// Unthrottled by design: every on-appear trigger expects this to reach the
+  /// network, and the single-flight — not a timer — is what keeps the launch
+  /// flurry to one pass. Rethrows to *every* joined caller, so a user-initiated
+  /// pull-to-refresh that lands on an in-flight background sync still sees the
+  /// failure it needs to toast.
+  public func syncElements() async throws {
+    if let elementSyncTask {
+      Logger.sync.debug("Joining in-flight element sync")
+      return try await elementSyncTask.value
+    }
+    guard let backend = current else {
+      // No repository yet (e.g. a store still on `NullRepository` before login).
+      Logger.sync.info("Element sync skipped: session has no repository")
+      return
+    }
+    Logger.sync.debug("Starting element sync")
+    let task = Task { [weak self] in
+      try await NetworkTransfer.$category.withValue(.sync) {
+        try await backend.syncElements { self?.report($0, for: .elementSync) }
+      }
+    }
+    elementSyncTask = task
+    defer {
+      // Retract only our own task: a replacement may already own the slot by the
+      // time we resume, and clearing it blindly would break its coalescing.
+      if elementSyncTask == task {
+        elementSyncTask = nil
+      }
+    }
+    try await task.value
+  }
+
+  /// What one reconcile pass achieved.
+  ///
+  /// Two stamps ask two different questions of the same pass — the scheduler
+  /// wants "fully clean" before it advances a throttle that could hide a broken
+  /// server for fifteen minutes; the Offline & Sync screen wants "did anything
+  /// refresh", because one flaky sweep shouldn't erase the two that worked. One
+  /// pass, both answers.
+  public struct ReconcileResult: Sendable {
+    public var succeeded = 0
+    public var failed = false
+    public var cancelled = false
+
+    /// Neither failed nor called off. Only a clean pass advances the scheduler's
+    /// freshness stamp.
+    public var isClean: Bool { !failed && !cancelled }
+  }
+
+  /// Throttled remote-delete reconcile: drop cached documents that no longer
+  /// exist on the server, fold in the changed-metadata delta, then rebuild
+  /// saved-view membership. Soft-fail throughout. `force` bypasses the 300 s
+  /// sub-throttle.
+  @discardableResult
+  public func reconcileDocuments(force: Bool = false) async -> ReconcileResult {
+    if let reconcileTask {
+      return await reconcileTask.value
+    }
+    guard let backend = current else { return ReconcileResult() }
+    if !force, let last = lastReconcileAttempt,
+      Date().timeIntervalSince(last) < reconcileThrottle
+    {
+      return ReconcileResult()
+    }
+    lastReconcileAttempt = Date()
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return ReconcileResult() }
+      return await runReconcile(backend: backend)
+    }
+    reconcileTask = task
+    let result = await task.value
+    if reconcileTask == task {
+      reconcileTask = nil
+    }
+    return result
+  }
+
+  private func runReconcile(backend: any CachingBackend) async -> ReconcileResult {
+    report(SyncActivity(stage: .reconcile), for: .reconcile)
+    defer { report(nil, for: .reconcile) }
+
+    // Each sweep carries its own catch. The delete sweep is the most
+    // failure-prone of the three — it fetches the server's entire live id set —
+    // and under one shared `do` its failure took the freshness delta *and* the
+    // membership rebuild down with it, so a single flaky request cost the whole
+    // reconcile. Cancellation is the exception: it means the pass as a whole is
+    // unwanted, so it stops the remaining sweeps instead of being stepped over.
+    var result = ReconcileResult()
+    func sweep(_ label: String, _ body: () async throws -> Void) async {
+      guard !result.cancelled else { return }
+      do {
+        try await body()
+        result.succeeded += 1
+      } catch {
+        guard !error.isCancellationError else {
+          Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+          result.cancelled = true
+          return
+        }
+        Logger.sync.info(
+          "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+        result.failed = true
+      }
+    }
+
+    // Deletes first (correctness), then the changed-metadata delta (freshness),
+    // then the saved-view membership sweep (so newly-matched docs — now landed
+    // at detail by the delta — appear in every offline list). The last two are
+    // no-ops unless *Entire library* is enabled.
+    await NetworkTransfer.$category.withValue(.reconcile) {
+      await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+      await sweep("changes") {
+        try await backend.reconcileDocumentChanges { [weak self] in
+          // The delta finishing doesn't end the reconcile — the membership
+          // sweep runs after it — so fall back to the bare stage.
+          self?.report($0 ?? SyncActivity(stage: .reconcile), for: .reconcile)
+        }
+      }
+      await sweep("membership") { try await backend.reconcileSavedViewMembership() }
+    }
+
+    // A pass in which *something* refreshed counts. A cancelled pass stamps
+    // nothing — it didn't finish, it was called off.
+    if result.succeeded > 0, !result.cancelled {
+      lastReconcileSuccess = Date()
+    }
+    return result
+  }
+
+  /// Proactive *Entire library* fill, gated by the setting and an unmetered
+  /// link. Soft-fail (offline-tolerant). `force` ignores the freshness marker
+  /// (e.g. the user just enabled the setting).
+  ///
+  /// Returns whether the pass finished — `true` also when there was legitimately
+  /// nothing to do, `false` only when it errored or was called off. The composed
+  /// sequence needs that distinction to decide whether the server is fully
+  /// synced; the store's callers discard it.
+  @discardableResult
+  public func fillLibrary(unmetered: Bool, force: Bool = false) async -> Bool {
+    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+    else { return true }
+
+    // Join an in-flight fill rather than starting a second pass over the same
+    // queries. `force` is not lost by joining: a fill only runs at all when the
+    // coverage marker is stale or forced, so one is already doing the work.
+    if let libraryFillTask {
+      return await libraryFillTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      do {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillLibrary(force: force) { self?.report($0, for: .libraryFill) }
+        }
+        return true
+      } catch is CancellationError {
+        Logger.sync.info("Proactive library fill cancelled")
+        return false
+      } catch {
+        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
+        return false
+      }
+    }
+    libraryFillTask = task
+    let completed = await task.value
+    if libraryFillTask == task {
+      libraryFillTask = nil
+    }
+    return completed
+  }
+
+  /// Proactive *Entire library* per-document detail fill (notes + file
+  /// metadata). Run after ``fillLibrary(unmetered:force:)`` so the document rows
+  /// to walk are already on disk. Idempotent and resumable (driven off what's
+  /// still missing), so it needs no `force`. Soft-fail.
+  @discardableResult
+  public func fillDocumentDetails(unmetered: Bool) async -> Bool {
+    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+    else { return true }
+    if let detailFillTask {
+      return await detailFillTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      do {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillDocumentDetails { self?.report($0, for: .detailFill) }
+        }
+        return true
+      } catch is CancellationError {
+        Logger.sync.info("Proactive detail fill cancelled")
+        return false
+      } catch {
+        Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
+        return false
+      }
+    }
+    detailFillTask = task
+    let completed = await task.value
+    if detailFillTask == task {
+      detailFillTask = nil
+    }
+    return completed
+  }
+
+  // MARK: - Composed sequence
+
+  /// Run (or join) this server's full sync pass.
   ///
   /// The sequence is the one the active path has always run — element sync, the
   /// three reconcile sweeps, then the proactive fills — and is now the only copy
@@ -218,55 +473,28 @@ public final class ServerSession {
     Logger.sync.info(
       "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
     do {
-      let backend = try await prepareRepository(for: stored)
+      _ = try await prepareRepository(for: stored)
       state = .ready
 
       // Cheap tier (always, regardless of metered-ness): element sync + the
       // reconcile sweeps (the last two self-gate on *Entire library*).
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements()
-      }
+      try await syncElements()
 
-      // Each reconcile sweep carries its own catch: the deletion sweep is the
-      // most failure-prone of the three — it fetches the server's entire live id
-      // set — and under one shared `try` its failure took the freshness delta,
-      // the membership rebuild *and* the heavy fill down with it. Cancellation is
-      // the exception: it means the pass as a whole is unwanted, so it stops the
-      // remaining sweeps instead of being logged and stepped over.
-      var failed = false
-      var cancelled = false
-      func sweep(_ label: String, _ body: () async throws -> Void) async {
-        guard !cancelled else { return }
-        do {
-          try await body()
-        } catch {
-          guard !error.isCancellationError else {
-            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-            cancelled = true
-            return
-          }
-          Logger.sync.info(
-            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-          failed = true
-        }
-      }
-      await NetworkTransfer.$category.withValue(.reconcile) {
-        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-        await sweep("changes") { try await backend.reconcileDocumentChanges() }
-        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-      }
+      // The scheduler applied its own, much longer throttle before asking, so
+      // the reconcile's 300 s sub-throttle — which exists to keep the *active*
+      // server's on-appear flurry off the wire — must not veto this pass.
+      let reconcile = await reconcileDocuments(force: true)
 
       // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
-      if runHeavyFill, !cancelled {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillLibrary(force: false)
-          try await backend.fillDocumentDetails()
-        }
+      var filled = true
+      if runHeavyFill, !reconcile.cancelled {
+        filled = await fillLibrary(unmetered: true, force: false)
+        filled = await fillDocumentDetails(unmetered: true) && filled
       }
 
       // Advance the stamp only on a *fully* successful pass — a pass that failed
       // or was called off partway retries on the next trigger.
-      guard !failed, !cancelled else {
+      guard reconcile.isClean, filled else {
         Logger.sync.info(
           "Server \(stored.logLabel, privacy: .public) partially synced; stamp not advanced")
         return

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -1,0 +1,235 @@
+//
+//  ServerSession.swift
+//  AppShared
+//
+//  One configured server's networking life: its `CachingRepository`, its
+//  in-flight sync, and the freshness stamp the scheduler throttles on.
+//
+//  This type exists to make the invariant **"at most one `CachingRepository`
+//  per server executes at any time"** structural. Previously that was upheld by
+//  convention: `DocumentStore` drove the active server, `SyncEngine` swept the
+//  rest and skipped `activeConnectionId` to stay out of its way. Two independent
+//  owners, coordinating through a key that mutates underneath them — which is
+//  exactly how a server that went active mid-sweep could end up driven twice.
+//  With one session per server, the coordination scope (`CachingRepository`'s
+//  per-instance `activeFills`) and the ownership scope finally coincide.
+//
+//  The session is an imperative shell only. Every *decision* — which servers to
+//  sync, in what order, whether the throttle has elapsed, whether a heavy fill
+//  is allowed on this link — stays in the pure, unit-tested `DataModel.SyncPlan`,
+//  because `AppShared` has no test target and anything moved in here stops being
+//  covered.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+@Observable
+public final class ServerSession {
+  /// Where this server stands. `needsAuth` is a *state*, not a branch in the
+  /// scheduler: a config-synced-but-uncredentialed server is a normal session
+  /// that simply has nothing it can do yet, and picks up the moment a token
+  /// lands.
+  public enum State: Equatable, Sendable {
+    /// No repository built yet (nothing has asked this server to do anything).
+    case idle
+    /// Repository built; the server is usable.
+    case ready
+    /// No usable credential. No network call is attempted.
+    case needsAuth
+    /// The last attempt failed (offline, rejected token, …). Retried on the
+    /// next trigger; the stamp is not advanced, so the throttle won't hide it.
+    case failed
+  }
+
+  public let serverID: UUID
+
+  @ObservationIgnored private let database: Database
+  @ObservationIgnored private let manager: ConnectionManager
+  @ObservationIgnored private let mode: ApiRepository.Mode
+
+  /// The retained stack, together with the `Connection` it was assembled from.
+  ///
+  /// Retaining it is the point — a long-lived repository is what lets
+  /// `activeFills` dedupe across sweeps instead of only within one. But the
+  /// per-sweep rebuild it replaces picked up connection edits for free, so the
+  /// `Connection` is kept alongside and compared on each use: a changed URL,
+  /// token, identity or extra header rebuilds the stack. (`Connection` is
+  /// `Equatable` over exactly the fields `makeCachingRepository` consumes.)
+  @ObservationIgnored private var built:
+    (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
+
+  /// In-flight sync, so concurrent callers coalesce onto one pass rather than
+  /// running a second one against the same server.
+  @ObservationIgnored private var syncTask: Task<Void, Never>?
+
+  public private(set) var state: State = .idle
+
+  /// Last *fully* successful pass. The scheduler's throttle input; advanced only
+  /// on a clean pass, so an interrupted or partially-failed one retries on the
+  /// next trigger rather than being throttled away.
+  public private(set) var lastSuccessfulSync: Date?
+
+  public init(
+    serverID: UUID,
+    database: Database,
+    manager: ConnectionManager,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+  ) {
+    self.serverID = serverID
+    self.database = database
+    self.manager = manager
+    self.mode = mode
+  }
+
+  deinit {
+    syncTask?.cancel()
+  }
+
+  // MARK: - Repository access
+
+  /// The server's repository, or `nil` before anything has built it.
+  public var repository: (any Repository)? { built?.repository }
+
+  /// The same instance seen as the cache-backed surface the sync sequence and
+  /// the store's projections both drive.
+  public var backend: (any CachingBackend)? { built?.repository }
+
+  /// Build the stack, or hand back the retained one when it still matches
+  /// `stored`. Assembly goes through ``makeCachingRepository`` so every server's
+  /// layering is identical to the app shell's.
+  private func repository(
+    for stored: StoredConnection
+  ) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
+    let connection = try stored.connection
+    if let built, built.connection == connection {
+      return built.repository
+    }
+    if built != nil {
+      Logger.sync.info(
+        "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
+    }
+    let repository = try await makeCachingRepository(
+      for: stored, database: database, manager: manager, mode: mode)
+    built = (connection, repository)
+    return repository
+  }
+
+  /// Drop the retained stack. Used when the server row goes away — the row
+  /// delete FK-cascades the cache, so there is nothing else to clean up.
+  public func invalidate() {
+    syncTask?.cancel()
+    syncTask = nil
+    built = nil
+    state = .idle
+  }
+
+  // MARK: - Sync
+
+  /// Run (or join) this server's sync pass.
+  ///
+  /// The sequence is the one the active path has always run — element sync, the
+  /// three reconcile sweeps, then the proactive fills — and is now the only copy
+  /// of it. Nothing throws out: a per-server failure (offline, a rethrown 401)
+  /// is this server's problem alone and must never affect its siblings.
+  ///
+  /// `runHeavyFill` is `SyncPlan`'s decision, not this type's.
+  public func sync(stored: StoredConnection, runHeavyFill: Bool) async {
+    if let syncTask {
+      return await syncTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await runSync(stored: stored, runHeavyFill: runHeavyFill)
+    }
+    syncTask = task
+    await task.value
+    // Retract only our own task: a swap can retire this pass mid-flight and a
+    // replacement may already own `syncTask` by the time we resume, and clearing
+    // it blindly would break the replacement's coalescing.
+    if syncTask == task {
+      syncTask = nil
+    }
+  }
+
+  /// Degrade to per-server needs-auth without a network call: deterministic and
+  /// cheap, and the next trigger picks the server up once a token lands. The 401
+  /// path stays a backstop for a token the server rejects.
+  public func markNeedsAuth(_ stored: StoredConnection) {
+    Logger.sync.info(
+      "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
+    state = .needsAuth
+    manager.markNeedsAuth(for: serverID)
+  }
+
+  private func runSync(stored: StoredConnection, runHeavyFill: Bool) async {
+    Logger.sync.info(
+      "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
+    do {
+      let backend = try await repository(for: stored)
+      state = .ready
+
+      // Cheap tier (always, regardless of metered-ness): element sync + the
+      // reconcile sweeps (the last two self-gate on *Entire library*).
+      try await NetworkTransfer.$category.withValue(.sync) {
+        try await backend.syncElements()
+      }
+
+      // Each reconcile sweep carries its own catch: the deletion sweep is the
+      // most failure-prone of the three — it fetches the server's entire live id
+      // set — and under one shared `try` its failure took the freshness delta,
+      // the membership rebuild *and* the heavy fill down with it. Cancellation is
+      // the exception: it means the pass as a whole is unwanted, so it stops the
+      // remaining sweeps instead of being logged and stepped over.
+      var failed = false
+      var cancelled = false
+      func sweep(_ label: String, _ body: () async throws -> Void) async {
+        guard !cancelled else { return }
+        do {
+          try await body()
+        } catch {
+          guard !error.isCancellationError else {
+            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+            cancelled = true
+            return
+          }
+          Logger.sync.info(
+            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+          failed = true
+        }
+      }
+      await NetworkTransfer.$category.withValue(.reconcile) {
+        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+        await sweep("changes") { try await backend.reconcileDocumentChanges() }
+        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
+      }
+
+      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
+      if runHeavyFill, !cancelled {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillLibrary(force: false)
+          try await backend.fillDocumentDetails()
+        }
+      }
+
+      // Advance the stamp only on a *fully* successful pass — a pass that failed
+      // or was called off partway retries on the next trigger.
+      guard !failed, !cancelled else {
+        Logger.sync.info(
+          "Server \(stored.logLabel, privacy: .public) partially synced; stamp not advanced")
+        return
+      }
+      lastSuccessfulSync = Date()
+      Logger.sync.info("Server \(stored.logLabel, privacy: .public) synced")
+    } catch {
+      state = .failed
+      Logger.sync.info(
+        "Sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)")
+    }
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -47,13 +47,25 @@ public final class ServerSession {
     case failed
   }
 
+  /// Where this session's repository comes from.
+  private enum Source {
+    /// Production: assembled from the server's stored connection through
+    /// ``makeCachingRepository``, and rebuilt whenever that connection changes.
+    case stored(database: Database, manager: ConnectionManager, mode: ApiRepository.Mode)
+    /// Previews and tests: handed in ready-made, and never rebuilt. This is what
+    /// keeps "every store is driven by a session" true without dragging a
+    /// `ConnectionManager` and a real connection record into a fixture — the
+    /// alternative being a `DocumentStore.init(repository:)` escape hatch that
+    /// would let production code bypass a server's owner too.
+    case fixed(any Repository & CachingBackend)
+  }
+
   public let serverID: UUID
 
-  @ObservationIgnored private let database: Database
-  @ObservationIgnored private let manager: ConnectionManager
-  @ObservationIgnored private let mode: ApiRepository.Mode
+  @ObservationIgnored private let source: Source
 
   /// The retained stack, together with the `Connection` it was assembled from.
+  /// Only ever populated for ``Source/stored``.
   ///
   /// Retaining it is the point — a long-lived repository is what lets
   /// `activeFills` dedupe across sweeps instead of only within one. But the
@@ -70,7 +82,7 @@ public final class ServerSession {
   /// holds for `ConnectionsView.updateExtraHeaders`, which edits headers in
   /// place.
   @ObservationIgnored private var built:
-    (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
+    (connection: Connection, repository: any Repository & CachingBackend)?
 
   /// In-flight sync, so concurrent callers coalesce onto one pass rather than
   /// running a second one against the same server.
@@ -90,9 +102,16 @@ public final class ServerSession {
     mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
   ) {
     self.serverID = serverID
-    self.database = database
-    self.manager = manager
-    self.mode = mode
+    source = .stored(database: database, manager: manager, mode: mode)
+  }
+
+  /// A session around a repository that already exists, for previews and tests.
+  /// It consults no connection record and never rebuilds: the repository it is
+  /// handed is the one it keeps, so it is `.ready` from birth.
+  public init(serverID: UUID, repository: any Repository & CachingBackend) {
+    self.serverID = serverID
+    source = .fixed(repository)
+    state = .ready
   }
 
   deinit {
@@ -101,31 +120,50 @@ public final class ServerSession {
 
   // MARK: - Repository access
 
+  /// The live repository, or `nil` before anything has built it.
+  private var current: (any Repository & CachingBackend)? {
+    switch source {
+    case .fixed(let repository): repository
+    case .stored: built?.repository
+    }
+  }
+
   /// The server's repository, or `nil` before anything has built it.
-  public var repository: (any Repository)? { built?.repository }
+  public var repository: (any Repository)? { current }
 
   /// The same instance seen as the cache-backed surface the sync sequence and
   /// the store's projections both drive.
-  public var backend: (any CachingBackend)? { built?.repository }
+  public var backend: (any CachingBackend)? { current }
 
   /// Build the stack, or hand back the retained one when it still matches
   /// `stored`. Assembly goes through ``makeCachingRepository`` so every server's
   /// layering is identical to the app shell's.
-  private func repository(
+  ///
+  /// Public because activating a store on this server has to *await* the build:
+  /// the store publishes `repository` straight off the session, so a lazy build
+  /// would leave it on `NullRepository` — projection detached — for the first
+  /// render after every switch.
+  @discardableResult
+  public func prepareRepository(
     for stored: StoredConnection
-  ) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
-    let connection = try stored.connection
-    if let built, built.connection == connection {
-      return built.repository
+  ) async throws -> any Repository & CachingBackend {
+    switch source {
+    case .fixed(let repository):
+      return repository
+    case .stored(let database, let manager, let mode):
+      let connection = try stored.connection
+      if let built, built.connection == connection {
+        return built.repository
+      }
+      if built != nil {
+        Logger.sync.info(
+          "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
+      }
+      let repository = try await makeCachingRepository(
+        for: stored, database: database, manager: manager, mode: mode)
+      built = (connection, repository)
+      return repository
     }
-    if built != nil {
-      Logger.sync.info(
-        "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
-    }
-    let repository = try await makeCachingRepository(
-      for: stored, database: database, manager: manager, mode: mode)
-    built = (connection, repository)
-    return repository
   }
 
   /// Drop the retained stack. Used when the server row goes away — the row
@@ -169,6 +207,7 @@ public final class ServerSession {
   /// cheap, and the next trigger picks the server up once a token lands. The 401
   /// path stays a backstop for a token the server rejects.
   public func markNeedsAuth(_ stored: StoredConnection) {
+    guard case .stored(_, let manager, _) = source else { return }
     Logger.sync.info(
       "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
     state = .needsAuth
@@ -179,7 +218,7 @@ public final class ServerSession {
     Logger.sync.info(
       "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
     do {
-      let backend = try await repository(for: stored)
+      let backend = try await prepareRepository(for: stored)
       state = .ready
 
       // Cheap tier (always, regardless of metered-ness): element sync + the

--- a/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
@@ -124,9 +124,17 @@ public final class ServerSessionRegistry {
     return session
   }
 
-  /// Every session's last fully-successful sync, for the scheduler's throttle.
+  /// Every server's last fully-successful sync, for the scheduler's throttle.
   /// Servers that have never completed a pass are absent rather than distant-past.
+  ///
+  /// The persisted `last_sync_at` stamps fill in for sessions that have not run
+  /// this process — a cold launch, or a background wake where nothing has been
+  /// on screen — so sweep ordering stays stalest-first instead of treating every
+  /// server as never-synced. Where both exist the live session wins: it is the
+  /// stricter signal, advanced only on a *fully* successful pass, so a server
+  /// whose fill was interrupted still retries.
   public func lastSuccessfulSyncs() -> [UUID: Date] {
-    sessions.compactMapValues(\.lastSuccessfulSync)
+    let persisted = (try? database.lastSyncAts()) ?? [:]
+    return persisted.merging(sessions.compactMapValues(\.lastSuccessfulSync)) { _, live in live }
   }
 }

--- a/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
@@ -1,0 +1,132 @@
+//
+//  ServerSessionRegistry.swift
+//  AppShared
+//
+//  Owns exactly one ``ServerSession`` per configured server, for the lifetime of
+//  that server's row.
+//
+//  Session *lifetime* and sync *scheduling* are different jobs, and keeping them
+//  in one type is what let `SyncEngine` grow into an owner as well as a
+//  scheduler. The registry answers "which servers exist, and what is each one's
+//  session"; `SyncEngine` answers "which of them should sync now, in what
+//  order". Neither needs the other's state.
+//
+//  The registry is the **sole** observer of `manager.connections` for session
+//  lifecycle. It has to be: it maintains a second map keyed by the same UUIDs,
+//  and two independent observers of the same table would drift apart exactly the
+//  way the previous two repository owners did.
+//
+//  `ConnectionManager` deliberately stays *below* this type — `NeedsAuthRepository`
+//  already depends on it, so a registry-aware `ConnectionManager` would close a
+//  dependency cycle.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+@Observable
+public final class ServerSessionRegistry {
+  @ObservationIgnored private let database: Database
+  @ObservationIgnored private let manager: ConnectionManager
+  @ObservationIgnored private let mode: ApiRepository.Mode
+
+  /// One session per known server. Observable so a screen can show every
+  /// server's state, not just the active one's.
+  public private(set) var sessions: [UUID: ServerSession] = [:]
+
+  /// Server IDs seen at the last observation tick, diffed to spot additions and
+  /// removals.
+  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
+  @ObservationIgnored private var observationTask: Task<Void, Never>?
+
+  /// Called after each observation tick with the current set and the set as it
+  /// was before, so a scheduler can decide what a newly-appeared server deserves.
+  ///
+  /// The registry deliberately does not make that decision itself: whether a new
+  /// server is synced immediately, and whether the active one is excluded, is
+  /// `SyncPlan`'s call, not lifecycle.
+  @ObservationIgnored
+  public var onServersChanged: (@MainActor (_ current: Set<UUID>, _ previous: Set<UUID>) -> Void)?
+
+  public init(
+    database: Database,
+    manager: ConnectionManager,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+  ) {
+    self.database = database
+    self.manager = manager
+    self.mode = mode
+  }
+
+  deinit {
+    observationTask?.cancel()
+  }
+
+  // MARK: - Lifecycle
+
+  /// Begin observing the `server` table (via `manager.connections`, its sole
+  /// projection), creating and dropping sessions as rows come and go.
+  ///
+  /// Wired to the *observation* rather than the "Add server" UI action, so a
+  /// Stage-12 UBKVS `server` upsert flows through the same path for free.
+  public func start() {
+    guard observationTask == nil else { return }
+    // Seed with the current set so the first tick reports no spurious additions;
+    // servers present at launch are handled by the caller's explicit sweep.
+    knownServerIDs = Set(manager.connections.keys)
+    observationTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+          _ = self?.manager.connections.keys
+        } onChange: {
+          continuation.yield()
+          continuation.finish()
+        }
+        self?.handleConnectionsChanged()
+        for await _ in stream { break }
+      }
+    }
+  }
+
+  private func handleConnectionsChanged() {
+    let current = Set(manager.connections.keys)
+    let previous = knownServerIDs
+    // A vanished row has already FK-cascaded its whole cache, so there is no
+    // cache work here — just stop and release the session.
+    for id in previous.subtracting(current) {
+      sessions.removeValue(forKey: id)?.invalidate()
+      Logger.sync.info("Server row removed; dropped its session")
+    }
+    knownServerIDs = current
+    onServersChanged?(current, previous)
+  }
+
+  // MARK: - Access
+
+  /// The server's session, created on first request.
+  ///
+  /// Creation is cheap: a session assembles no repository until something
+  /// actually asks it to sync, so holding one per configured server costs
+  /// nothing for servers that stay idle.
+  public func session(for id: UUID) -> ServerSession {
+    if let existing = sessions[id] {
+      return existing
+    }
+    let session = ServerSession(
+      serverID: id, database: database, manager: manager, mode: mode)
+    sessions[id] = session
+    return session
+  }
+
+  /// Every session's last fully-successful sync, for the scheduler's throttle.
+  /// Servers that have never completed a pass are absent rather than distant-past.
+  public func lastSuccessfulSyncs() -> [UUID: Date] {
+    sessions.compactMapValues(\.lastSuccessfulSync)
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -13,14 +13,21 @@
 //  own their repositories through `ServerSession`, so a sweep that reaches the
 //  active server coalesces onto the session the store is already using.
 //
-//  Scheduling stays on app-lifecycle triggers (launch / foreground /
-//  active-change); true `BGProcessingTask` execution is Stage 11's.
+//  Foreground app-lifecycle triggers (launch / foreground / active-change)
+//  drive `syncInactiveServers`; Stage 11's background tasks drive
+//  `syncServers(scope:tier:...)` through `BackgroundSyncCoordinator` — either
+//  against this same instance (registered UI graph) or a headless twin on a
+//  cold background launch. The engine deliberately stays `@MainActor` (an
+//  earlier note here suggested moving enumeration off-main for background
+//  execution — superseded): the main thread runs normally during background
+//  execution, and the entire downstream stack (`ConnectionManager`,
+//  `CachingRepository`, `CachingBackend`) is main-actor anyway.
 //
 //  This type is now purely the *scheduler*: it decides which servers to sync and
 //  in what order, and hands each one to its ``ServerSession``, which owns that
-//  server's repository and runs the sequence. The interesting decisions (active
-//  exclusion, throttle, uncredentialed degrade, heavy-fill gating, new-server
-//  diff) live in the pure, unit-tested `DataModel.SyncPlan`.
+//  server's repository and runs the sequence. The interesting decisions (scope,
+//  throttle, uncredentialed degrade, heavy-fill gating, stalest-first ordering,
+//  new-server diff) live in the pure, unit-tested `DataModel.SyncPlan`.
 //
 //  It keeps no per-server state of its own: freshness stamps and in-flight work
 //  live on the sessions, which is what lets a background sweep and the on-screen
@@ -37,6 +44,15 @@ import os
 @MainActor
 @Observable
 public final class SyncEngine {
+  /// How much work a sweep does per server.
+  public enum SyncTier: Sendable {
+    /// Elements + reconcile sweeps only — sized for a `BGAppRefreshTask`
+    /// budget (~30 s).
+    case cheap
+    /// Cheap plus the proactive fills where mode and network allow.
+    case full
+  }
+
   @ObservationIgnored private let manager: ConnectionManager
   /// Live raw path cost read for the observation-driven initial-sync path (the
   /// lifecycle-triggered sweep receives it as a parameter instead). Raw, not a
@@ -80,13 +96,33 @@ public final class SyncEngine {
     registry.start()
   }
 
-  /// Sweep every inactive server once, sequentially (active-first is implicit —
-  /// active is excluded and driven by the store), each isolated so one server's
-  /// failure never affects the others. Coalesces concurrent callers.
+  /// The foreground sweep: every inactive server, full tier (active-first is
+  /// implicit — active is excluded and driven by the store).
   ///
   /// `userInitiated` bypasses the per-server throttle (explicit "sync now").
   public func syncInactiveServers(
     isExpensive: Bool, isConstrained: Bool, userInitiated: Bool = false
+  ) async {
+    await syncServers(
+      scope: .excludingActive(manager.activeConnectionId), tier: .full,
+      isExpensive: isExpensive, isConstrained: isConstrained, userInitiated: userInitiated)
+  }
+
+  /// Sweep the servers selected by `scope` once, sequentially (stalest-first),
+  /// each isolated so one server's failure never affects the others. Coalesces
+  /// concurrent callers: a second caller joins the in-flight sweep whatever its
+  /// scope/tier — the end-of-run reschedule (background) or the next lifecycle
+  /// trigger (foreground) recovers any work the joined sweep didn't cover.
+  ///
+  /// `scope: .all` is for the headless background path, where no `DocumentStore`
+  /// exists (see `BackgroundSyncCoordinator`). It is no longer a *safety*
+  /// distinction — sessions own their repositories, so an in-process sweep that
+  /// reaches the active server coalesces onto the store's session rather than
+  /// racing it — but it stays the honest description of which servers a
+  /// headless run is responsible for.
+  public func syncServers(
+    scope: SyncPlan.SweepScope, tier: SyncTier, isExpensive: Bool, isConstrained: Bool,
+    userInitiated: Bool = false
   ) async {
     if let sweepTask {
       return await sweepTask.value
@@ -94,7 +130,8 @@ public final class SyncEngine {
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
       await runSweep(
-        isExpensive: isExpensive, isConstrained: isConstrained, userInitiated: userInitiated)
+        scope: scope, tier: tier, isExpensive: isExpensive, isConstrained: isConstrained,
+        userInitiated: userInitiated)
     }
     sweepTask = task
     await task.value
@@ -103,7 +140,10 @@ public final class SyncEngine {
 
   // MARK: - Sweep
 
-  private func runSweep(isExpensive: Bool, isConstrained: Bool, userInitiated: Bool) async {
+  private func runSweep(
+    scope: SyncPlan.SweepScope, tier: SyncTier, isExpensive: Bool, isConstrained: Bool,
+    userInitiated: Bool
+  ) async {
     let snapshots = manager.connections.values.map { conn in
       SyncPlan.ServerSnapshot(
         id: conn.id,
@@ -111,17 +151,22 @@ public final class SyncEngine {
         isEntireLibrary: conn.offlineBrowsingMode == .entireLibrary,
         syncOverCellular: conn.syncOverCellular)
     }
-    let actions = SyncPlan.inactiveActions(
+    // `lastSuccessfulSyncs()` merges the persisted per-server stamps under the
+    // sessions' in-memory ones, so ordering stays stalest-first across a cold
+    // launch (background wake or fresh process) and a server synced moments
+    // before the process died isn't re-swept.
+    let actions = SyncPlan.sweepActions(
       connections: snapshots,
-      activeID: manager.activeConnectionId,
+      scope: scope,
       lastSweep: userInitiated ? [:] : registry.lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       isExpensive: isExpensive,
-      isConstrained: isConstrained)
+      isConstrained: isConstrained,
+      includeHeavy: tier == .full)
 
     Logger.sync.info(
-      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
+      "Sweep (\(String(describing: scope), privacy: .public), tier: \(String(describing: tier), privacy: .public)): \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
     )
     for action in actions {
       // No "skip the server that went active mid-sweep" guard any more: sweeping
@@ -132,7 +177,7 @@ public final class SyncEngine {
       guard let stored = manager.connections[action.serverID] else { continue }
       await runAction(action, stored: stored)
     }
-    Logger.sync.info("Inactive sweep complete")
+    Logger.sync.info("Sweep complete")
   }
 
   /// Policy for a server that just appeared. Session creation and teardown

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -2,13 +2,16 @@
 //  SyncEngine.swift
 //  AppShared
 //
-//  Stage 10 (multi-server sync): keeps every *inactive* configured server's
-//  offline cache warm. The active server is deliberately NOT touched here — it
-//  is driven by `DocumentStore` (its own `CachingRepository` instance), so the
-//  engine skips `activeConnectionId` to avoid two instances racing the same
-//  `query_order` rows. "Active-first" therefore falls out for free: the store
-//  syncs the active server on the same lifecycle trigger, and the engine sweeps
-//  the rest.
+//  Stage 10 (multi-server sync): keeps every configured server's offline cache
+//  warm. The sweep still *selects* the inactive ones — the active server is
+//  driven by `DocumentStore` on the same lifecycle trigger, so "active-first"
+//  falls out for free — but that is now an ordering choice, not a safety
+//  requirement. It used to be both: the store and the engine each built their
+//  own `CachingRepository`, so sweeping the active server meant two instances
+//  racing the same `query_order` rows, and the engine had to re-check
+//  `activeConnectionId` on every iteration to narrow the window. Servers now
+//  own their repositories through `ServerSession`, so a sweep that reaches the
+//  active server coalesces onto the session the store is already using.
 //
 //  Scheduling stays on app-lifecycle triggers (launch / foreground /
 //  active-change); true `BGProcessingTask` execution is Stage 11's.
@@ -18,6 +21,10 @@
 //  server's repository and runs the sequence. The interesting decisions (active
 //  exclusion, throttle, uncredentialed degrade, heavy-fill gating, new-server
 //  diff) live in the pure, unit-tested `DataModel.SyncPlan`.
+//
+//  It keeps no per-server state of its own: freshness stamps and in-flight work
+//  live on the sessions, which is what lets a background sweep and the on-screen
+//  store agree about a server without either consulting the other.
 //
 
 import Common
@@ -117,10 +124,11 @@ public final class SyncEngine {
       "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
     )
     for action in actions {
-      // Re-read per iteration: the action list was computed before the first
-      // `await`, so a server the user switched to mid-sweep would otherwise be
-      // swept here while `DocumentStore` drives it on the same server.
-      guard action.serverID != manager.activeConnectionId else { continue }
+      // No "skip the server that went active mid-sweep" guard any more: sweeping
+      // it now means driving the *same* `ServerSession` the store drives, which
+      // coalesces onto that session's per-phase single-flights instead of racing
+      // a second `CachingRepository`. The guard only ever narrowed that window;
+      // one owner per server closes it.
       guard let stored = manager.connections[action.serverID] else { continue }
       await runAction(action, stored: stored)
     }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -11,13 +11,13 @@
 //  the rest.
 //
 //  Scheduling stays on app-lifecycle triggers (launch / foreground /
-//  active-change); true `BGProcessingTask` execution is Stage 11's. When that
-//  lands, `runSweep`'s server enumeration should move from `manager.connections`
-//  (main-actor) to an off-main `database.allConnections()` read.
+//  active-change); true `BGProcessingTask` execution is Stage 11's.
 //
-//  The interesting decisions (active exclusion, throttle, uncredentialed
-//  degrade, heavy-fill gating, new-server diff) live in the pure, unit-tested
-//  `DataModel.SyncPlan`; this type is the imperative shell that executes them.
+//  This type is now purely the *scheduler*: it decides which servers to sync and
+//  in what order, and hands each one to its ``ServerSession``, which owns that
+//  server's repository and runs the sequence. The interesting decisions (active
+//  exclusion, throttle, uncredentialed degrade, heavy-fill gating, new-server
+//  diff) live in the pure, unit-tested `DataModel.SyncPlan`.
 //
 
 import Common
@@ -40,12 +40,16 @@ public final class SyncEngine {
   @ObservationIgnored private let pathCost:
     @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
 
-  /// Last successful sweep per server; drives the throttle. The active server is
-  /// never keyed here (never swept by the engine).
-  @ObservationIgnored private var lastSweep: [UUID: Date] = [:]
-  /// Per-server in-flight sync, so an observation-driven initial sync and a
-  /// lifecycle sweep for the same server coalesce onto one task.
-  @ObservationIgnored private var inFlight: [UUID: Task<Void, Never>] = [:]
+  /// One session per server, retained across sweeps.
+  ///
+  /// This replaces the parallel `inFlight` / `lastSweep` dictionaries that used
+  /// to live here: both were per-server state keyed by UUID, which is precisely
+  /// what a session *is*. Retaining them also means a server's repository —
+  /// and therefore its `activeFills` dedupe — survives from one sweep to the
+  /// next instead of being rebuilt and forgotten each time.
+  ///
+  /// The active server is never keyed here: it is `DocumentStore`'s to drive.
+  @ObservationIgnored private var sessions: [UUID: ServerSession] = [:]
   /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
   @ObservationIgnored private var sweepTask: Task<Void, Never>?
   /// Server IDs seen at the last observation tick, to detect newly-added ones.
@@ -80,8 +84,8 @@ public final class SyncEngine {
   ///
   /// This is wired to the *observation*, not the "Add server" UI action, so a
   /// Stage-12 UBKVS `server` upsert flows into the initial-sync path for free.
-  /// Removed servers need no work — the `server` row delete FK-cascades the whole
-  /// cache; the engine just drops their throttle/in-flight bookkeeping.
+  /// Removed servers need no cache work — the `server` row delete FK-cascades
+  /// the whole cache; the engine just drops their session.
   public func start() {
     guard observationTask == nil else { return }
     // Seed with the current set so the observation only reacts to *new* servers;
@@ -136,7 +140,7 @@ public final class SyncEngine {
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
       activeID: manager.activeConnectionId,
-      lastSweep: userInitiated ? [:] : lastSweep,
+      lastSweep: userInitiated ? [:] : lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       isExpensive: isExpensive,
@@ -158,11 +162,9 @@ public final class SyncEngine {
 
   private func handleConnectionsChanged() {
     let current = Set(manager.connections.keys)
-    // Drop bookkeeping for servers whose rows vanished (cache already cascaded).
+    // Drop the session of any server whose row vanished (cache already cascaded).
     for id in knownServerIDs.subtracting(current) {
-      inFlight[id]?.cancel()
-      inFlight[id] = nil
-      lastSweep[id] = nil
+      sessions.removeValue(forKey: id)?.invalidate()
     }
     let added = SyncPlan.newlyAdded(
       current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
@@ -188,97 +190,31 @@ public final class SyncEngine {
   // MARK: - Per-server execution
 
   private func runAction(_ action: SyncServerAction, stored: StoredConnection) async {
+    let session = session(for: stored.id)
     if action.needsAuthOnly {
-      // Config-synced-but-uncredentialed: mark per-server needs-auth and make no
-      // network call. Deterministic and cheap; when the token later lands, the
-      // next sweep picks it up. The 401 path stays a backstop for a rejected token.
-      Logger.sync.info(
-        "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
-      manager.markNeedsAuth(for: stored.id)
+      session.markNeedsAuth(stored)
       return
     }
-    if let existing = inFlight[stored.id] {
-      return await existing.value
-    }
-    let task = Task { @MainActor [weak self] in
-      guard let self else { return }
-      await performServerSync(stored, runHeavyFill: action.runHeavyFill)
-    }
-    inFlight[stored.id] = task
-    await task.value
-    inFlight[stored.id] = nil
+    await session.sync(stored: stored, runHeavyFill: action.runHeavyFill)
   }
 
-  /// Mirrors the active path's sequence (`DocumentStore.sync` + `reconcileDocuments`
-  /// + `fillLibraryIfEnabled` + `fillDocumentDetailsIfEnabled`) against an
-  /// ephemeral per-server backend. The whole body is caught so a per-server
-  /// failure (offline, rethrown 401, …) never escapes to sibling servers.
-  private func performServerSync(_ stored: StoredConnection, runHeavyFill: Bool) async {
-    let id = stored.id
-    Logger.sync.info(
-      "Syncing inactive server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
-    do {
-      let backend = try await makeCachingRepository(
-        for: stored, database: database, manager: manager, mode: mode)
+  // MARK: - Sessions
 
-      // Cheap tier (always, regardless of metered-ness): element sync + the
-      // reconcile sweeps (the last two self-gate on *Entire library*).
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements()
-      }
-      // Each reconcile sweep carries its own catch, as on the active path
-      // (`DocumentStore.reconcileDocuments`): the deletion sweep is the most
-      // failure-prone of the three — it fetches the server's entire live id set
-      // — and under one shared `try` its failure took the freshness delta, the
-      // membership rebuild *and* the heavy fill down with it. Cancellation is
-      // the exception: it means the pass as a whole is unwanted, so it stops
-      // the remaining sweeps instead of being logged and stepped over.
-      var failed = false
-      var cancelled = false
-      func sweep(_ label: String, _ body: () async throws -> Void) async {
-        guard !cancelled else { return }
-        do {
-          try await body()
-        } catch {
-          guard !error.isCancellationError else {
-            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-            cancelled = true
-            return
-          }
-          Logger.sync.info(
-            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-          failed = true
-        }
-      }
-      await NetworkTransfer.$category.withValue(.reconcile) {
-        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-        await sweep("changes") { try await backend.reconcileDocumentChanges() }
-        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-      }
-
-      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
-      if runHeavyFill, !cancelled {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillLibrary(force: false)
-          try await backend.fillDocumentDetails()
-        }
-      }
-
-      // Advance the throttle only on a *fully* successful pass — a sweep that
-      // failed or was called off partway retries on the next trigger.
-      guard !failed, !cancelled else {
-        Logger.sync.info(
-          "Inactive server \(stored.logLabel, privacy: .public) partially synced; throttle not advanced"
-        )
-        return
-      }
-      lastSweep[id] = Date()
-      Logger.sync.info("Inactive server \(stored.logLabel, privacy: .public) synced")
-    } catch {
-      Logger.sync.info(
-        "Inactive-server sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)"
-      )
+  /// The server's session, created on first use. Sessions are cheap — a
+  /// repository is only assembled when something actually syncs.
+  private func session(for id: UUID) -> ServerSession {
+    if let existing = sessions[id] {
+      return existing
     }
+    let session = ServerSession(
+      serverID: id, database: database, manager: manager, mode: mode)
+    sessions[id] = session
+    return session
+  }
+
+  /// The throttle input `SyncPlan` consumes, projected out of the sessions.
+  private func lastSuccessfulSyncs() -> [UUID: Date] {
+    sessions.compactMapValues(\.lastSuccessfulSync)
   }
 
   // MARK: - Helpers

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -30,9 +30,7 @@ import os
 @MainActor
 @Observable
 public final class SyncEngine {
-  @ObservationIgnored private let database: Database
   @ObservationIgnored private let manager: ConnectionManager
-  @ObservationIgnored private let mode: ApiRepository.Mode
   /// Live raw path cost read for the observation-driven initial-sync path (the
   /// lifecycle-triggered sweep receives it as a parameter instead). Raw, not a
   /// decision — each server combines it with its own `syncOverCellular` via
@@ -40,70 +38,39 @@ public final class SyncEngine {
   @ObservationIgnored private let pathCost:
     @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
 
-  /// One session per server, retained across sweeps.
-  ///
-  /// This replaces the parallel `inFlight` / `lastSweep` dictionaries that used
-  /// to live here: both were per-server state keyed by UUID, which is precisely
-  /// what a session *is*. Retaining them also means a server's repository —
-  /// and therefore its `activeFills` dedupe — survives from one sweep to the
-  /// next instead of being rebuilt and forgotten each time.
-  ///
-  /// The active server is never keyed here: it is `DocumentStore`'s to drive.
-  @ObservationIgnored private var sessions: [UUID: ServerSession] = [:]
+  /// Where the per-server sessions live. The engine borrows them; it does not
+  /// own them, and it no longer keeps any per-server state of its own.
+  @ObservationIgnored private let registry: ServerSessionRegistry
   /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
   @ObservationIgnored private var sweepTask: Task<Void, Never>?
-  /// Server IDs seen at the last observation tick, to detect newly-added ones.
-  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
-  @ObservationIgnored private var observationTask: Task<Void, Never>?
 
   /// Background warmth cadence for inactive servers — deliberately looser than
   /// the active path's 300 s reconcile throttle; these servers aren't on screen.
   @ObservationIgnored private let inactiveThrottle: TimeInterval = 900
 
   public init(
-    database: Database,
+    registry: ServerSessionRegistry,
     manager: ConnectionManager,
-    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool),
-    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
   ) {
-    self.database = database
+    self.registry = registry
     self.manager = manager
     self.pathCost = pathCost
-    self.mode = mode
-  }
-
-  deinit {
-    observationTask?.cancel()
   }
 
   // MARK: - Public API
 
-  /// Begin observing the `server` table (via `manager.connections`, which is the
-  /// sole projection of it). A newly-appeared, non-active server triggers a
-  /// throttle-exempt initial sync.
+  /// Start reacting to the server table: a newly-appeared, non-active server
+  /// gets a throttle-exempt initial sync.
   ///
-  /// This is wired to the *observation*, not the "Add server" UI action, so a
-  /// Stage-12 UBKVS `server` upsert flows into the initial-sync path for free.
-  /// Removed servers need no cache work — the `server` row delete FK-cascades
-  /// the whole cache; the engine just drops their session.
+  /// The observation itself belongs to ``ServerSessionRegistry`` — it owns
+  /// session lifetime, and one observer of that table is the whole point. The
+  /// engine only supplies the *policy* for what an addition deserves.
   public func start() {
-    guard observationTask == nil else { return }
-    // Seed with the current set so the observation only reacts to *new* servers;
-    // the servers present at launch are handled by the explicit sweep below.
-    knownServerIDs = Set(manager.connections.keys)
-    observationTask = Task { @MainActor [weak self] in
-      while !Task.isCancelled {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
-        withObservationTracking {
-          _ = self?.manager.connections.keys
-        } onChange: {
-          continuation.yield()
-          continuation.finish()
-        }
-        self?.handleConnectionsChanged()
-        for await _ in stream { break }
-      }
+    registry.onServersChanged = { [weak self] current, previous in
+      self?.handleServersChanged(current: current, previous: previous)
     }
+    registry.start()
   }
 
   /// Sweep every inactive server once, sequentially (active-first is implicit —
@@ -140,7 +107,7 @@ public final class SyncEngine {
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
       activeID: manager.activeConnectionId,
-      lastSweep: userInitiated ? [:] : lastSuccessfulSyncs(),
+      lastSweep: userInitiated ? [:] : registry.lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       isExpensive: isExpensive,
@@ -160,15 +127,12 @@ public final class SyncEngine {
     Logger.sync.info("Inactive sweep complete")
   }
 
-  private func handleConnectionsChanged() {
-    let current = Set(manager.connections.keys)
-    // Drop the session of any server whose row vanished (cache already cascaded).
-    for id in knownServerIDs.subtracting(current) {
-      sessions.removeValue(forKey: id)?.invalidate()
-    }
+  /// Policy for a server that just appeared. Session creation and teardown
+  /// already happened in the registry; all that is left is deciding what the
+  /// addition deserves, which is `SyncPlan`'s call.
+  private func handleServersChanged(current: Set<UUID>, previous: Set<UUID>) {
     let added = SyncPlan.newlyAdded(
-      current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
-    knownServerIDs = current
+      current: current, known: previous, activeID: manager.activeConnectionId)
     if !added.isEmpty {
       Logger.sync.info("Observed \(added.count) new server(s); kicking initial sync")
     }
@@ -190,31 +154,12 @@ public final class SyncEngine {
   // MARK: - Per-server execution
 
   private func runAction(_ action: SyncServerAction, stored: StoredConnection) async {
-    let session = session(for: stored.id)
+    let session = registry.session(for: stored.id)
     if action.needsAuthOnly {
       session.markNeedsAuth(stored)
       return
     }
     await session.sync(stored: stored, runHeavyFill: action.runHeavyFill)
-  }
-
-  // MARK: - Sessions
-
-  /// The server's session, created on first use. Sessions are cheap — a
-  /// repository is only assembled when something actually syncs.
-  private func session(for id: UUID) -> ServerSession {
-    if let existing = sessions[id] {
-      return existing
-    }
-    let session = ServerSession(
-      serverID: id, database: database, manager: manager, mode: mode)
-    sessions[id] = session
-    return session
-  }
-
-  /// The throttle input `SyncPlan` consumes, projected out of the sessions.
-  private func lastSuccessfulSyncs() -> [UUID: Date] {
-    sessions.compactMapValues(\.lastSuccessfulSync)
   }
 
   // MARK: - Helpers

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -2,7 +2,7 @@
 //  SyncEngine.swift
 //  AppShared
 //
-//  Stage 10 (multi-server sync): keeps every configured server's offline cache
+//  Multi-server sync: keeps every configured server's offline cache
 //  warm. The sweep still *selects* the inactive ones — the active server is
 //  driven by `DocumentStore` on the same lifecycle trigger, so "active-first"
 //  falls out for free — but that is now an ordering choice, not a safety
@@ -14,7 +14,7 @@
 //  active server coalesces onto the session the store is already using.
 //
 //  Foreground app-lifecycle triggers (launch / foreground / active-change)
-//  drive `syncInactiveServers`; Stage 11's background tasks drive
+//  drive `syncInactiveServers`; the background tasks drive
 //  `syncServers(scope:tier:...)` through `BackgroundSyncCoordinator` — either
 //  against this same instance (registered UI graph) or a headless twin on a
 //  cold background launch. The engine deliberately stays `@MainActor` (an

--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -10117,6 +10117,42 @@
         }
       }
     },
+    "requestErrorConnectivityHintHostNotFound" : {
+      "comment" : "Shown in the error details when the server's hostname could not be resolved (DNS failure, bad URL).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server's address could not be resolved. Check that the URL in the connection settings is spelled correctly. If the server uses a local-only hostname, you may need to be on its network, or connected to a VPN."
+          }
+        }
+      }
+    },
+    "requestErrorConnectivityHintOffline" : {
+      "comment" : "Shown in the error details when a request failed because the device itself is offline.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your device does not appear to have an internet connection. Check Wi-Fi or cellular data, then try again."
+          }
+        }
+      }
+    },
+    "requestErrorConnectivityHintUnreachable" : {
+      "comment" : "Shown in the error details when the server could not be reached (connection refused, timeout, connection lost).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server could not be reached. It may be offline or restarting, the address or port in the connection settings may be wrong, or the server may only be reachable from its own network or through a VPN that is not currently connected."
+          }
+        }
+      }
+    },
     "requestErrorDetailLabel" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
@@ -3484,7 +3484,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Since %@"
+            "value" : "Across all servers, since %@"
           }
         },
         "fr" : {

--- a/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
@@ -3249,6 +3249,18 @@
         }
       }
     },
+    "offlineSyncBackgroundRunning" : {
+      "comment" : "Activity status on the Offline & Sync screen while a background task drives the sync",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Background sync…"
+          }
+        }
+      }
+    },
     "offlineSyncCachedDocuments" : {
       "comment" : "Row label for how many documents are currently stored on the device for offline use",
       "extractionState" : "manual",

--- a/AppShared/Sources/AppShared/Views/Error/ErrorSuppression.swift
+++ b/AppShared/Sources/AppShared/Views/Error/ErrorSuppression.swift
@@ -29,6 +29,19 @@ extension ErrorController {
 
     guard offline else { return false }
 
+    // Repositories normalize transport failures into `RequestError`, so this is
+    // the case an offline API call actually arrives as. The raw `URLError` /
+    // `NSError` checks below still matter for the paths that don't go through a
+    // repository (image loading, for one).
+    if let request = error as? RequestError, case .connectivity(let code, _) = request {
+      switch code {
+      case .notConnectedToInternet, .networkConnectionLost,
+        .dataNotAllowed, .timedOut:
+        return true
+      default: break
+      }
+    }
+
     if let url = error as? URLError {
       switch url.code {
       case .notConnectedToInternet, .networkConnectionLost,

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -92,7 +92,6 @@ public struct ConnectionSelectionMenu: View {
 
 public struct ConnectionsView: View {
   private var connectionManager: ConnectionManager
-  private let database: Database
   @Binding public var showLoginSheet: Bool
 
   @ScaledMetric(relativeTo: .title) private var plusIconSize = 18.0
@@ -108,11 +107,8 @@ public struct ConnectionsView: View {
 
   @Environment(DocumentStore.self) private var store
 
-  public init(
-    connectionManager: ConnectionManager, database: Database, showLoginSheet: Binding<Bool>
-  ) {
+  public init(connectionManager: ConnectionManager, showLoginSheet: Binding<Bool>) {
     self.connectionManager = connectionManager
-    self.database = database
     _extraHeaders = State(initialValue: connectionManager.storedConnection?.extraHeaders ?? [])
     _showLoginSheet = showLoginSheet
   }
@@ -131,11 +127,11 @@ public struct ConnectionsView: View {
           // flipping the flag (and 401s are suppressed on the assumption the
           // connection banner covers them), and the caching wrapper because the
           // store detaches its ElementStore projection from any repository that
-          // fronts no database. `activate` owns that assembly, so this call site
-          // can no longer get it wrong.
+          // fronts no database. The server's session owns that assembly, so this
+          // call site can no longer get it wrong — and the header edit reaches the
+          // *same* repository the SyncEngine drives, rather than a second one.
           do {
-            try await store.activate(
-              connection: stored, database: database, manager: connectionManager)
+            try await store.activate(connection: stored)
           } catch {
             Logger.shared.error(
               "Could not rebuild repository after extra header change: \(error)")

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -24,6 +24,7 @@ public struct OfflineSyncView: View {
   /// The server's total for the default list, read once from the cached query
   /// status. Only used to decide whether to suggest *Entire library*.
   @State private var libraryTotal: UInt?
+  @State private var backgroundSync = BackgroundSyncCoordinator.shared
 
   public init() {}
 
@@ -280,10 +281,15 @@ public struct OfflineSyncView: View {
   }
 
   /// Only reached when nothing is running — the stage rows speak for themselves
-  /// otherwise. Says *why* it's not running where there's a reason to give.
+  /// otherwise. Says *why* it isn't running where there's a reason to give.
+  ///
+  /// The coordinator flag covers the phases the store can't see (engine sweeps
+  /// of other servers), so a task-driven run never reads as "Idle".
   private var activityText: String {
     if waitingForNetwork {
       String(localized: .settings(.offlineSyncWaitingForWifi))
+    } else if backgroundSync.isRunning {
+      String(localized: .settings(.offlineSyncBackgroundRunning))
     } else {
       String(localized: .settings(.offlineSyncIdle))
     }

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -72,7 +72,7 @@ public struct OfflineSyncView: View {
               } else {
                 connectionManager.setOfflineBrowsingMode(newMode)
                 if newMode == .entireLibrary {
-                  Task { await store.fillLibraryIfEnabled(unmetered: unmetered, force: true) }
+                  Task { await store.runProactiveFill(unmetered: unmetered, force: true) }
                 }
               }
             })
@@ -186,14 +186,15 @@ public struct OfflineSyncView: View {
             } catch {
               errorController.push(error: error)
             }
-            await store.fillLibraryIfEnabled(unmetered: true, force: true)
-            // Both lifecycle paths pair the library fill with the detail fill;
-            // without this, notes and file metadata could only ever be filled by
-            // backgrounding and foregrounding the app.
-            await store.fillDocumentDetailsIfEnabled(unmetered: true)
+            await store.runProactiveFill(unmetered: true, force: true)
           }
         } label: {
+          // Explicit `foregroundStyle`, not just `.disabled`: a `Label`'s icon
+          // in a `Form` row button doesn't pick up the row's disabled dimming
+          // the way its text does, so a disabled row otherwise reads as a
+          // grayed-out title next to a still-accent-colored icon.
           Label(String(localized: .settings(.offlineSyncNow)), systemImage: "arrow.clockwise")
+            .foregroundStyle(store.syncActivities.isEmpty ? Color.accentColor : Color.secondary)
         }
         // Any sweep, not just the library fill: the detail fill left this
         // enabled, so a second pass could be stacked on a running one.

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -91,6 +91,11 @@ public struct OfflineSyncView: View {
           Button(
             String(localized: .settings(.offlineBrowsingDowngradeConfirm)), role: .destructive
           ) {
+            // Stop the fill *before* the mode flip triggers the reclaim GC — a
+            // still-running fill has no other way to learn it should stop
+            // (unlike a server switch, this never goes through `install`), and
+            // would otherwise keep writing rows the reclaim just removed.
+            store.cancelProactiveFill()
             connectionManager.setOfflineBrowsingMode(.recentlyBrowsed)
           }
 

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -167,7 +167,7 @@ public struct OfflineSyncView: View {
             String(localized: .settings(.offlineSyncLastFullFill)), date: store.libraryCoverageAt)
         }
         dateStatusRow(
-          String(localized: .settings(.offlineSyncLastRefresh)), date: store.lastReconcileAt)
+          String(localized: .settings(.offlineSyncLastRefresh)), date: store.lastSyncAt)
         statusRow(
           String(localized: .settings(.offlineSyncCachedDocuments)),
           value: store.cachedDocumentCount.formatted())

--- a/AppShared/Sources/AppShared/Views/Tags/TagView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagView.swift
@@ -212,5 +212,5 @@ private func tag(_ id: UInt, _ name: String, _ color: Color) -> Tag {
 #Preview("Placeholder") {
   TagsView()
     .redacted(reason: .placeholder)
-    .environment(DocumentStore(repository: NullRepository()))
+    .environment(DocumentStore.preview())
 }

--- a/Common/Sources/Common/NSURLError.swift
+++ b/Common/Sources/Common/NSURLError.swift
@@ -6,7 +6,7 @@
 //
 
 // Taken from NSURLError.h
-public enum NSURLError: Int {
+public enum NSURLError: Int, Sendable {
   public enum Category {
     case ssl
     case fileio

--- a/DataModel/Sources/DataModel/Model/CustomFieldModel.swift
+++ b/DataModel/Sources/DataModel/Model/CustomFieldModel.swift
@@ -77,7 +77,7 @@ public enum CustomFieldDataType: RawRepresentable, Codable, Equatable, Hashable,
 }
 
 // Wire-symmetric leaf value type — round-tripped by ApiCustomFieldExtraData
-// and the (future) storage layer. Stays Codable per the Stage 3 principle.
+// and the storage layer, so it stays Codable.
 public struct CustomFieldSelectOption: Codable, Identifiable, Hashable, Sendable {
   public var id: String
   public var label: String

--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -40,7 +40,7 @@ public struct DocumentNote: Identifiable, Equatable, Sendable, Hashable {
   }
 
   // Wire-symmetric leaf value type — round-tripped by ApiDocumentNote and
-  // the (future) storage layer. Stays Codable per the Stage 3 principle.
+  // the storage layer, so it stays Codable.
   public struct User: Codable, Equatable, Sendable, Hashable {
     public var id: UInt
     public var username: String

--- a/DataModel/Sources/DataModel/Model/MetadataModel.swift
+++ b/DataModel/Sources/DataModel/Model/MetadataModel.swift
@@ -13,7 +13,7 @@ public struct Metadata: Sendable {
   public var hasArchiveVersion: Bool
 
   // Wire-symmetric value type — round-tripped by `ApiMetadata` and storage
-  // alike. Stays `Codable` per the Stage 3 principle.
+  // alike, so it stays `Codable`.
   public struct Item: Codable, Sendable, Equatable {
     public var namespace: String
     public var prefix: String

--- a/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
+++ b/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public struct ShareLink: Sendable, Equatable {
-  // Wire-symmetric leaf enum; round-tripped as-is by the wire type and (future)
-  // storage layer. Stays Codable per the Stage 3 principle.
+  // Wire-symmetric leaf enum; round-tripped as-is by the wire type and the
+  // storage layer, so it stays Codable.
   public enum FileVersion: String, Codable, Sendable {
     case original
     case archive

--- a/DataModel/Sources/DataModel/SyncActivity.swift
+++ b/DataModel/Sources/DataModel/SyncActivity.swift
@@ -15,7 +15,7 @@ import Foundation
 /// equally be stuck.
 ///
 /// Several of these run at once, so the store publishes *all* of them rather
-/// than picking one — see `AppShared.DocumentStore.syncActivities`.
+/// than picking one — see `AppShared.ServerSession.syncActivities`.
 ///
 /// In `DataModel` rather than `AppShared` for the same reason as
 /// ``OfflineLibrarySize``: the ordering rule is easy to regress silently and

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -36,6 +36,18 @@ public struct SyncServerAction: Equatable, Sendable {
 
 /// Pure planning for the multi-server (inactive-server) sync sweep.
 public enum SyncPlan {
+  /// Which servers a sweep considers.
+  public enum SweepScope: Equatable, Sendable {
+    /// Exclude the given active server. The foreground case: the active server
+    /// is driven by `DocumentStore`, and a second `CachingRepository` instance
+    /// must never race it on the same `query_order` rows.
+    case excludingActive(UUID?)
+    /// Consider every configured server. The headless background case: no
+    /// `DocumentStore` exists in the process, so the engine is provably the
+    /// only writer and may safely include the active server.
+    case all
+  }
+
   /// A dependency-free snapshot of one configured server, as the engine sees it
   /// at sweep time. `isEntireLibrary` is `AppShared.OfflineBrowsingMode ==
   /// .entireLibrary` flattened to a `Bool` so this stays in `DataModel` (which
@@ -56,32 +68,49 @@ public enum SyncPlan {
     }
   }
 
-  /// The ordered set of actions for a sweep of every **inactive** server.
+  /// The ordered set of actions for one sweep.
   ///
-  /// - The active server is excluded (it is driven by `DocumentStore`, never by
-  ///   the engine — this is what prevents a two-instance double-fill race).
+  /// - `scope` decides whether the active server participates (see
+  ///   ``SweepScope``).
   /// - Uncredentialed servers always yield a `needsAuthOnly` action (cheap,
   ///   throttle-exempt, so a freshly-arrived token is picked up on the very next
   ///   sweep).
   /// - Credentialed servers are dropped while their last successful sweep is
   ///   still within `throttle`; otherwise they yield a sync action whose
-  ///   `runHeavyFill` is gated on `isEntireLibrary &&` that server's own
-  ///   ``SyncCondition/allowsProactiveSync`` — each server's own
+  ///   `runHeavyFill` is gated on `includeHeavy && isEntireLibrary &&` that
+  ///   server's own ``SyncCondition/allowsProactiveSync`` — each server's own
   ///   `syncOverCellular` opt-in applies to *that* server only, not the whole
-  ///   sweep.
-  /// - Ordering is stable (by `id`) for deterministic, testable behavior.
-  public static func inactiveActions(
+  ///   sweep (`includeHeavy: false` is the quick-refresh tier: cheap sweep
+  ///   only, no proactive fill, regardless of mode or network).
+  /// - Ordering is **stalest-first** by `lastSweep` (never-synced first), with a
+  ///   stable `id` tie-break — so a time-boxed background run reaches the
+  ///   neediest servers before its budget expires.
+  public static func sweepActions(
     connections: [ServerSnapshot],
-    activeID: UUID?,
+    scope: SweepScope,
     lastSweep: [UUID: Date],
     now: Date,
     throttle: TimeInterval,
     isExpensive: Bool,
-    isConstrained: Bool
+    isConstrained: Bool,
+    includeHeavy: Bool
   ) -> [SyncServerAction] {
-    connections
-      .filter { $0.id != activeID }
-      .sorted { $0.id.uuidString < $1.id.uuidString }
+    let excluded: UUID? =
+      switch scope {
+      case .excludingActive(let id): id
+      case .all: nil
+      }
+    return
+      connections
+      .filter { $0.id != excluded }
+      .sorted { lhs, rhs in
+        switch (lastSweep[lhs.id], lastSweep[rhs.id]) {
+        case (nil, nil): lhs.id.uuidString < rhs.id.uuidString
+        case (nil, .some): true
+        case (.some, nil): false
+        case (.some(let l), .some(let r)): l != r ? l < r : lhs.id.uuidString < rhs.id.uuidString
+        }
+      }
       .compactMap { server in
         guard server.hasToken else {
           // Uncredentialed: mark needs-auth every sweep (no network, no throttle).
@@ -96,8 +125,30 @@ public enum SyncPlan {
         return SyncServerAction(
           serverID: server.id,
           needsAuthOnly: false,
-          runHeavyFill: condition.allowsProactiveSync && server.isEntireLibrary)
+          runHeavyFill: includeHeavy && condition.allowsProactiveSync && server.isEntireLibrary)
       }
+  }
+
+  /// The foreground sweep: every **inactive** server, full tier. Wrapper over
+  /// ``sweepActions(connections:scope:lastSweep:now:throttle:isExpensive:isConstrained:includeHeavy:)``.
+  public static func inactiveActions(
+    connections: [ServerSnapshot],
+    activeID: UUID?,
+    lastSweep: [UUID: Date],
+    now: Date,
+    throttle: TimeInterval,
+    isExpensive: Bool,
+    isConstrained: Bool
+  ) -> [SyncServerAction] {
+    sweepActions(
+      connections: connections,
+      scope: .excludingActive(activeID),
+      lastSweep: lastSweep,
+      now: now,
+      throttle: throttle,
+      isExpensive: isExpensive,
+      isConstrained: isConstrained,
+      includeHeavy: true)
   }
 
   /// Server IDs that appeared since the last observation tick and warrant an

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -127,6 +127,75 @@ struct SyncPlanTests {
     #expect(actions.first?.runHeavyFill == false)
   }
 
+  @Test("Scope .all includes the active server in the sweep")
+  func scopeAllIncludesActive() {
+    let actions = SyncPlan.sweepActions(
+      connections: [snapshot(Self.a), snapshot(Self.b)],
+      scope: .all, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: false, isConstrained: false, includeHeavy: true)
+    #expect(actions.map(\.serverID) == [Self.a, Self.b])
+  }
+
+  @Test("Scope .excludingActive matches the inactiveActions wrapper")
+  func wrapperEquivalence() {
+    let connections = [snapshot(Self.a), snapshot(Self.b, hasToken: false), snapshot(Self.c)]
+    let direct = SyncPlan.sweepActions(
+      connections: connections, scope: .excludingActive(Self.a), lastSweep: [:],
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false, includeHeavy: true)
+    let wrapped = SyncPlan.inactiveActions(
+      connections: connections, activeID: Self.a, lastSweep: [:],
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
+    #expect(direct == wrapped)
+  }
+
+  @Test("includeHeavy: false suppresses the heavy fill even when allowed + entireLibrary")
+  func cheapTierSuppressesHeavy() {
+    let actions = SyncPlan.sweepActions(
+      connections: [snapshot(Self.a, isEntireLibrary: true)],
+      scope: .all, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: false, isConstrained: false, includeHeavy: false)
+    #expect(
+      actions == [
+        SyncServerAction(serverID: Self.a, needsAuthOnly: false, runHeavyFill: false)
+      ])
+  }
+
+  @Test("needsAuthOnly degrade is unaffected by scope and tier")
+  func needsAuthUnaffectedByScopeAndTier() {
+    for includeHeavy in [true, false] {
+      let actions = SyncPlan.sweepActions(
+        connections: [snapshot(Self.a, hasToken: false)],
+        scope: .all, lastSweep: [Self.a: now], now: now, throttle: throttle,
+        isExpensive: false, isConstrained: false, includeHeavy: includeHeavy)
+      #expect(
+        actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, runHeavyFill: false)])
+    }
+  }
+
+  @Test("Ordering is stalest-first: never-synced first, then oldest, id tie-break")
+  func stalestFirstOrdering() {
+    let old = now.addingTimeInterval(-(throttle * 3))
+    let older = now.addingTimeInterval(-(throttle * 4))
+    let actions = SyncPlan.sweepActions(
+      connections: [snapshot(Self.a), snapshot(Self.b), snapshot(Self.c)],
+      scope: .all,
+      lastSweep: [Self.a: old, Self.b: older],
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false, includeHeavy: true)
+    // c never synced → first; then b (older) before a (old).
+    #expect(actions.map(\.serverID) == [Self.c, Self.b, Self.a])
+  }
+
+  @Test("Equal staleness falls back to deterministic id order")
+  func stalestTieBreak() {
+    let same = now.addingTimeInterval(-(throttle * 2))
+    let actions = SyncPlan.sweepActions(
+      connections: [snapshot(Self.c), snapshot(Self.a), snapshot(Self.b)],
+      scope: .all,
+      lastSweep: [Self.a: same, Self.b: same, Self.c: same],
+      now: now, throttle: throttle, isExpensive: false, isConstrained: false, includeHeavy: true)
+    #expect(actions.map(\.serverID) == [Self.a, Self.b, Self.c])
+  }
+
   @Test("newlyAdded returns only genuinely new, non-active ids")
   func newlyAddedDiff() {
     let added = SyncPlan.newlyAdded(

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -382,7 +382,7 @@ public class ApiRepository {
       Logger.networking.error(
         "Caught error fetching \(sanitizedUrl, privacy: .public): \(sanitizedError, privacy: .public)"
       )
-      throw error
+      throw RequestError.normalizing(error)
     }
 
     let (data, response) = result
@@ -661,8 +661,13 @@ extension ApiRepository: Repository {
 
       let request = try request(
         .download(documentId: document.id, original: original, version: queryVersion))
-      let (tempURL, response) = try await urlSession.getDownload(
-        for: request, progress: progress)
+      let (tempURL, response): (URL, URLResponse)
+      do {
+        (tempURL, response) = try await urlSession.getDownload(
+          for: request, progress: progress)
+      } catch {
+        throw RequestError.normalizing(error)
+      }
 
       try validateDownloadResponse(response, request: request)
 
@@ -679,8 +684,13 @@ extension ApiRepository: Repository {
   ) async throws -> URL {
     let request = try request(
       .download(documentId: documentID, original: original, version: version))
-    let (tempURL, response) = try await urlSession.getDownload(
-      for: request, progress: progress)
+    let (tempURL, response): (URL, URLResponse)
+    do {
+      (tempURL, response) = try await urlSession.getDownload(
+        for: request, progress: progress)
+    } catch {
+      throw RequestError.normalizing(error)
+    }
     try validateDownloadResponse(response, request: request)
 
     let dest = URL(

--- a/Networking/Sources/Networking/Api/Wire/ApiSavedView.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiSavedView.swift
@@ -8,9 +8,8 @@ import DataModel
 // MARK: - Wire type for reading saved views
 //
 // `filter_rules: [FilterRule]`, `owner: Owner?`, `permissions: Permissions?`
-// embed leaf wire-symmetric value types straight from DataModel — see the
-// Stage 3 plan for the rule. Each domain type carries its own JSON shape and
-// is round-tripped as-is.
+// embed leaf wire-symmetric value types straight from DataModel. Each domain
+// type carries its own JSON shape and is round-tripped as-is.
 
 struct ApiSavedView: Codable, Sendable {
   var id: UInt

--- a/Networking/Sources/Networking/RequestError.swift
+++ b/Networking/Sources/Networking/RequestError.swift
@@ -34,6 +34,22 @@ public enum RequestError: Error, Equatable {
 
   case certificate(detail: String)
 
+  // A transport-level failure: the request never produced a response (host
+  // unreachable, DNS failure, timeout, device offline, ...).
+  //
+  // `code` is carried through rather than being flattened into a message so
+  // policy code downstream can still tell these apart — `ErrorSuppression`
+  // needs to distinguish "the device is offline" (a banner already says so)
+  // from "this server is unreachable" (nothing else reports it).
+  //
+  // `detail` is the localized system message, which is identical for every
+  // request that fails the same way. That makes two failures against the same
+  // host `==`, whereas the underlying `URLError`s are not: their bridged
+  // `NSError.userInfo` carries the failing URL and a per-request task id, so
+  // no two are ever equal. Collapsing a fan-out of requests into one error
+  // (and so one toast) depends on this.
+  case connectivity(code: NSURLError, detail: String)
+
   // Can split this up into additional cases for customized error messages
   case other(_: String)
 
@@ -113,6 +129,12 @@ private func string(for error: any Error) -> String {
 }
 
 extension RequestError {
+  /// Map a `URLSession` transport failure onto the request-error vocabulary.
+  ///
+  /// Returns `nil` for anything that isn't a transport failure we want to
+  /// reinterpret: errors from another domain, cancellation (callers handle that
+  /// separately, and it must never be shown), and the file-I/O codes a download
+  /// can hit — those are about the local filesystem, not reachability.
   public init?(from error: NSError) {
     guard error.domain == NSURLErrorDomain else {
       return nil
@@ -122,19 +144,28 @@ extension RequestError {
       return nil
     }
 
-    if code.category == .ssl {
-      self = .certificate(detail: string(for: error))
-      return
-    }
-
-    switch code {
-    case .badURL, .unsupportedURL, .cannotFindHost, .cannotConnectToHost, .networkConnectionLost,
-      .dnsLookupFailed, .httpTooManyRedirects, .resourceUnavailable, .notConnectedToInternet,
-      .redirectToNonExistentLocation, .badServerResponse:
-      self = .other(string(for: error))
-    default:
+    guard code != .cancelled else {
       return nil
     }
+
+    switch code.category {
+    case .ssl:
+      self = .certificate(detail: string(for: error))
+    case .fileio:
+      return nil
+    case .other:
+      self = .connectivity(code: code, detail: string(for: error))
+    }
+  }
+
+  /// Normalize an error thrown by a `URLSession` transport call.
+  ///
+  /// Applied at the repository's transport boundary so that everything leaving
+  /// a repository speaks `RequestError`, rather than the raw `URLError` that
+  /// `URLSession` throws. Anything that isn't a recognized transport failure —
+  /// including cancellation — is passed through untouched.
+  public static func normalizing(_ error: any Error) -> any Error {
+    RequestError(from: error as NSError) ?? error
   }
 }
 

--- a/Networking/Tests/NetworkingTests/RequestErrorNormalizationTest.swift
+++ b/Networking/Tests/NetworkingTests/RequestErrorNormalizationTest.swift
@@ -1,0 +1,197 @@
+//
+//  RequestErrorNormalizationTest.swift
+//  Networking
+//
+//  Transport failures thrown by URLSession are normalized into `RequestError` at
+//  the repository boundary. The point is that a single outage produces one error
+//  *value*, no matter how many endpoints it hit: callers that fan out (the
+//  document detail view loads document/metadata/notes/suggestions together)
+//  collapse the failures and surface one message instead of four.
+//
+
+import Common
+import Foundation
+import Testing
+
+@testable import Networking
+
+// Dedicated URLProtocol subclass with its own static responder so this suite
+// doesn't race against other suites that share a mock URLProtocol global.
+final class NormalizationMockURLProtocol: URLProtocol, @unchecked Sendable {
+  typealias Responder = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var _responder: Responder?
+
+  static var responder: Responder? {
+    get { lock.withLock { _responder } }
+    set { lock.withLock { _responder = newValue } }
+  }
+
+  static func reset() { responder = nil }
+
+  static func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [NormalizationMockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  override class func canInit(with _: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let responder = Self.responder else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    do {
+      let (response, data) = try responder(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+@MainActor
+@Suite(.serialized)
+struct RequestErrorNormalizationTest {
+  private static func urlError(code: Int, failingURL: String) -> NSError {
+    NSError(
+      domain: NSURLErrorDomain, code: code,
+      userInfo: [
+        NSLocalizedDescriptionKey: "Could not connect to the server.",
+        NSURLErrorFailingURLStringErrorKey: failingURL,
+      ])
+  }
+
+  // The invariant the whole normalization exists for: the same outage against
+  // two different endpoints yields one equal error value.
+  @Test
+  func sameOutageOnDifferentEndpointsIsOneError() throws {
+    let metadata = Self.urlError(
+      code: NSURLErrorCannotConnectToHost,
+      failingURL: "https://example.com/api/documents/1/metadata/")
+    let notes = Self.urlError(
+      code: NSURLErrorCannotConnectToHost,
+      failingURL: "https://example.com/api/documents/1/notes/")
+
+    // The raw errors are *not* equal — their userInfo carries the failing URL.
+    // That is exactly why deduplicating on the raw error (or its description)
+    // cannot work, and why we normalize.
+    #expect(metadata != notes)
+
+    let a = try #require(RequestError(from: metadata))
+    let b = try #require(RequestError(from: notes))
+
+    #expect(a == b)
+    #expect(String(describing: a) == String(describing: b))
+  }
+
+  @Test
+  func preservesTheUnderlyingCode() throws {
+    let error = try #require(
+      RequestError(
+        from: Self.urlError(
+          code: NSURLErrorNotConnectedToInternet, failingURL: "https://example.com")))
+
+    // The code survives the conversion: `ErrorSuppression` still needs to tell
+    // "device offline" apart from "this server is unreachable".
+    guard case .connectivity(let code, let detail) = error else {
+      Issue.record("Expected .connectivity, got \(error)")
+      return
+    }
+    #expect(code == .notConnectedToInternet)
+    #expect(detail == "Could not connect to the server.")
+  }
+
+  @Test
+  func mapsSSLFailuresToCertificate() throws {
+    let error = try #require(
+      RequestError(
+        from: Self.urlError(
+          code: NSURLErrorServerCertificateUntrusted, failingURL: "https://example.com")))
+
+    guard case .certificate = error else {
+      Issue.record("Expected .certificate, got \(error)")
+      return
+    }
+  }
+
+  // Cancellation must never be reinterpreted as a connectivity failure — callers
+  // check for it separately and it must never reach the user as an error.
+  @Test
+  func doesNotConvertCancellation() {
+    #expect(
+      RequestError(
+        from: Self.urlError(code: NSURLErrorCancelled, failingURL: "https://example.com")) == nil)
+  }
+
+  // File-I/O codes are about the local filesystem during a download, not
+  // reachability, so they are left alone.
+  @Test
+  func doesNotConvertFileIOErrors() {
+    #expect(
+      RequestError(
+        from: Self.urlError(code: -3003, failingURL: "https://example.com")) == nil)
+  }
+
+  @Test
+  func doesNotConvertForeignDomains() {
+    let error = NSError(domain: "com.example.other", code: -1004)
+    #expect(RequestError(from: error) == nil)
+  }
+
+  @Test
+  func normalizingPassesThroughUnrelatedErrors() {
+    struct Custom: Error, Equatable {}
+    let result = RequestError.normalizing(Custom())
+    #expect(result as? Custom == Custom())
+  }
+
+  // End-to-end through the repository: an unreachable server makes the three
+  // enrichment endpoints the detail view loads fail with one identical error.
+  @Test
+  func repositoryCollapsesAnOutageAcrossEndpoints() async throws {
+    NormalizationMockURLProtocol.responder = { _ in throw URLError(.cannotConnectToHost) }
+    defer { NormalizationMockURLProtocol.reset() }
+
+    let repo = ApiRepository(
+      connection: Connection(
+        url: URL(string: "https://example.com")!, token: "t", identityName: nil,
+        serverID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!),
+      mode: .release,
+      contentStore: nil,
+      urlSession: NormalizationMockURLProtocol.makeSession())
+
+    var thrown: [RequestError] = []
+    for endpoint in ["metadata", "notes", "suggestions"] {
+      do {
+        switch endpoint {
+        case "metadata": _ = try await repo.metadata(documentId: 1)
+        case "notes": _ = try await repo.notes(documentId: 1)
+        default: _ = try await repo.suggestions(documentId: 1)
+        }
+        Issue.record("Expected \(endpoint) to throw")
+      } catch let error as RequestError {
+        thrown.append(error)
+      }
+    }
+
+    #expect(thrown.count == 3)
+    for error in thrown {
+      guard case .connectivity(let code, _) = error else {
+        Issue.record("Expected .connectivity, got \(error)")
+        continue
+      }
+      #expect(code == .cannotConnectToHost)
+    }
+
+    // One distinct value across all three → one toast, not three.
+    #expect(Set(thrown.map { String(describing: $0) }).count == 1)
+  }
+}

--- a/Persistence/Sources/Persistence/Database+Connections.swift
+++ b/Persistence/Sources/Persistence/Database+Connections.swift
@@ -7,8 +7,9 @@ import os
 ///
 /// These are the only entry points `ConnectionManager` uses to read or
 /// mutate `server` rows; GRDB stays hidden from AppShared and the rest of
-/// the app. Stage 7 will add analogous APIs for element and document
-/// records under the same principle ("GRDB is sealed inside Persistence").
+/// the app. `Database+Elements` and `Database+Documents` are the analogous
+/// APIs for the caches, under the same principle ("GRDB is sealed inside
+/// Persistence").
 extension Database {
   /// Fetch every connection row currently in the table.
   public func allConnections() throws(DatabaseError) -> [ConnectionRecord] {
@@ -76,8 +77,7 @@ extension Database {
   /// The first value is the current state (so callers can use this as both
   /// "initial hydrate" and "subsequent updates" in one loop). Cross-process
   /// changes (e.g. from the Share Extension) are not delivered live —
-  /// foreground re-hydrate covers that, as called out in Stage 5 of the
-  /// offline-cache plan.
+  /// foreground re-hydrate covers that.
   public func observeConnections() -> AsyncThrowingStream<[ConnectionRecord], Error> {
     let observation = ValueObservation.tracking(ConnectionRecord.fetchAll)
     let writer = writer

--- a/Persistence/Sources/Persistence/Database+DocumentDetail.swift
+++ b/Persistence/Sources/Persistence/Database+DocumentDetail.swift
@@ -68,7 +68,7 @@ extension Database {
     }
   }
 
-  // MARK: - Proactive detail fill (Stage 9)
+  // MARK: - Proactive detail fill
 
   /// Seed an empty `document_note` row for every cached document that reports
   /// zero notes and has no cached notes row yet — no network. The list/fill

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -96,8 +96,9 @@ extension Database {
   }
 
   /// Mark every cached query containing `remoteID` order-stale under its active
-  /// sort. v1 over-marks (any query the doc is a member of); the ordering
-  /// corrects on the next fill / delta.
+  /// sort. This deliberately over-marks — every query the document is a member
+  /// of, not only those whose sort field actually changed — because the ordering
+  /// corrects itself on the next fill / delta either way.
   public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID)
     throws(DatabaseError)
   {
@@ -175,7 +176,7 @@ extension Database {
   /// list). Called ahead of ``pruneUnreferencedDocuments(serverID:)`` on a
   /// `.entireLibrary` → `.recentlyBrowsed` downgrade: saved views proactively
   /// filled while `.entireLibrary` was active should no longer be tracked at
-  /// all — they eager-fill again from scratch if reopened (Stage 8), matching
+  /// all — they eager-fill again from scratch if reopened, matching
   /// what `.recentlyBrowsed` already does for any other saved view. Returns
   /// the number of `query_order` rows removed.
   @discardableResult

--- a/Persistence/Sources/Persistence/Database+SyncState.swift
+++ b/Persistence/Sources/Persistence/Database+SyncState.swift
@@ -1,11 +1,11 @@
 import Foundation
 import GRDB
 
-/// Per-server sync-cursor operations (`server_sync_state`). The delta watermark
-/// and the proactive-fill coverage timestamp are regenerable state, written by
-/// `CachingRepository` and reset by `clearCache`. Dates cross the boundary as
-/// `Date?`; the on-disk shape (REAL `timeIntervalSinceReferenceDate`) stays
-/// inside `Persistence`.
+/// Per-server sync-cursor operations (`server_sync_state`). The delta
+/// watermark, the proactive-fill coverage timestamp, and the last-successful-
+/// sync stamp are regenerable state, written by `CachingRepository` and reset
+/// by `clearCache`. Dates cross the boundary as `Date?`; the on-disk shape
+/// (REAL `timeIntervalSinceReferenceDate`) stays inside `Persistence`.
 extension Database {
   /// The newest document `modified` the changed-metadata delta has applied for
   /// this server, or `nil` if it has never baselined.
@@ -34,12 +34,49 @@ extension Database {
     }
   }
 
+  /// When this server's element sync last completed successfully, or `nil` if
+  /// never. The persisted "fresh as of" stamp: stalest-first background sweep
+  /// ordering and the Offline & Sync screen both read it.
+  public func lastSyncAt(serverID: UUID) throws -> Date? {
+    try date(\.lastSyncAt, serverID: serverID)
+  }
+
+  public func setLastSyncAt(_ date: Date?, serverID: UUID) throws {
+    try update(serverID: serverID) { $0.lastSyncAt = date?.timeIntervalSinceReferenceDate }
+  }
+
+  /// All servers' `last_sync_at` stamps in one read, for sweep ordering.
+  /// Servers with no row (or a `nil` stamp) are simply absent.
+  public func lastSyncAts() throws -> [UUID: Date] {
+    try writer.read { db in
+      let records = try ServerSyncStateRecord.fetchAll(db)
+      return Dictionary(
+        uniqueKeysWithValues: records.compactMap { record in
+          record.lastSyncAt.map { (record.serverId, Date(timeIntervalSinceReferenceDate: $0)) }
+        })
+    }
+  }
+
+  /// Observe this server's `last_sync_at`; same contract as
+  /// ``observeLibraryCoverageAt(serverID:)``.
+  public func observeLastSyncAt(serverID: UUID) -> AsyncThrowingStream<Date?, Error> {
+    observeStamp(serverID: serverID, \.lastSyncAt)
+  }
+
   /// Observe this server's `library_coverage_at`, emitting the current value
   /// immediately and again on every write (including a `clearCache` reset to
   /// `nil`). Backed by GRDB `ValueObservation`; consumers don't see GRDB types.
   public func observeLibraryCoverageAt(serverID: UUID) -> AsyncThrowingStream<Date?, Error> {
+    observeStamp(serverID: serverID, \.libraryCoverageAt)
+  }
+
+  // MARK: - Helpers
+
+  private func observeStamp(
+    serverID: UUID, _ keyPath: KeyPath<ServerSyncStateRecord, Double?> & Sendable
+  ) -> AsyncThrowingStream<Date?, Error> {
     let observation = ValueObservation.tracking { db in
-      try ServerSyncStateRecord.fetchOne(db, key: serverID)?.libraryCoverageAt
+      try ServerSyncStateRecord.fetchOne(db, key: serverID)?[keyPath: keyPath]
     }
     let writer = writer
     return AsyncThrowingStream { continuation in
@@ -59,8 +96,6 @@ extension Database {
     }
   }
 
-  // MARK: - Helpers
-
   private func date(
     _ keyPath: KeyPath<ServerSyncStateRecord, Double?>, serverID: UUID
   ) throws -> Date? {
@@ -71,7 +106,7 @@ extension Database {
     }
   }
 
-  /// Read-modify-write upsert preserving the row's other column.
+  /// Read-modify-write upsert preserving the row's other columns.
   private func update(
     serverID: UUID, _ mutate: (inout ServerSyncStateRecord) -> Void
   ) throws {

--- a/Persistence/Sources/Persistence/Migrations/Migrations.swift
+++ b/Persistence/Sources/Persistence/Migrations/Migrations.swift
@@ -87,6 +87,10 @@ enum Migrations {
       try V9_PromoteDocumentQueryColumns.run(db)
     }
 
+    migrator.registerMigration("v10_add_last_sync_at") { db in
+      try V10_AddLastSyncAt.run(db)
+    }
+
     return migrator
   }
 }

--- a/Persistence/Sources/Persistence/Migrations/V10_AddLastSyncAt.swift
+++ b/Persistence/Sources/Persistence/Migrations/V10_AddLastSyncAt.swift
@@ -4,7 +4,7 @@ import GRDB
 /// last completed successfully (`timeIntervalSinceReferenceDate`, REAL, like
 /// the other cursors).
 ///
-/// Stage 11 (background sync) needs a *persisted* per-server freshness stamp:
+/// Background sync needs a *persisted* per-server freshness stamp:
 /// a cold background launch has no in-memory throttle map, so stalest-first
 /// sweep ordering must come from the DB, and the Offline & Sync screen shows
 /// it as the honest "fresh as of last successful sync" surface. Regenerable

--- a/Persistence/Sources/Persistence/Migrations/V10_AddLastSyncAt.swift
+++ b/Persistence/Sources/Persistence/Migrations/V10_AddLastSyncAt.swift
@@ -1,0 +1,19 @@
+import GRDB
+
+/// Adds `last_sync_at` to `server_sync_state`: when this server's element sync
+/// last completed successfully (`timeIntervalSinceReferenceDate`, REAL, like
+/// the other cursors).
+///
+/// Stage 11 (background sync) needs a *persisted* per-server freshness stamp:
+/// a cold background launch has no in-memory throttle map, so stalest-first
+/// sweep ordering must come from the DB, and the Offline & Sync screen shows
+/// it as the honest "fresh as of last successful sync" surface. Regenerable
+/// like its siblings — the row is wiped by `clearCache` and cascade-deleted
+/// with its `server`.
+enum V10_AddLastSyncAt {
+  static func run(_ db: GRDB.Database) throws {
+    try db.alter(table: "server_sync_state") { t in
+      t.add(column: "last_sync_at", .real)
+    }
+  }
+}

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -1,6 +1,6 @@
 import GRDB
 
-/// Document-metadata cache tables (Stage 8).
+/// Document-metadata cache tables.
 ///
 /// Three tables, three jobs:
 ///

--- a/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
@@ -1,6 +1,6 @@
 import GRDB
 
-/// Per-document detail-cache tables (Stage 8 follow-up) — the two Tier-2
+/// Per-document detail-cache tables — the two Tier-2
 /// sub-resources that don't ride the `document` row's `data` blob because they
 /// have different keys and lifecycles:
 ///

--- a/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
@@ -9,7 +9,7 @@ import GRDB
 /// always returns the full list, and create/delete return the updated full list,
 /// so a cache write is a row *replace*, never a per-note merge. `DocumentNote`
 /// isn't `Codable`, so the long tail is an explicit storage `NotePayload` mapped
-/// by hand (the Stage 3 principle: storage shape ≠ wire shape ≠ domain shape).
+/// by hand (storage shape ≠ wire shape ≠ domain shape).
 public struct DocumentNoteRecord:
   FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
 {

--- a/Persistence/Sources/Persistence/Models/DocumentRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentRecord.swift
@@ -28,8 +28,8 @@ public enum DocumentEntry: Sendable, Equatable, Identifiable {
 ///
 /// Bespoke rather than an `ElementRecord`: documents are ordered through
 /// `query_order` (never by `name`), and `Document` is not `Codable` — so the long
-/// tail is an explicit storage `Payload`, mapped by hand (the Stage 3 principle:
-/// storage shape ≠ wire shape ≠ domain shape).
+/// tail is an explicit storage `Payload`, mapped by hand (storage shape ≠ wire
+/// shape ≠ domain shape).
 ///
 /// There is no projection/completeness level: the list always requests
 /// `full_perms`, so a stored row is always the complete object. "Loaded-ness" is

--- a/Persistence/Sources/Persistence/Models/QueryKey.swift
+++ b/Persistence/Sources/Persistence/Models/QueryKey.swift
@@ -22,7 +22,7 @@ import Foundation
 ///   independent of dictionary iteration order and of the transient
 ///   `FilterState.modified` flag (which is not a query parameter).
 ///
-/// Virtual / client-defined views (e.g. Stage 14's pinned "Downloaded" list) use
+/// Virtual / client-defined views (e.g. a future pinned "Downloaded" list) use
 /// a ``init(sentinel:)`` well-known key instead of a hash, since they have no
 /// server query to replay.
 public struct QueryKey: Hashable, Sendable {

--- a/Persistence/Sources/Persistence/Models/ServerSyncStateRecord.swift
+++ b/Persistence/Sources/Persistence/Models/ServerSyncStateRecord.swift
@@ -17,18 +17,22 @@ public struct ServerSyncStateRecord:
   public var serverId: UUID
   public var deltaWatermark: Double?
   public var libraryCoverageAt: Double?
+  public var lastSyncAt: Double?
 
   public init(
-    serverId: UUID, deltaWatermark: Double? = nil, libraryCoverageAt: Double? = nil
+    serverId: UUID, deltaWatermark: Double? = nil, libraryCoverageAt: Double? = nil,
+    lastSyncAt: Double? = nil
   ) {
     self.serverId = serverId
     self.deltaWatermark = deltaWatermark
     self.libraryCoverageAt = libraryCoverageAt
+    self.lastSyncAt = lastSyncAt
   }
 
   enum CodingKeys: String, CodingKey {
     case serverId = "server_id"
     case deltaWatermark = "delta_watermark"
     case libraryCoverageAt = "library_coverage_at"
+    case lastSyncAt = "last_sync_at"
   }
 }

--- a/Persistence/Sources/Persistence/Observation/Broadcaster.swift
+++ b/Persistence/Sources/Persistence/Observation/Broadcaster.swift
@@ -9,8 +9,7 @@ import Foundation
 /// Same shape as Combine's `PassthroughSubject` (drop-on-floor for late
 /// subscribers, no replay), but consumed as an `AsyncSequence`. Used here to
 /// observe GRDB table changes; also backs the discrete-event channels on
-/// `DocumentStore` / `ConnectionManager` (Stage 6) and will back the
-/// `CacheChange` signal in later offline-cache stages.
+/// `DocumentStore` / `ConnectionManager`.
 ///
 /// For SwiftUI consumers, prefer AppShared's `.onEvent(from:perform:)` — or
 /// ``sink(_:)`` directly, holding the returned ``Subscription`` in `@State` —

--- a/Persistence/Tests/PersistenceTests/DetailFillTests.swift
+++ b/Persistence/Tests/PersistenceTests/DetailFillTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @testable import Persistence
 
-/// Covers the proactive notes/file-metadata detail-fill support queries
-/// (Stage 9): the zero-note seed, the "needs a network fetch" sets, and the
-/// R3δ notes invalidation.
+/// Covers the proactive notes/file-metadata detail-fill support queries: the
+/// zero-note seed, the "needs a network fetch" sets, and the R3δ notes
+/// invalidation.
 @Suite("DetailFill")
 struct DetailFillTests {
   // MARK: - Helpers

--- a/Persistence/Tests/PersistenceTests/SyncStateTests.swift
+++ b/Persistence/Tests/PersistenceTests/SyncStateTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Persistence
+
+@Suite("Sync-state cursors")
+struct SyncStateTests {
+  @Test("v8 adds last_sync_at to server_sync_state")
+  func v8AddsLastSyncAt() throws {
+    let database = try Database.inMemory()
+    try database.writer.read { db in
+      let columns = Set(try db.columns(in: "server_sync_state").map(\.name))
+      #expect(columns == ["server_id", "delta_watermark", "library_coverage_at", "last_sync_at"])
+      let column = try #require(
+        try db.columns(in: "server_sync_state").first(where: { $0.name == "last_sync_at" }))
+      #expect(column.type.uppercased() == "REAL")
+      #expect(!column.isNotNull)
+    }
+  }
+
+  @Test("lastSyncAt round-trips and starts nil")
+  func lastSyncAtRoundTrip() throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    #expect(try database.lastSyncAt(serverID: server) == nil)
+
+    let stamp = Date(timeIntervalSinceReferenceDate: 12345.678)
+    try database.setLastSyncAt(stamp, serverID: server)
+    #expect(try database.lastSyncAt(serverID: server) == stamp)
+
+    try database.setLastSyncAt(nil, serverID: server)
+    #expect(try database.lastSyncAt(serverID: server) == nil)
+  }
+
+  @Test("setLastSyncAt preserves the row's other cursors")
+  func preservesSiblingCursors() throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let watermark = Date(timeIntervalSinceReferenceDate: 1000)
+    let coverage = Date(timeIntervalSinceReferenceDate: 2000)
+    try database.setDeltaWatermark(watermark, serverID: server)
+    try database.setLibraryCoverageAt(coverage, serverID: server)
+
+    try database.setLastSyncAt(Date(timeIntervalSinceReferenceDate: 3000), serverID: server)
+
+    #expect(try database.deltaWatermark(serverID: server) == watermark)
+    #expect(try database.libraryCoverageAt(serverID: server) == coverage)
+  }
+
+  @Test("lastSyncAts returns only servers with a stamp")
+  func bulkRead() throws {
+    let a = UUID()
+    let b = UUID()
+    let database = try Database.seeded(serverID: a)
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: b,
+        url: URL(string: "https://second.example.com/api/")!,
+        user: .init(id: 2, isSuperUser: false, username: "second")))
+
+    let stamp = Date(timeIntervalSinceReferenceDate: 42)
+    try database.setLastSyncAt(stamp, serverID: a)
+    // b gets a row but no stamp — must be absent from the bulk read.
+    try database.setDeltaWatermark(Date(), serverID: b)
+
+    #expect(try database.lastSyncAts() == [a: stamp])
+  }
+
+  @Test("clearCache resets last_sync_at")
+  func clearCacheResets() throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    try database.setLastSyncAt(Date(), serverID: server)
+
+    try database.clearCache()
+
+    #expect(try database.lastSyncAt(serverID: server) == nil)
+  }
+
+  @Test("observeLastSyncAt emits current value and updates")
+  func observation() async throws {
+    let server = UUID()
+    let database = try Database.seeded(serverID: server)
+    let stamp = Date(timeIntervalSinceReferenceDate: 7)
+
+    var iterator = database.observeLastSyncAt(serverID: server).makeAsyncIterator()
+    #expect(try await iterator.next() == .some(nil))
+
+    try database.setLastSyncAt(stamp, serverID: server)
+    #expect(try await iterator.next() == .some(stamp))
+  }
+}

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -14,16 +14,8 @@ import os
 struct ShareView: View {
   @ObservedObject var attachmentManager: AttachmentManager
 
-  // The extension process's own Database (app-group SQLite, WAL). The same DB
-  // backs the `ConnectionManager` and — wrapped in a `CachingRepository` in
-  // `refreshConnection` — the element cache, so the store's `ElementStore`
-  // projection observes the extension's own writes. Cross-process live
-  // notification isn't delivered (the extension syncs at launch), but the
-  // extension's in-process writes drive its own observation normally.
-  private let database: Database
-
   @State private var connectionManager: ConnectionManager
-  @State private var store = DocumentStore(repository: NullRepository())
+  @State private var store: DocumentStore
   @State private var storeReady = false
 
   @StateObject private var errorController = ErrorController()
@@ -35,9 +27,22 @@ struct ShareView: View {
   init(attachmentManager: AttachmentManager, callback: @escaping () -> Void) {
     self.attachmentManager = attachmentManager
     self.callback = callback
+    // The extension process's own Database (app-group SQLite, WAL). The same DB
+    // backs the `ConnectionManager` and — through the session's
+    // `CachingRepository` — the element cache, so the store's `ElementStore`
+    // projection observes the extension's own writes. Cross-process live
+    // notification isn't delivered (the extension syncs at launch), but the
+    // extension's in-process writes drive its own observation normally.
     let database = Self.bootstrapDatabase()
-    self.database = database
-    _connectionManager = State(initialValue: ConnectionManager(database: database))
+    let connectionManager = ConnectionManager(database: database)
+    _connectionManager = State(initialValue: connectionManager)
+    // The extension keeps the same one-session-per-server rule as the app, in a
+    // process that has no `SyncEngine` to share those sessions with. The registry
+    // is retained by the store; it is never `start()`ed, because an extension has
+    // no reason to react to connection edits made elsewhere.
+    _store = State(
+      initialValue: DocumentStore(
+        registry: ServerSessionRegistry(database: database, manager: connectionManager)))
   }
 
   // Open the app-group SQLite file. If the bootstrap fails (corrupt file,
@@ -94,11 +99,10 @@ struct ShareView: View {
         store.events.emit(.repositoryWillChange)
         // Caching outermost, over the extension's own DB, so the store's
         // ElementStore projection observes the writes its sync performs. The
-        // store owns that assembly (see `DocumentStore.activate`), so the
-        // extension can't drift from the app's layering.
+        // server's session owns that assembly (see `DocumentStore.activate`), so
+        // the extension can't drift from the app's layering.
         do {
-          try await store.activate(
-            connection: stored, database: database, manager: connectionManager)
+          try await store.activate(connection: stored)
         } catch {
           Logger.api.error("Could not build repository for active connection: \(error)")
           return

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -25,3 +25,4 @@
 - A failed cleanup of documents deleted on the server no longer stops the rest of the offline refresh
 - Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
+- Refreshing a document while the server is unreachable now shows a single error instead of repeating the same one several times, and the details explain what can cause it: the server being offline, a wrong address, or a VPN that isn't connected

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -27,3 +27,4 @@
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
 - Refreshing a document while the server is unreachable now shows a single error instead of repeating the same one several times, and the details explain what can cause it: the server being offline, a wrong address, or a VPN that isn't connected
 - Offline caches now also refresh while the app is closed: metadata syncs periodically in the background, and "Entire library" downloads top up on Wi-Fi, so your documents are fresh when you open the app
+- The Offline & Sync screen's activity row now also shows when a background sync started by the system is still running

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -23,3 +23,5 @@
 - Background sync and an open document list downloading at the same time no longer leave gaps in a cached list
 - A document you no longer have permission to view is no longer served from the offline cache as though the server were unreachable
 - A failed cleanup of documents deleted on the server no longer stops the rest of the offline refresh
+- Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
+- Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -26,3 +26,4 @@
 - Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
 - Refreshing a document while the server is unreachable now shows a single error instead of repeating the same one several times, and the details explain what can cause it: the server being offline, a wrong address, or a VPN that isn't connected
+- Offline caches now also refresh while the app is closed: metadata syncs periodically in the background, and "Entire library" downloads top up on Wi-Fi, so your documents are fresh when you open the app

--- a/swift-paperless/Info.plist
+++ b/swift-paperless/Info.plist
@@ -7,6 +7,17 @@
 		<string>com.paulgessinger.swift-paperless.sync.refresh</string>
 		<string>com.paulgessinger.swift-paperless.sync.processing</string>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>da</string>
+		<string>de</string>
+		<string>fr</string>
+		<string>it</string>
+		<string>nl</string>
+		<string>pl</string>
+		<string>tr</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/swift-paperless/Info.plist
+++ b/swift-paperless/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.paulgessinger.swift-paperless.sync.refresh</string>
+		<string>com.paulgessinger.swift-paperless.sync.processing</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -29,5 +34,10 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>

--- a/swift-paperless/Utilities/AppDelegate.swift
+++ b/swift-paperless/Utilities/AppDelegate.swift
@@ -66,16 +66,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     return configuration
   }
 
-  //  func application(
-  //          _ application: UIApplication,
-  //          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  //      ) -> Bool {
-  //          // Inject coordinator into scene delegate
-  //          if let sceneDelegate = UIApplication.shared.connectedScenes
-  //              .compactMap({ $0.delegate as? SceneDelegate })
-  //              .first {
-  //              sceneDelegate.routeManager = routeManager
-  //          }
-  //          return true
-  //      }
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    // BGTask handlers must be registered before app launch finishes — this
+    // covers cold background launches, where no scene ever connects.
+    BackgroundTaskManager.registerTasks()
+    BackgroundTaskManager.scheduleAll()
+    return true
+  }
 }

--- a/swift-paperless/Utilities/BackgroundTaskManager.swift
+++ b/swift-paperless/Utilities/BackgroundTaskManager.swift
@@ -1,0 +1,136 @@
+//
+//  BackgroundTaskManager.swift
+//  swift-paperless
+//
+//  Stage 11 (background sync): the app shell's BGTaskScheduler wiring — the
+//  only place in the project that imports BackgroundTasks (AppShared must stay
+//  extension-safe). Registration happens in AppDelegate before launch
+//  finishes; the handlers delegate to BackgroundSyncCoordinator, which decides
+//  between the registered UI graph and a headless stack.
+//
+//  Requests are (re)submitted at launch, on scenePhase == .background, and at
+//  the end of every background run — same-identifier submits replace the
+//  pending request, so this is idempotent. The earliestBeginDate values are
+//  floors, not cadences: the OS decides actual timing from its energy budget.
+//
+
+import AppShared
+import BackgroundTasks
+import Common
+import Foundation
+import os
+
+@MainActor
+enum BackgroundTaskManager {
+  static let refreshIdentifier = "com.paulgessinger.swift-paperless.sync.refresh"
+  static let processingIdentifier = "com.paulgessinger.swift-paperless.sync.processing"
+
+  /// Register both handlers. Must run before `didFinishLaunching` returns.
+  /// `using: .main` runs the launch handlers on the main queue, so
+  /// `MainActor.assumeIsolated` is sound under strict concurrency.
+  static func registerTasks() {
+    BGTaskScheduler.shared.register(forTaskWithIdentifier: refreshIdentifier, using: .main) {
+      task in
+      MainActor.assumeIsolated {
+        handle(task, label: "refresh") { await BackgroundSyncCoordinator.shared.runRefresh() }
+      }
+    }
+    BGTaskScheduler.shared.register(forTaskWithIdentifier: processingIdentifier, using: .main) {
+      task in
+      MainActor.assumeIsolated {
+        handle(task, label: "processing") {
+          await BackgroundSyncCoordinator.shared.runProcessing()
+        }
+      }
+    }
+  }
+
+  /// Submit (or refresh) both pending requests.
+  static func scheduleAll() {
+    scheduleRefresh()
+    scheduleProcessing()
+  }
+
+  // MARK: - Handling
+
+  private static func handle(
+    _ task: BGTask, label: String, _ body: @escaping @MainActor () async -> Bool
+  ) {
+    Logger.sync.info("Background task fired: \(label, privacy: .public)")
+    let work = Task { @MainActor in
+      await body()
+    }
+    // Expiration only cancels; cancellation propagates cooperatively into the
+    // sync machinery, whose watermarks/checkpoints persist for the next run.
+    task.expirationHandler = {
+      Logger.sync.info("Background task expiring: \(label, privacy: .public); cancelling work")
+      work.cancel()
+    }
+    Task { @MainActor in
+      let success = await work.value
+      scheduleAll()
+      // The single completion site for this task, success and expiration alike.
+      task.setTaskCompleted(success: success)
+      Logger.sync.info(
+        "Background task completed: \(label, privacy: .public) (success: \(success))")
+    }
+  }
+
+  // MARK: - Scheduling
+
+  private static func scheduleRefresh() {
+    let request = BGAppRefreshTaskRequest(identifier: refreshIdentifier)
+    request.earliestBeginDate = Date(timeIntervalSinceNow: 60 * 60)
+    submit(request)
+  }
+
+  private static func scheduleProcessing() {
+    // Skip — and drop any pending request — when no server wants the heavy
+    // fill. Unknown (nil: no UI graph registered, e.g. scheduling from a
+    // background launch) submits anyway; the handler no-ops cheaply rather
+    // than opening a headless database just to decide.
+    if BackgroundSyncCoordinator.shared.hasEntireLibraryServer() == false {
+      BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: processingIdentifier)
+      return
+    }
+    let request = BGProcessingTaskRequest(identifier: processingIdentifier)
+    request.earliestBeginDate = Date(timeIntervalSinceNow: 12 * 60 * 60)
+    request.requiresNetworkConnectivity = true
+    request.requiresExternalPower = false
+    submit(request)
+  }
+
+  private static func submit(_ request: BGTaskRequest) {
+    do {
+      try BGTaskScheduler.shared.submit(request)
+      Logger.sync.debug("Submitted background task request \(request.identifier, privacy: .public)")
+    } catch {
+      // Expected on the simulator (.unavailable); never fatal.
+      Logger.sync.info(
+        "Background task submit failed for \(request.identifier, privacy: .public): \(describe(error), privacy: .public)"
+      )
+    }
+  }
+
+  /// `BGTaskSchedulerError` renders as an opaque `Code=N "(null)"`; spell out
+  /// what each code actually means so the log line is actionable.
+  private static func describe(_ error: any Error) -> String {
+    guard let schedulerError = error as? BGTaskScheduler.Error else {
+      return String(describing: error)
+    }
+    return switch schedulerError.code {
+    case .unavailable:
+      "unavailable — background tasks are unsupported here (simulator or app extension) "
+        + "or Background App Refresh is off for this app (Settings, or Low Power Mode)"
+    case .tooManyPendingTaskRequests:
+      "too many pending task requests — submitted identifiers beyond the pending limit"
+    case .notPermitted:
+      "not permitted — identifier missing from BGTaskSchedulerPermittedIdentifiers "
+        + "or the background mode capability is absent"
+    case .immediateRunIneligible:
+      "immediate run ineligible — the system declined to start this task right away"
+    @unknown default:
+      "unrecognized BGTaskSchedulerError code \(schedulerError.code.rawValue)"
+    }
+  }
+}

--- a/swift-paperless/Utilities/BackgroundTaskManager.swift
+++ b/swift-paperless/Utilities/BackgroundTaskManager.swift
@@ -2,7 +2,7 @@
 //  BackgroundTaskManager.swift
 //  swift-paperless
 //
-//  Stage 11 (background sync): the app shell's BGTaskScheduler wiring — the
+//  Background sync: the app shell's BGTaskScheduler wiring — the
 //  only place in the project that imports BackgroundTasks (AppShared must stay
 //  extension-safe). Registration happens in AppDelegate before launch
 //  finishes; the handlers delegate to BackgroundSyncCoordinator, which decides

--- a/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
@@ -141,8 +141,8 @@ struct DocumentMetadataView: View {
 // - MARK: Preview
 
 #Preview {
-  @Previewable @State var store = DocumentStore(
-    repository: PreviewRepository(downloadDelay: 3.0))
+  @Previewable @State var store = DocumentStore.preview(
+    PreviewRepository(downloadDelay: 3.0))
   @Previewable @StateObject var errorController = ErrorController()
 
   @Previewable @State var document: Document?

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -21,17 +21,9 @@ struct SettingsView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
-  /// Threaded down to ``ConnectionsView`` so it can rebuild the full caching
-  /// repository stack when the active connection's extra headers change.
-  private let database: Database
-
   @State private var feedbackMailRequest: FeedbackMailRequest?
   @State private var showLoginSheet: Bool = false
   @State var identityManager = IdentityManager()
-
-  init(database: Database) {
-    self.database = database
-  }
 
   private func checked(_ fn: @escaping () async throws -> Void) async {
     do {
@@ -237,7 +229,6 @@ struct SettingsView: View {
       Form {
         ConnectionsView(
           connectionManager: connectionManager,
-          database: database,
           showLoginSheet: $showLoginSheet)
 
         Section(String(localized: .settings(.preferences))) {
@@ -300,14 +291,13 @@ struct SettingsView: View {
 #Preview("SettingsView") {
   @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @State var database = try! Database.inMemory()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   VStack {
   }
   .sheet(isPresented: .constant(true)) {
-    SettingsView(database: database)
+    SettingsView()
       .environment(store)
       .environment(connectionManager)
   }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -36,7 +36,7 @@ struct MainView: View {
   // Shared GRDB database, threaded into each connection's CachingRepository.
   private let database: Database
 
-  @State private var friendlyNameTask: Task<Void, Never>?
+  @State private var friendlyNameSubscription: Subscription?
 
   @StateObject private var errorController: ErrorController
 
@@ -273,22 +273,27 @@ struct MainView: View {
     // active connection. The nil-guard drops resets from store.clear() so
     // they don't wipe out a previously stored friendly name. setFriendlyName
     // is already idempotent, so no explicit dedup is needed.
-    friendlyNameTask?.cancel()
-    friendlyNameTask = Task { @MainActor [manager] in
-      while !Task.isCancelled {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
-        withObservationTracking {
-          _ = store.settings.appTitle
-        } onChange: {
-          continuation.yield()
-          continuation.finish()
+    //
+    // Held as a `Subscription` rather than a bare `Task` so it cancels when
+    // this view's `@State` storage is freed, the way the `AnyCancellable` it
+    // replaced did.
+    friendlyNameSubscription?.cancel()
+    friendlyNameSubscription = Subscription(
+      Task { @MainActor [manager] in
+        while !Task.isCancelled {
+          let (stream, continuation) = AsyncStream<Void>.makeStream()
+          withObservationTracking {
+            _ = store.settings.appTitle
+          } onChange: {
+            continuation.yield()
+            continuation.finish()
+          }
+          if let title = store.settings.appTitle {
+            manager.setFriendlyName(title)
+          }
+          for await _ in stream { break }
         }
-        if let title = store.settings.appTitle {
-          manager.setFriendlyName(title)
-        }
-        for await _ in stream { break }
-      }
-    }
+      })
   }
 
   private func setupQuickActions() {

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -24,6 +24,11 @@ struct MainView: View {
 
   @State private var manager: ConnectionManager
 
+  // Owns one ServerSession per configured server, for the lifetime of its row.
+  // Held here rather than inside the engine because it is the process's single
+  // source of per-server repositories, not a scheduling detail.
+  @State private var sessionRegistry: ServerSessionRegistry
+
   // Keeps every *inactive* server's offline cache warm (Stage 10). The active
   // server stays on the DocumentStore path; the engine skips it.
   @State private var syncEngine: SyncEngine
@@ -61,9 +66,11 @@ struct MainView: View {
     // Raw path cost, read live so the engine's observation-driven initial
     // sync gates on the current link — same source `isUnmetered` below reads,
     // combined per-server via `SyncCondition` rather than folded here.
+    let sessionRegistry = ServerSessionRegistry(database: database, manager: manager)
+    _sessionRegistry = State(wrappedValue: sessionRegistry)
     _syncEngine = State(
       wrappedValue: SyncEngine(
-        database: database,
+        registry: sessionRegistry,
         manager: manager,
         pathCost: { [weak networkMonitor] in
           guard let networkMonitor else { return (isExpensive: true, isConstrained: true) }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -242,6 +242,12 @@ struct MainView: View {
       }
 
       storeReady = true
+      // Register (or refresh) the UI graph with the background-sync coordinator
+      // *before* kicking the store's own sync: registration cancels-and-awaits
+      // any in-flight headless background run, so two CachingRepository
+      // instances never execute against the same server.
+      await BackgroundSyncCoordinator.shared.register(
+        database: database, manager: manager, syncEngine: syncEngine, store: target)
       try? await target.sync()
       target.startTaskPolling()
       kickLibraryFill(target)
@@ -253,6 +259,10 @@ struct MainView: View {
     } else {
       storeReady = false
       Logger.shared.trace("App does not have any active connection, show login screen")
+      // Still hand the graph over (store: nil): background runs can keep the
+      // configured-but-inactive servers warm while the user is logged out.
+      await BackgroundSyncCoordinator.shared.register(
+        database: database, manager: manager, syncEngine: syncEngine, store: nil)
       showLoginScreen = true
       showLoadingScreen = false
     }
@@ -421,6 +431,7 @@ struct MainView: View {
         Logger.shared.notice("App goes to background")
         biometricLockManager.lockIfEnabled()
         TransferStatistics.shared.persist()
+        BackgroundTaskManager.scheduleAll()
 
       case .active:
         store?.startTaskPolling()

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -29,7 +29,7 @@ struct MainView: View {
   // source of per-server repositories, not a scheduling detail.
   @State private var sessionRegistry: ServerSessionRegistry
 
-  // Keeps every *inactive* server's offline cache warm (Stage 10). The active
+  // Keeps every *inactive* server's offline cache warm. The active
   // server stays on the DocumentStore path; the engine skips it.
   @State private var syncEngine: SyncEngine
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -184,8 +184,7 @@ struct MainView: View {
   /// scenePhase path chains it after `sync()` directly.
   private func kickLibraryFill(_ store: DocumentStore, force: Bool = false) {
     Task {
-      await store.fillLibraryIfEnabled(unmetered: isUnmetered, force: force)
-      await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+      await store.runProactiveFill(unmetered: isUnmetered, force: force)
     }
   }
 
@@ -451,8 +450,7 @@ struct MainView: View {
           if let store {
             Task {
               try? await store.sync()
-              await store.fillLibraryIfEnabled(unmetered: isUnmetered)
-              await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+              await store.runProactiveFill(unmetered: isUnmetered)
             }
           }
           // Warm the inactive servers alongside the active refresh.

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -243,10 +243,10 @@ struct MainView: View {
       storeReady = true
       // Register (or refresh) the UI graph with the background-sync coordinator
       // *before* kicking the store's own sync: registration cancels-and-awaits
-      // any in-flight headless background run, so two CachingRepository
-      // instances never execute against the same server.
+      // any in-flight headless background run, whose separate registry would
+      // otherwise be a second owner of these servers' repositories.
       await BackgroundSyncCoordinator.shared.register(
-        database: database, manager: manager, syncEngine: syncEngine, store: target)
+        manager: manager, syncEngine: syncEngine)
       try? await target.sync()
       target.startTaskPolling()
       kickLibraryFill(target)
@@ -258,10 +258,10 @@ struct MainView: View {
     } else {
       storeReady = false
       Logger.shared.trace("App does not have any active connection, show login screen")
-      // Still hand the graph over (store: nil): background runs can keep the
-      // configured-but-inactive servers warm while the user is logged out.
+      // Still hand the graph over: background runs can keep the configured
+      // servers warm while the user is logged out.
       await BackgroundSyncCoordinator.shared.register(
-        database: database, manager: manager, syncEngine: syncEngine, store: nil)
+        manager: manager, syncEngine: syncEngine)
       showLoginScreen = true
       showLoadingScreen = false
     }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -212,13 +212,13 @@ struct MainView: View {
         return
       }
 
-      // The store assembles the active server's stack itself (identical to the
-      // per-server stacks the SyncEngine builds for inactive servers), so both the
-      // reuse and the first-launch path go through one entry point. A fresh store
-      // starts on `NullRepository` and is only published once `activate` succeeds —
-      // otherwise a failed login would leave a detached store installed.
+      // The store activates onto the *same* session the SyncEngine sweeps this
+      // server with, so the active and inactive paths share one repository rather
+      // than racing two. A fresh store starts serverless (`NullRepository`) and is
+      // only published once `activate` succeeds — otherwise a failed login would
+      // leave a detached store installed.
       let isNewStore = store == nil
-      let target = store ?? DocumentStore(repository: NullRepository())
+      let target = store ?? DocumentStore(registry: sessionRegistry)
 
       if !isNewStore {
         await sleep(.seconds(0.1))
@@ -227,7 +227,7 @@ struct MainView: View {
       }
 
       do {
-        try await target.activate(connection: stored, database: database, manager: manager)
+        try await target.activate(connection: stored)
       } catch {
         Logger.api.error("Could not build repository for active connection: \(error)")
         storeReady = false
@@ -367,7 +367,7 @@ struct MainView: View {
 
     .sheet(isPresented: $showSettings) {
       if let store {
-        SettingsView(database: database)
+        SettingsView()
           .environment(manager)
           .environment(store)
           .environment(networkMonitor)


### PR DESCRIPTION
This pull request introduces Stage 11 background sync support, enabling the app to perform background synchronization tasks reliably, even when the UI is not active. It also improves error messaging for connectivity issues and refines how network status is detected for background tasks. The main changes are grouped as follows:

**Background Sync Infrastructure:**

* Added a new `BackgroundSyncCoordinator` class to coordinate background sync tasks, ensuring only one `CachingRepository` per server runs at a time and supporting both UI-driven and headless (background-only) execution. (`AppShared/Sources/AppShared/Networking/BackgroundSyncCoordinator.swift`)
* Introduced a `NetworkPathProbe` utility that reads the raw path cost (`isExpensive` / `isConstrained`) for background runs. The heavy-fill decision is not made here: each server combines that cost with its own `syncOverCellular` via `SyncCondition`, so a heavy sync runs only where that particular server allows it. (`AppShared/Sources/AppShared/Networking/NetworkPathProbe.swift`)
* Updated `SyncEngine` to support different sync "tiers" (cheap vs. full), background-safe server selection, and stalest-first sweep ordering. (`AppShared/Sources/AppShared/Networking/SyncEngine.swift`) [[1]](diffhunk://#diff-5682fab0cb4c34ee6b21447d47f8cbe3495cfb9fa125780f8bdf514b93b129c7L13-R26) [[2]](diffhunk://#diff-5682fab0cb4c34ee6b21447d47f8cbe3495cfb9fa125780f8bdf514b93b129c7R39-R58) [[3]](diffhunk://#diff-5682fab0cb4c34ee6b21447d47f8cbe3495cfb9fa125780f8bdf514b93b129c7L102-R146)

**Sync State Tracking and UI Integration:**

* `DocumentStore` now observes and exposes the last successful sync timestamp (`lastSyncAt`), keeping the Offline & Sync screen up-to-date across app restarts and background runs. (`AppShared/Sources/AppShared/Document/DocumentStore.swift`) [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R70-R75) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R126-R129) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R157) [[4]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R168) [[5]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R183-R190) [[6]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70R210)
* `CachingRepository` persists the last successful sync time to the database, providing a single source of truth for sync freshness. (`AppShared/Sources/AppShared/Networking/CachingRepository.swift`)

**Error Messaging Improvements:**

* Improved user-facing error messages for connectivity issues by adding actionable hints based on the underlying `NSURLError` code, and ensured multi-paragraph messages retain line breaks for clarity. (`AppShared/Sources/AppShared/Networking/Error/RequestError+DisplayableError.swift`, `AppShared/Sources/AppShared/Networking/Error/RequestError+PresentableError.swift`) [[1]](diffhunk://#diff-32e558a1cb9b45e3a8f050c8b01b6edc9ebb0e093e820056c7586622e34d2da7R72-R90) [[2]](diffhunk://#diff-32e558a1cb9b45e3a8f050c8b01b6edc9ebb0e093e820056c7586622e34d2da7R114-R134) [[3]](diffhunk://#diff-6a3cc1b0ea9958458d187045a844d6ddee5120a62c387ad48ec109a9d8943d50R71-R75)

These changes collectively make background sync more reliable, observable, and user-friendly, especially in scenarios where the app is not in the foreground.

### Stack-wide comment sweep (2026-08-16)

Top commit **`docs: drop plan-stage references from code comments`** is not about background sync — it removes all 29 `Stage N` references across the whole tree (source *and* `DetailFillTests`), closing ledger item 10 / #662. Comments only, no behaviour.

It sits here because these are doc comments on lines the upper PRs rewrite: splitting the sweep across five PRs would have conflicted in every direction, and the stack merges as a unit. Three references pointed at stages that don't exist in the tree and were reworded rather than deleted. Requested by Paul on [#600](https://github.com/paulgessinger/swift-paperless/pull/600#discussion_r3791999577).

### Per-server cellular gating moved down to #618 (2026-08-22)

This PR used to carry `fix: respect each server's own Sync over cellular in
multi-server sweeps`. Codex flagged the underlying bug on #618, and since #618 is
what introduces it (a single `isUnmetered` derived from the *active* server and
applied to every inactive one), the fix belongs there rather than here. It moved
down, so this PR is correspondingly smaller.

The parts that could not move are the ones that do not exist at #618's tip:
`BackgroundSyncCoordinator` and `NetworkPathProbe` are introduced by
`feat: background sync coordinator + tiered SyncEngine sweeps`, so that commit now
introduces them in their `currentCost()` form directly, and carries the
scope-narrowing of the mid-sweep active guard that `.all` makes necessary.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync  👈
<!-- /jjp:stack-nav -->


