### PR TITLE
fix: restore the with-server document deep link

### DIFF
--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Fix the "Deep link (with backend)" option missing from a document's share menu

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -161,12 +161,12 @@ class DocumentDetailModel {
     return Endpoint.documentUrl(documentId: document.id).url(url: connection.url)
   }
 
-  // @TODO: Extract `private var serverURL: URL?` from `(store.repository as? ApiRepository)?.connection.url`,
-  // use it in both `documentUrl` and `deepLinks`, then drop the `connection` property and propagation through init/protocol/view.
+  // The server URL comes from the injected connection, not from downcasting
+  // `store.repository`: the store holds a wrapper (`NeedsAuthRepository<ApiRepository>`),
+  // so an `as? ApiRepository` cast silently fails and would drop the with-server link.
   var deepLinks: (withServer: Route?, withoutServer: Route?) {
-    let withServer: Route? = (store.repository as? ApiRepository).flatMap {
-      let serverURL = $0.connection.url
-      guard let server = serverURL.stringDroppingScheme else { return nil }
+    let withServer: Route? = connection.flatMap {
+      guard let server = $0.url.stringDroppingScheme else { return nil }
       return Route(action: .document(id: document.id, edit: nil), server: server)
     }
 


### PR DESCRIPTION
## Problem

A document's Share menu has a **Deep link** submenu with two entries, "without backend" and "with backend". The "with backend" entry has been missing for every real connection.

`DocumentDetailModel.deepLinks` derived the server component by downcasting the store's repository:

```swift
let withServer: Route? = (store.repository as? ApiRepository).flatMap { ... }
```

But since `593fe53f0` ("Per-connection needs-auth + global offline state", 2026-05-26) the store holds `NeedsAuthRepository(wrapping: api)` (`swift_paperlessApp.swift:157-159`). `NeedsAuthRepository` is its own `final class`, not an `ApiRepository` subclass, so the cast always returns nil, `withServer` is always nil, and `DocumentDetailViewV4`'s `if let url = deepLinks.withServer?.url` never renders the entry.

It fails silently: `flatMap` on a nil optional is a legal no-op, so there's no warning — just a missing menu item.

## Fix

Read the server URL from the injected `connection` instead, which is the same source the neighbouring `documentUrl` already uses. This is the value the downcast was reaching for anyway: the `ApiRepository` is constructed from `manager.connection` (`swift_paperlessApp.swift:157`), and `StoredConnection.connection` passes `url` through unchanged, so the emitted `server` string still round-trips against the connection matching in `handleUrl` (`swift_paperlessApp.swift:82-112`). The link no longer depends on the concrete repository type, so wrapping the repository again (e.g. the caching stack on the offline branch) won't silently break it.

The obsolete `@TODO` above `deepLinks` proposed keeping the downcast; it's replaced with a note on why we don't.

## Testing

- `build_sim` (iPhone 17 Pro, iOS 26.4): succeeds, no warnings.
- `just lint`: clean.
- No unit test: `DocumentDetailModel` lives in the app target, which carries only the UI-automation target — there's no unit test target that can reach it. Verifying this properly would mean moving `deepLinks` into a testable package, which is more than this fix warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)