### PR TITLE
fix: tolerate null name/body in GitHub release payloads

### DIFF
--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Fix the "What's New" screen failing to load when a release was published without release notes

--- a/swift-paperless/Views/ReleaseNotesView.swift
+++ b/swift-paperless/Views/ReleaseNotesView.swift
@@ -80,6 +80,18 @@ class ReleaseNotesViewModel {
     let prerelease: Bool
     let published_at: String
     let html_url: String
+
+    // GitHub sends `null` for `name` and `body` on releases published without a
+    // title or release notes, which would otherwise fail the whole array decode.
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      tag_name = try container.decode(String.self, forKey: .tag_name)
+      name = try container.decodeIfPresent(String.self, forKey: .name) ?? tag_name
+      body = try container.decodeIfPresent(String.self, forKey: .body) ?? ""
+      prerelease = try container.decode(Bool.self, forKey: .prerelease)
+      published_at = try container.decode(String.self, forKey: .published_at)
+      html_url = try container.decode(String.self, forKey: .html_url)
+    }
   }
 
   private struct ReleasesCache: Codable {


### PR DESCRIPTION
The "What's New" screen currently fails to load with:

```
Error fetching GitHub releases: DecodingError.valueNotFound: Expected value of type
String but found null instead. Path: [0].body.
```

## Cause

`ReleaseNotesViewModel.Release` declared `name` and `body` as non-optional `String`. GitHub returns `"body": null` for a release published without release notes, and the schema allows `"name": null` too. Because the payload is decoded as `[Release]`, one null field aborts the **entire** array — so a single untitled build wipes out the whole screen rather than just omitting that entry. No code change was needed to trigger this; publishing `builds/1.11.0/206` without notes was enough.

Verified against the live endpoint:

```
count 89
0 builds/1.11.0/206 -> body is null
```

Note that the older bodyless releases (`builds/1.9.0/179`, `v1.7.2`, …) come back as `""` rather than `null`, which is why this only surfaced now.

## Fix

Decode both fields with `decodeIfPresent`: `body` falls back to `""`, `name` falls back to `tag_name` (so an untitled release still gets a sensible heading if it does have a body). The existing filters in `loadAppStoreReleaseNotes`/`loadTestFlightReleaseNotes` already skip releases whose trimmed body is empty, so a bodyless release is now silently omitted instead of rendering an empty section.

## Verification

- Ran the same decoder against the live 89-release payload on the host: all 89 decode, and the `ReleasesCache` encode→decode round-trip (the on-disk ETag cache) still works.
- `build_sim` on iPhone 17 Pro / iOS 26.4: succeeded, no warnings.

No unit test: `Release` is a private type in the app target, which has no unit-test target (tests live only in the four cross-platform packages). Getting fixture-based coverage would mean moving this wire type into `Networking/Api/Wire/` — happy to do that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)