### PR TITLE
fix: use the `text` search parameter on Paperless-ngx 3.0+

### DIFF
--- a/DataModel/Sources/DataModel/FilterRuleType+Search.swift
+++ b/DataModel/Sources/DataModel/FilterRuleType+Search.swift
@@ -1,0 +1,23 @@
+//
+//  FilterRuleType+Search.swift
+//  DataModel
+//
+//  Hand-written companion to the generated `FilterRuleType.swift`.
+//
+
+extension FilterRuleType {
+  /// Whether this rule type maps to one of the search parameters that
+  /// paperless-ngx 3.0 routes through its Tantivy index.
+  ///
+  /// The backend accepts at most one of `text`, `title_search`, `query` and
+  /// `more_like_id` per request and answers with HTTP 400 ("Specify only one
+  /// of text, title_search, query, or more_like_id.") otherwise. Before 3.0
+  /// only `query` and `more_like_id` went through the search index, and the
+  /// remaining ones did not exist, so there was nothing to collide with.
+  public var isExclusiveSearchRule: Bool {
+    switch self {
+    case .simpleText, .simpleTitle, .fulltextQuery, .fulltextMorelike: true
+    default: false
+    }
+  }
+}

--- a/DataModel/Sources/DataModel/FilterState+RuleGeneration.swift
+++ b/DataModel/Sources/DataModel/FilterState+RuleGeneration.swift
@@ -8,10 +8,67 @@
 import Foundation
 
 extension FilterState {
+  /// Which set of document-search query parameters the generated rules target.
+  ///
+  /// Only the ``FilterState/SearchMode/titleContent`` mode differs between the
+  /// two; every other rule this type generates is encoded identically.
+  public enum SearchApi: Sendable, Equatable, CaseIterable {
+    /// Backends before paperless-ngx 3.0. "Title and content" search is the
+    /// ORM filter `title_content` (a SQL `icontains` over title and content).
+    case legacy
+
+    /// paperless-ngx 3.0+ / API v10. "Title and content" search is the
+    /// Tantivy-backed `text` parameter, which supersedes `title_content`.
+    /// The old parameter still works there but makes the backend log
+    /// "Deprecated document filter parameter 'title_content' used".
+    case tantivy
+  }
+
+  /// Rules encoded for pre-3.0 backends.
+  ///
+  /// Callers that know the backend should use ``rules(for:)`` instead — both
+  /// for requests and for the rules stored in saved views, so that no new
+  /// deprecated rule type is written to a backend that has moved on.
   public var rules: [FilterRule] {
-    var result = remaining
-    result += searchRules
-    result += fulltextQueryRules
+    rules(for: .legacy)
+  }
+
+  public func rules(for searchApi: SearchApi) -> [FilterRule] {
+    // The web UI treats "more like this" and a text search as two settings of
+    // one control: its text field is read-only while more-like is selected,
+    // and switching to a text search clears the more-like document
+    // (`changeTextFilterTarget` in filter-editor.component.ts). It therefore
+    // never emits both. Mirror that — a search the user typed supersedes a
+    // `more_like_id` carried in from a saved view built elsewhere.
+    var result =
+      searchText.isEmpty ? remaining : remaining.filter { $0.ruleType != .fulltextMorelike }
+
+    // paperless-ngx 3.0 answers `text` from its search index and rejects any
+    // request carrying more than one index-backed parameter (`text`,
+    // `title_search`, `query`, `more_like_id`) with HTTP 400. `title_content`
+    // is an ORM filter and combines freely, which is why this only matters for
+    // the new encoding.
+    //
+    // No rule reaching `remaining` holds that slot today — `more_like_id` was
+    // the only one, and it is gone by now. This is a safety net: should a
+    // future rule type stop being understood and land here, degrade to the
+    // deprecated-but-working parameter rather than provoke a 400.
+    let passedThroughSearchRule = result.contains { $0.ruleType.isExclusiveSearchRule }
+    let usesSimpleText =
+      searchApi == .tantivy && searchMode == .titleContent && !passedThroughSearchRule
+
+    // Relative date ranges are expressed as a `query`, which does collide. The
+    // web UI resolves this by folding the search text into the query string
+    // rather than emitting two parameters — see the "carry it over" branch in
+    // filter-editor.component.ts — so mirror that. It is also what this app
+    // already produces once such a filter has round-tripped through a saved
+    // view, because `query` rules populate the advanced search mode.
+    let promoteSearchTextIntoQuery = usesSimpleText && hasRelativeDateRange
+
+    if !promoteSearchTextIntoQuery {
+      result += searchRules(for: usesSimpleText ? .tantivy : .legacy)
+    }
+    result += fulltextQueryRules(promotingSearchText: promoteSearchTextIntoQuery)
     result += correspondentRules
     result += documentTypeRules
     result += storagePathRules
@@ -23,16 +80,27 @@ extension FilterState {
     return result
   }
 
-  private var searchRules: [FilterRule] {
+  private func searchRules(for searchApi: SearchApi) -> [FilterRule] {
     guard !searchText.isEmpty else { return [] }
     guard searchMode != .advanced else { return [] }
-    return [FilterRule(ruleType: searchMode.ruleType, value: .string(value: searchText))!]
+    return [
+      FilterRule(ruleType: searchMode.ruleType(for: searchApi), value: .string(value: searchText))!
+    ]
   }
 
-  private var fulltextQueryRules: [FilterRule] {
+  /// Whether the date filters produce a `query` rule, which is the only
+  /// index-backed parameter this type emits outside of advanced search.
+  private var hasRelativeDateRange: Bool {
+    for argument in [date.created, date.added, date.modified] {
+      if case .range = argument { return true }
+    }
+    return false
+  }
+
+  private func fulltextQueryRules(promotingSearchText: Bool) -> [FilterRule] {
     var components: [String] = []
 
-    if searchMode == .advanced, !searchText.isEmpty {
+    if searchMode == .advanced || promotingSearchText, !searchText.isEmpty {
       components.append(searchText)
     }
 

--- a/DataModel/Sources/DataModel/FilterState+RuleGeneration.swift
+++ b/DataModel/Sources/DataModel/FilterState+RuleGeneration.swift
@@ -10,29 +10,33 @@ import Foundation
 extension FilterState {
   /// Which set of document-search query parameters the generated rules target.
   ///
-  /// Only the ``FilterState/SearchMode/titleContent`` mode differs between the
-  /// two; every other rule this type generates is encoded identically.
+  /// Only the ``FilterState/SearchMode/titleContent`` and
+  /// ``FilterState/SearchMode/title`` modes differ between the two; every other
+  /// rule this type generates is encoded identically.
   public enum SearchApi: Sendable, Equatable, CaseIterable {
-    /// Backends before paperless-ngx 3.0. "Title and content" search is the
-    /// ORM filter `title_content` (a SQL `icontains` over title and content).
+    /// Backends before paperless-ngx 3.0. Searching is done with the ORM
+    /// filters `title_content` and `title__icontains`, both SQL `icontains`
+    /// over the live rows.
     case legacy
 
-    /// paperless-ngx 3.0+ / API v10. "Title and content" search is the
-    /// Tantivy-backed `text` parameter, which supersedes `title_content`.
-    /// The old parameter still works there but makes the backend log
-    /// "Deprecated document filter parameter 'title_content' used".
+    /// paperless-ngx 3.0+ / API v10. Searching is done with the Tantivy-backed
+    /// `text` and `title_search` parameters, which the 3.0 web UI uses in place
+    /// of the ORM filters.
+    ///
+    /// `title_content` is outright deprecated there — it still works, but makes
+    /// the backend log "Deprecated document filter parameter 'title_content'
+    /// used". `title__icontains` is not deprecated; it is swapped anyway so
+    /// that a given search returns the same documents in this app as it does in
+    /// the web UI.
     case tantivy
   }
 
-  /// Rules encoded for pre-3.0 backends.
+  /// Encodes this state as the rules to send to a backend, or to store in a
+  /// saved view on it.
   ///
-  /// Callers that know the backend should use ``rules(for:)`` instead — both
-  /// for requests and for the rules stored in saved views, so that no new
-  /// deprecated rule type is written to a backend that has moved on.
-  public var rules: [FilterRule] {
-    rules(for: .legacy)
-  }
-
+  /// There is deliberately no backend-agnostic overload: the encoding of the
+  /// text-search modes depends on the backend, and defaulting to either one
+  /// silently produces the wrong request against the other.
   public func rules(for searchApi: SearchApi) -> [FilterRule] {
     // The web UI treats "more like this" and a text search as two settings of
     // one control: its text field is read-only while more-like is selected,
@@ -43,19 +47,20 @@ extension FilterState {
     var result =
       searchText.isEmpty ? remaining : remaining.filter { $0.ruleType != .fulltextMorelike }
 
-    // paperless-ngx 3.0 answers `text` from its search index and rejects any
-    // request carrying more than one index-backed parameter (`text`,
-    // `title_search`, `query`, `more_like_id`) with HTTP 400. `title_content`
-    // is an ORM filter and combines freely, which is why this only matters for
+    // paperless-ngx 3.0 answers `text` and `title_search` from its search index
+    // and rejects any request carrying more than one index-backed parameter
+    // (`text`, `title_search`, `query`, `more_like_id`) with HTTP 400. The ORM
+    // filters they replace combine freely, which is why this only matters for
     // the new encoding.
     //
     // No rule reaching `remaining` holds that slot today — `more_like_id` was
     // the only one, and it is gone by now. This is a safety net: should a
     // future rule type stop being understood and land here, degrade to the
-    // deprecated-but-working parameter rather than provoke a 400.
+    // ORM encoding rather than provoke a 400.
     let passedThroughSearchRule = result.contains { $0.ruleType.isExclusiveSearchRule }
-    let usesSimpleText =
-      searchApi == .tantivy && searchMode == .titleContent && !passedThroughSearchRule
+    let usesIndexedSearch =
+      searchApi == .tantivy && searchMode.isIndexBacked(for: .tantivy)
+      && !passedThroughSearchRule
 
     // Relative date ranges are expressed as a `query`, which does collide. The
     // web UI resolves this by folding the search text into the query string
@@ -63,10 +68,15 @@ extension FilterState {
     // filter-editor.component.ts — so mirror that. It is also what this app
     // already produces once such a filter has round-tripped through a saved
     // view, because `query` rules populate the advanced search mode.
-    let promoteSearchTextIntoQuery = usesSimpleText && hasRelativeDateRange
+    //
+    // Note that this changes how the text matches: `text`/`title_search` run a
+    // regex over the indexed fields, so a partial word still matches, whereas
+    // the folded `query` is parsed into whole terms and no longer does. The web
+    // UI has the same behaviour, and matching it is the point.
+    let promoteSearchTextIntoQuery = usesIndexedSearch && hasRelativeDateRange
 
     if !promoteSearchTextIntoQuery {
-      result += searchRules(for: usesSimpleText ? .tantivy : .legacy)
+      result += searchRules(for: usesIndexedSearch ? .tantivy : .legacy)
     }
     result += fulltextQueryRules(promotingSearchText: promoteSearchTextIntoQuery)
     result += correspondentRules

--- a/DataModel/Sources/DataModel/FilterState+RulePopulation.swift
+++ b/DataModel/Sources/DataModel/FilterState+RulePopulation.swift
@@ -13,7 +13,7 @@ extension FilterState {
   internal mutating func populateWith(rules: [FilterRule]) {
     for rule in rules {
       switch rule.ruleType {
-      case .title, .content, .titleContent, .fulltextQuery:
+      case .title, .simpleTitle, .content, .titleContent, .simpleText, .fulltextQuery:
         handleSearchRule(rule)
       case .createdFrom, .createdTo, .addedFrom, .addedTo, .modifiedBefore, .modifiedAfter:
         handleDateBetweenRule(rule)

--- a/DataModel/Sources/DataModel/FilterState.swift
+++ b/DataModel/Sources/DataModel/FilterState.swift
@@ -30,15 +30,17 @@ public struct FilterState: Equatable, Codable, Sendable {
     case titleContent
     case advanced
 
-    public var ruleType: FilterRuleType {
-      ruleType(for: .legacy)
-    }
-
     public func ruleType(for searchApi: SearchApi) -> FilterRuleType {
       switch self {
       case .title:
-        .title
+        // The 3.0 web UI searches titles with the Tantivy-backed
+        // `title_search`. `title__icontains` is not deprecated, but using it
+        // would make the same search return different documents in this app
+        // than in the web UI.
+        searchApi == .tantivy ? .simpleTitle : .title
       case .content:
+        // The web UI has no content-only search, so there is nothing to
+        // mirror and no Tantivy equivalent to switch to.
         .content
       case .titleContent:
         // paperless-ngx 3.0 deprecated `title_content` in favour of the
@@ -49,11 +51,34 @@ public struct FilterState: Equatable, Codable, Sendable {
       }
     }
 
-    /// Maps a rule type onto the mode the UI offers.
+    /// Whether this mode's rule for `searchApi` is answered from the search
+    /// index, and therefore cannot be combined with another such parameter.
     ///
-    /// This is deliberately not injective: `title_content` (pre-3.0) and `text`
-    /// (3.0+) are two encodings of the same "title and content" mode, so a
-    /// saved view written by either the app or the 3.0 web UI round-trips.
+    /// ``FilterState/SearchMode/advanced`` is excluded: it *is* the `query`
+    /// parameter, so it has nothing to collide with and nothing to fold into.
+    func isIndexBacked(for searchApi: SearchApi) -> Bool {
+      self != .advanced && ruleType(for: searchApi).isExclusiveSearchRule
+    }
+
+    /// Recovers the search mode from a rule stored in a saved view.
+    ///
+    /// Saved views live on the server, so a rule may have been written by any
+    /// client against any backend version. Several rule types therefore denote
+    /// the same mode:
+    ///
+    ///     19 `title_content`  this app pre-3.0, and other pre-3.0 clients
+    ///     49 `text`           the 3.0 web UI, and this app on a 3.0 backend
+    ///     20 `title`          any client
+    ///     48 `title_search`   the 3.0 web UI
+    ///
+    /// Both encodings have to load into the mode the UI offers; otherwise a
+    /// view saved in the 3.0 web UI would fall through to `remaining` and
+    /// present an empty search field with an invisible filter attached.
+    ///
+    /// The mapping is many-to-one, and the inverse ``ruleType(for:)`` picks a
+    /// single encoding per backend. Nothing is lost, but note the consequence:
+    /// a view stored as 19 and saved again against a 3.0 backend comes back
+    /// as 49.
     public init?(ruleType: FilterRuleType) {
       switch ruleType {
       case .title, .simpleTitle:

--- a/DataModel/Sources/DataModel/FilterState.swift
+++ b/DataModel/Sources/DataModel/FilterState.swift
@@ -31,25 +31,36 @@ public struct FilterState: Equatable, Codable, Sendable {
     case advanced
 
     public var ruleType: FilterRuleType {
+      ruleType(for: .legacy)
+    }
+
+    public func ruleType(for searchApi: SearchApi) -> FilterRuleType {
       switch self {
       case .title:
         .title
       case .content:
         .content
       case .titleContent:
-        .titleContent
+        // paperless-ngx 3.0 deprecated `title_content` in favour of the
+        // Tantivy-backed `text` parameter.
+        searchApi == .tantivy ? .simpleText : .titleContent
       case .advanced:
         .fulltextQuery
       }
     }
 
+    /// Maps a rule type onto the mode the UI offers.
+    ///
+    /// This is deliberately not injective: `title_content` (pre-3.0) and `text`
+    /// (3.0+) are two encodings of the same "title and content" mode, so a
+    /// saved view written by either the app or the 3.0 web UI round-trips.
     public init?(ruleType: FilterRuleType) {
       switch ruleType {
-      case .title:
+      case .title, .simpleTitle:
         self = .title
       case .content:
         self = .content
-      case .titleContent:
+      case .titleContent, .simpleText:
         self = .titleContent
       case .fulltextQuery:
         self = .advanced

--- a/DataModel/Sources/DataModel/FilterState.swift
+++ b/DataModel/Sources/DataModel/FilterState.swift
@@ -26,9 +26,37 @@ public struct FilterState: Equatable, Codable, Sendable {
 
   public enum SearchMode: Equatable, Codable, CaseIterable, Sendable {
     case title
+
+    /// Retired: the paperless-ngx web UI no longer offers a content-only
+    /// search, so neither does this app. The case stays because the mode is
+    /// still *representable* — persisted filter states, `search_mode=content`
+    /// deeplinks and saved views carrying rule type 21 all decode into it, and
+    /// dropping it would reset those rather than migrate them.
+    ///
+    /// Use ``selectableCases`` to populate a picker, not `allCases`.
     case content
+
     case titleContent
     case advanced
+
+    /// The modes offered in the UI, mirroring the text-filter targets the web
+    /// UI exposes.
+    ///
+    /// A mode absent here can still be arrived at from a deeplink, a saved view
+    /// or a state persisted by an older build, so use
+    /// ``selectableCases(including:)`` where a current selection has to stay
+    /// representable.
+    public static let selectableCases: [SearchMode] = [.title, .titleContent, .advanced]
+
+    /// ``selectableCases``, plus `mode` when that is a retired one.
+    ///
+    /// The web UI does the same for its own retired targets — see the
+    /// `textFilterTargets` getter in filter-editor.component.ts, which appends
+    /// the deprecated option only while it is the active one. Without this a
+    /// picker bound to a retired mode would show no selection at all.
+    public static func selectableCases(including mode: SearchMode) -> [SearchMode] {
+      selectableCases.contains(mode) ? selectableCases : selectableCases + [mode]
+    }
 
     public func ruleType(for searchApi: SearchApi) -> FilterRuleType {
       switch self {

--- a/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
+++ b/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
@@ -1,0 +1,465 @@
+//
+//  FilterStateSearchApiTest.swift
+//  DataModel
+//
+//  Covers the pre-3.0 (`title_content`) vs 3.0+ (`text`) encodings of the
+//  "title and content" search mode.
+//
+
+import Foundation
+import Testing
+
+@testable import DataModel
+
+/// The two parameter names that carry a "title and content" search.
+private let legacySearchParameter = "title_content"
+private let tantivySearchParameter = "text"
+
+/// Parameters paperless-ngx 3.0 answers through its search index. It rejects
+/// requests carrying more than one of them with HTTP 400.
+private let exclusiveSearchParameters: Set<String> = [
+  "text", "title_search", "query", "more_like_id",
+]
+
+/// Encodes a state the way `Endpoint.documents` does, grouped by parameter name
+/// so the comparison does not depend on the (dictionary-derived) rule order.
+private func encoded(_ state: FilterState, for searchApi: FilterState.SearchApi) -> [String:
+  [String]]
+{
+  Dictionary(grouping: FilterRule.queryItems(for: state.rules(for: searchApi))) { $0.name }
+    .mapValues { $0.compactMap(\.value).sorted() }
+}
+
+private func withoutSearchParameters(_ items: [String: [String]]) -> [String: [String]] {
+  items.filter { $0.key != legacySearchParameter && !exclusiveSearchParameters.contains($0.key) }
+}
+
+private let searchText = "invoice 2024"
+
+/// A value each rule type will accept, so a sweep can instantiate all of them.
+/// Custom field queries need a parseable payload and are covered elsewhere.
+private func sampleValue(for ruleType: FilterRuleType) -> FilterRuleValue? {
+  switch ruleType.dataType() {
+  case .boolean: .boolean(value: true)
+  case .number: .number(value: 1)
+  case .date: .date(value: Date())
+  case .tag: .tag(id: 1)
+  case .correspondent: .correspondent(id: 1)
+  case .documentType: .documentType(id: 1)
+  case .storagePath: .storagePath(id: 1)
+  case .string: ruleType == .customFieldsQuery ? nil : .string(value: "x")
+  }
+}
+
+/// A state exercising every non-search rule generator at once, so the
+/// equivalence checks below are not just comparing two nearly empty rule sets.
+private func fullyPopulated(_ factory: (inout FilterState) -> Void) -> FilterState {
+  FilterState.empty.with {
+    $0.correspondent = .anyOf(ids: [1, 2])
+    $0.documentType = .noneOf(ids: [3])
+    $0.storagePath = .anyOf(ids: [4])
+    $0.owner = .noneOf(ids: [5])
+    $0.tags = .allOf(include: [6, 7], exclude: [8])
+    $0.asn = .greaterThan(42)
+    $0.customField = CustomFieldQuery(rawValue: #"[11,"exists","true"]"#)!
+    $0.date.created = .between(
+      start: datetime(year: 2024, month: 1, day: 1),
+      end: datetime(year: 2024, month: 12, day: 31))
+    factory(&$0)
+  }
+}
+
+/// States where the two encodings are expected to differ only in the name of
+/// the search parameter.
+private let divergingStates: [(String, FilterState)] = [
+  (
+    "bare title-and-content search",
+    FilterState.empty.with {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+    }
+  ),
+  (
+    "title-and-content search alongside every other filter",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+    }
+  ),
+]
+
+/// States where both encodings are expected to be byte-identical, either
+/// because the mode does not use the deprecated parameter at all, or because
+/// the exclusivity fallback kicks in.
+private let identicalStates: [(String, FilterState)] = [
+  ("empty state", FilterState.empty),
+  (
+    "title-only search",
+    fullyPopulated {
+      $0.searchMode = .title
+      $0.searchText = searchText
+    }
+  ),
+  (
+    "content-only search",
+    fullyPopulated {
+      $0.searchMode = .content
+      $0.searchText = searchText
+    }
+  ),
+  (
+    "advanced search",
+    fullyPopulated {
+      $0.searchMode = .advanced
+      $0.searchText = "title:invoice"
+    }
+  ),
+  (
+    "title-and-content mode with no search text",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = ""
+    }
+  ),
+  (
+    "a more_like_id saved view with no search text typed on top",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = ""
+      $0.remaining = [FilterRule(ruleType: .fulltextMorelike, value: .number(value: 17))!]
+    }
+  ),
+  (
+    "title-only search with a relative created range",
+    fullyPopulated {
+      $0.searchMode = .title
+      $0.searchText = searchText
+      $0.date.created = .range(.previousYear)
+    }
+  ),
+]
+
+/// States where the 3.0 encoding folds the search text into the `query` rule
+/// instead of emitting a second, colliding search parameter.
+private let promotedStates: [(String, FilterState)] = [
+  (
+    "relative created range",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+      $0.date.created = .range(.within(num: -3, interval: .month))
+    }
+  ),
+  (
+    "relative added range",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+      $0.date.added = .range(.previousQuarter)
+    }
+  ),
+  (
+    "relative created and added ranges",
+    fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+      $0.date.created = .range(.within(num: -1, interval: .week))
+      $0.date.added = .range(.today)
+    }
+  ),
+]
+
+private let allStates = divergingStates + identicalStates + promotedStates
+
+@Suite("Legacy vs Tantivy search parameter encoding")
+struct FilterStateSearchApiTest {
+  // - MARK: Equivalence
+
+  /// Guards the equivalence checks below against passing vacuously: if
+  /// `fullyPopulated` silently stopped producing rules, comparing two empty
+  /// parameter sets would still succeed.
+  @Test("The shared fixture exercises every non-search rule generator", .bug(id: "642"))
+  func fixtureIsNotEmpty() {
+    let state = fullyPopulated {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+    }
+
+    #expect(
+      Set(encoded(state, for: .legacy).keys) == [
+        "title_content",
+        "correspondent__id__in",
+        "document_type__id__none",
+        "storage_path__id__in",
+        "owner__id__none",
+        "tags__id__all",
+        "tags__id__none",
+        "archive_serial_number__gt",
+        "custom_field_query",
+        "created__date__gte",
+        "created__date__lte",
+      ])
+  }
+
+  @Test(
+    "Everything except the search parameters encodes identically for both backends",
+    .bug(id: "642"),
+    arguments: allStates)
+  func nonSearchParametersAreEquivalent(name: String, state: FilterState) {
+    let legacy = withoutSearchParameters(encoded(state, for: .legacy))
+    let tantivy = withoutSearchParameters(encoded(state, for: .tantivy))
+    #expect(legacy == tantivy, "\(name)")
+  }
+
+  @Test(
+    "The search text itself survives both encodings unchanged",
+    .bug(id: "642"),
+    arguments: divergingStates)
+  func searchTextIsPreserved(name: String, state: FilterState) {
+    let legacy = encoded(state, for: .legacy)
+    let tantivy = encoded(state, for: .tantivy)
+
+    #expect(legacy[legacySearchParameter] == [state.searchText], "\(name)")
+    #expect(legacy[tantivySearchParameter] == nil, "\(name)")
+
+    #expect(tantivy[tantivySearchParameter] == [state.searchText], "\(name)")
+    #expect(tantivy[legacySearchParameter] == nil, "\(name)")
+  }
+
+  @Test(
+    "Renaming the search parameter is the only difference between the encodings",
+    .bug(id: "642"),
+    arguments: divergingStates)
+  func encodingsDifferOnlyInTheParameterName(name: String, state: FilterState) {
+    var renamed = encoded(state, for: .legacy)
+    renamed[tantivySearchParameter] = renamed.removeValue(forKey: legacySearchParameter)
+
+    #expect(renamed == encoded(state, for: .tantivy), "\(name)")
+  }
+
+  @Test(
+    "Modes that do not use `title_content` encode identically on both backends",
+    .bug(id: "642"),
+    arguments: identicalStates)
+  func unaffectedStatesAreUnchanged(name: String, state: FilterState) {
+    #expect(encoded(state, for: .legacy) == encoded(state, for: .tantivy), "\(name)")
+  }
+
+  // - MARK: Where equivalence stops
+  //
+  // `text` is answered from the search index and cannot be combined with the
+  // other index-backed parameters, so a full one-to-one translation of every
+  // filter state is not possible.
+  //
+  // Where a relative date range would collide, the search text is folded into
+  // the `query` string instead — the same thing the web UI does in the "carry
+  // it over" branch of filter-editor.component.ts, and the same rules this app
+  // produces once the filter has round-tripped through a saved view. Matching
+  // then goes through the advanced query parser rather than a substring scan.
+  //
+  // Where a passed-through rule already holds the one search slot, there is
+  // nothing to fold into and the deprecated parameter stays.
+  //
+  // The remaining, deliberately untested, difference is server-side: on 3.0
+  // `text` matches per-token substrings against the search index, whereas
+  // `title_content` runs a SQL `icontains` over the live rows. Result sets can
+  // therefore differ for the same query; the app cannot assert that here.
+
+  @Test(
+    "A relative date range folds the search text into `query`",
+    .bug(id: "642"),
+    arguments: promotedStates)
+  func relativeDateRangePromotesSearchText(name: String, state: FilterState) throws {
+    let tantivy = encoded(state, for: .tantivy)
+    let legacy = encoded(state, for: .legacy)
+
+    // No separate search parameter survives — the query carries the text.
+    #expect(tantivy[legacySearchParameter] == nil, "\(name)")
+    #expect(tantivy[tantivySearchParameter] == nil, "\(name)")
+
+    // The legacy encoding is untouched: search parameter plus a query holding
+    // only the date terms. Prepending the text to it yields the 3.0 query, so
+    // no date term is lost or reordered by the fold.
+    let dateTerms = try #require(legacy["query"]?.first)
+    #expect(legacy[legacySearchParameter] == [state.searchText], "\(name)")
+    #expect(tantivy["query"] == ["\(state.searchText),\(dateTerms)"], "\(name)")
+  }
+
+  @Test("The folded query matches what a saved-view round trip produces", .bug(id: "642"))
+  func promotionMatchesSavedViewRoundTrip() {
+    let state = FilterState.empty.with {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+      $0.date.created = .range(.within(num: -3, interval: .month))
+    }
+
+    // Storing this filter as a saved view and reading it back turns it into an
+    // advanced search, because the `query` rule populates that mode.
+    let roundTripped = FilterState.create(using: \.empty, withRules: state.rules)
+    #expect(roundTripped.searchMode == .advanced)
+
+    #expect(encoded(state, for: .tantivy) == encoded(roundTripped, for: .tantivy))
+    #expect(encoded(state, for: .tantivy)["query"] == ["\(searchText),created:[-3 month to now]"])
+  }
+
+  @Test(
+    "A typed search supersedes a more_like_id carried in from a saved view",
+    .bug(id: "642"),
+    arguments: FilterState.SearchApi.allCases)
+  func typedSearchSupersedesMoreLikeId(searchApi: FilterState.SearchApi) {
+    let savedView = FilterState.empty.with {
+      $0.searchMode = .titleContent
+      $0.remaining = [FilterRule(ruleType: .fulltextMorelike, value: .number(value: 17))!]
+    }
+
+    // Untouched, the saved view keeps filtering by similarity.
+    #expect(encoded(savedView, for: searchApi)["more_like_id"] == ["17"])
+
+    // Typing a search takes over that one control, as it does in the web UI.
+    let searched = savedView.with { $0.searchText = searchText }
+    let encodedSearch = encoded(searched, for: searchApi)
+    #expect(encodedSearch["more_like_id"] == nil)
+    #expect(
+      encodedSearch[searchApi == .tantivy ? tantivySearchParameter : legacySearchParameter]
+        == [searchText])
+  }
+
+  @Test(
+    "At most one index-backed search parameter is ever emitted",
+    .bug(id: "642"),
+    arguments: allStates, FilterState.SearchApi.allCases)
+  func neverEmitsCollidingSearchParameters(
+    state: (String, FilterState), searchApi: FilterState.SearchApi
+  ) {
+    let names = Set(encoded(state.1, for: searchApi).keys)
+    #expect(
+      names.intersection(exclusiveSearchParameters).count <= 1,
+      "\(state.0) / \(searchApi)")
+  }
+
+  // - MARK: Rule types
+
+  @Test("Search modes map onto the rule type matching the backend", .bug(id: "642"))
+  func searchModeRuleTypes() {
+    #expect(FilterState.SearchMode.titleContent.ruleType(for: .legacy) == .titleContent)
+    #expect(FilterState.SearchMode.titleContent.ruleType(for: .tantivy) == .simpleText)
+
+    // Only the title-and-content mode changed in 3.0.
+    for mode in [FilterState.SearchMode.title, .content, .advanced] {
+      #expect(mode.ruleType(for: .legacy) == mode.ruleType(for: .tantivy))
+    }
+
+    // The default stays on the encoding every backend understands.
+    for mode in FilterState.SearchMode.allCases {
+      #expect(mode.ruleType == mode.ruleType(for: .legacy))
+    }
+  }
+
+  @Test(
+    "The bare `rules` property is the legacy encoding",
+    .bug(id: "642"),
+    arguments: allStates)
+  func bareRulesPropertyIsLegacy(name: String, state: FilterState) {
+    #expect(state.rules == state.rules(for: .legacy), "\(name)")
+  }
+
+  /// Saved views are stored server-side, so writing rule type 19 to a 3.0
+  /// backend would leave a deprecated rule behind for every client that reads
+  /// it back. The web UI writes 49 there, and so must we.
+  @Test("Saved views written for a 3.0 backend carry rule 49, not 19", .bug(id: "642"))
+  func savedViewRulesUseTheBackendsEncoding() {
+    let state = FilterState.empty.with {
+      $0.searchMode = .titleContent
+      $0.searchText = searchText
+    }
+
+    #expect(state.rules(for: .tantivy).map(\.ruleType) == [.simpleText])
+    #expect(state.rules(for: .legacy).map(\.ruleType) == [.titleContent])
+
+    // Rule 19 read back from an older saved view still round-trips into the
+    // same mode, so upgrading the stored rule loses nothing.
+    let stored = FilterState.create(
+      using: \.empty,
+      withRules: [FilterRule(ruleType: .titleContent, value: .string(value: searchText))!])
+    #expect(stored.rules(for: .tantivy).map(\.ruleType) == [.simpleText])
+  }
+
+  @Test("Both rule types round-trip into the same search mode", .bug(id: "642"))
+  func bothRuleTypesRoundTrip() {
+    #expect(FilterState.SearchMode(ruleType: .titleContent) == .titleContent)
+    #expect(FilterState.SearchMode(ruleType: .simpleText) == .titleContent)
+    #expect(FilterState.SearchMode(ruleType: .title) == .title)
+    #expect(FilterState.SearchMode(ruleType: .simpleTitle) == .title)
+  }
+
+  @Test(
+    "A saved view written by the 3.0 web UI populates the title-and-content mode",
+    .bug(id: "642"))
+  func populatesFromSimpleTextRule() {
+    let state = FilterState.create(
+      using: \.empty,
+      withRules: [FilterRule(ruleType: .simpleText, value: .string(value: searchText))!])
+
+    #expect(state.searchMode == .titleContent)
+    #expect(state.searchText == searchText)
+    // Not parked in `remaining`, which would have re-sent it verbatim.
+    #expect(state.remaining.isEmpty)
+
+    #expect(encoded(state, for: .legacy)[legacySearchParameter] == [searchText])
+    #expect(encoded(state, for: .tantivy)[tantivySearchParameter] == [searchText])
+  }
+
+  @Test(
+    "A saved view written by the 3.0 web UI populates the title-only mode",
+    .bug(id: "642"))
+  func populatesFromSimpleTitleRule() {
+    let state = FilterState.create(
+      using: \.empty,
+      withRules: [FilterRule(ruleType: .simpleTitle, value: .string(value: searchText))!])
+
+    #expect(state.searchMode == .title)
+    #expect(state.searchText == searchText)
+    #expect(state.remaining.isEmpty)
+  }
+
+  /// On a 3.0 backend the app must never generate the deprecated parameter.
+  /// Sweeping every rule type against every search mode keeps that honest: if a
+  /// future rule type stops being handled by `populateWith` and lands in
+  /// `remaining`, or a new index-backed one appears, this fails rather than
+  /// quietly reintroducing requests that log a deprecation warning.
+  @Test("`title_content` is never generated for a 3.0 backend", .bug(id: "642"))
+  func neverGeneratesLegacyParameterForTantivy() {
+    var residual: [String] = []
+
+    for ruleType in FilterRuleType.allCases {
+      guard let value = sampleValue(for: ruleType),
+        let rule = FilterRule(ruleType: ruleType, value: value)
+      else { continue }
+
+      // Go through the saved-view path rather than assigning `remaining`
+      // directly: only rules `populateWith` does not understand end up there,
+      // and those are the only ones a server can actually hand us.
+      let loaded = FilterState.create(using: \.empty, withRules: [rule])
+
+      for mode in FilterState.SearchMode.allCases {
+        // The user then types into the search field on top of the saved view.
+        let state = loaded.with {
+          $0.searchMode = mode
+          $0.searchText = searchText
+        }
+        if encoded(state, for: .tantivy)[legacySearchParameter] != nil {
+          residual.append("\(ruleType) + \(mode)")
+        }
+      }
+    }
+
+    #expect(residual == [])
+  }
+
+  @Test("Only the index-backed rule types are flagged as exclusive", .bug(id: "642"))
+  func exclusiveSearchRuleFlag() {
+    let exclusive = FilterRuleType.allCases.filter(\.isExclusiveSearchRule)
+    #expect(Set(exclusive) == [.simpleText, .simpleTitle, .fulltextQuery, .fulltextMorelike])
+    #expect(Set(exclusive.compactMap { $0.filterVar() }) == exclusiveSearchParameters)
+  }
+}

--- a/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
+++ b/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
@@ -2,8 +2,8 @@
 //  FilterStateSearchApiTest.swift
 //  DataModel
 //
-//  Covers the pre-3.0 (`title_content`) vs 3.0+ (`text`) encodings of the
-//  "title and content" search mode.
+//  Covers the pre-3.0 (`title_content`, `title__icontains`) vs 3.0+ (`text`,
+//  `title_search`) encodings of the text-search modes.
 //
 
 import Foundation
@@ -11,15 +11,35 @@ import Testing
 
 @testable import DataModel
 
-/// The two parameter names that carry a "title and content" search.
-private let legacySearchParameter = "title_content"
-private let tantivySearchParameter = "text"
+/// The parameter names carrying a "title and content" search.
+private let legacyTitleContentParameter = "title_content"
+private let tantivyTitleContentParameter = "text"
+
+/// The parameter names carrying a title-only search.
+private let legacyTitleParameter = "title__icontains"
+private let tantivyTitleParameter = "title_search"
 
 /// Parameters paperless-ngx 3.0 answers through its search index. It rejects
 /// requests carrying more than one of them with HTTP 400.
 private let exclusiveSearchParameters: Set<String> = [
   "text", "title_search", "query", "more_like_id",
 ]
+
+/// The ORM parameters the 3.0 encoding replaces. Neither may appear in a
+/// request generated for a 3.0 backend.
+///
+/// `content__icontains` is deliberately absent: the web UI has no content-only
+/// search, so there is no Tantivy parameter to swap it for and it stays put on
+/// both backends.
+private let supersededSearchParameters: Set<String> = [
+  legacyTitleContentParameter, legacyTitleParameter,
+]
+
+/// Every parameter that can carry the search text under either encoding.
+private let searchTextParameters =
+  exclusiveSearchParameters
+  .union(supersededSearchParameters)
+  .union(["content__icontains"])
 
 /// Encodes a state the way `Endpoint.documents` does, grouped by parameter name
 /// so the comparison does not depend on the (dictionary-derived) rule order.
@@ -31,7 +51,7 @@ private func encoded(_ state: FilterState, for searchApi: FilterState.SearchApi)
 }
 
 private func withoutSearchParameters(_ items: [String: [String]]) -> [String: [String]] {
-  items.filter { $0.key != legacySearchParameter && !exclusiveSearchParameters.contains($0.key) }
+  items.filter { !searchTextParameters.contains($0.key) }
 }
 
 private let searchText = "invoice 2024"
@@ -69,22 +89,53 @@ private func fullyPopulated(_ factory: (inout FilterState) -> Void) -> FilterSta
   }
 }
 
-/// States where the two encodings are expected to differ only in the name of
-/// the search parameter.
-private let divergingStates: [(String, FilterState)] = [
-  (
-    "bare title-and-content search",
-    FilterState.empty.with {
+/// A state whose two encodings differ only in the name of the parameter
+/// carrying the search text.
+private struct DivergingState: Sendable {
+  let name: String
+  let state: FilterState
+  /// Where the pre-3.0 encoding puts the search text.
+  let legacyParameter: String
+  /// Where the 3.0 encoding puts it instead.
+  let tantivyParameter: String
+}
+
+private let divergingStates: [DivergingState] = [
+  DivergingState(
+    name: "bare title-and-content search",
+    state: FilterState.empty.with {
       $0.searchMode = .titleContent
       $0.searchText = searchText
-    }
+    },
+    legacyParameter: legacyTitleContentParameter,
+    tantivyParameter: tantivyTitleContentParameter
   ),
-  (
-    "title-and-content search alongside every other filter",
-    fullyPopulated {
+  DivergingState(
+    name: "title-and-content search alongside every other filter",
+    state: fullyPopulated {
       $0.searchMode = .titleContent
       $0.searchText = searchText
-    }
+    },
+    legacyParameter: legacyTitleContentParameter,
+    tantivyParameter: tantivyTitleContentParameter
+  ),
+  DivergingState(
+    name: "bare title-only search",
+    state: FilterState.empty.with {
+      $0.searchMode = .title
+      $0.searchText = searchText
+    },
+    legacyParameter: legacyTitleParameter,
+    tantivyParameter: tantivyTitleParameter
+  ),
+  DivergingState(
+    name: "title-only search alongside every other filter",
+    state: fullyPopulated {
+      $0.searchMode = .title
+      $0.searchText = searchText
+    },
+    legacyParameter: legacyTitleParameter,
+    tantivyParameter: tantivyTitleParameter
   ),
 ]
 
@@ -94,13 +145,7 @@ private let divergingStates: [(String, FilterState)] = [
 private let identicalStates: [(String, FilterState)] = [
   ("empty state", FilterState.empty),
   (
-    "title-only search",
-    fullyPopulated {
-      $0.searchMode = .title
-      $0.searchText = searchText
-    }
-  ),
-  (
+    // The web UI has no content-only search, so nothing is mirrored here.
     "content-only search",
     fullyPopulated {
       $0.searchMode = .content
@@ -129,47 +174,63 @@ private let identicalStates: [(String, FilterState)] = [
       $0.remaining = [FilterRule(ruleType: .fulltextMorelike, value: .number(value: 17))!]
     }
   ),
-  (
-    "title-only search with a relative created range",
-    fullyPopulated {
-      $0.searchMode = .title
-      $0.searchText = searchText
-      $0.date.created = .range(.previousYear)
-    }
-  ),
 ]
 
-/// States where the 3.0 encoding folds the search text into the `query` rule
+/// A state where the 3.0 encoding folds the search text into the `query` rule
 /// instead of emitting a second, colliding search parameter.
-private let promotedStates: [(String, FilterState)] = [
-  (
-    "relative created range",
-    fullyPopulated {
+private struct PromotedState: Sendable {
+  let name: String
+  let state: FilterState
+  /// Where the pre-3.0 encoding still puts the search text. The 3.0 encoding
+  /// has no separate parameter at all.
+  let legacyParameter: String
+}
+
+private let promotedStates: [PromotedState] = [
+  PromotedState(
+    name: "relative created range",
+    state: fullyPopulated {
       $0.searchMode = .titleContent
       $0.searchText = searchText
       $0.date.created = .range(.within(num: -3, interval: .month))
-    }
+    },
+    legacyParameter: legacyTitleContentParameter
   ),
-  (
-    "relative added range",
-    fullyPopulated {
+  PromotedState(
+    name: "relative added range",
+    state: fullyPopulated {
       $0.searchMode = .titleContent
       $0.searchText = searchText
       $0.date.added = .range(.previousQuarter)
-    }
+    },
+    legacyParameter: legacyTitleContentParameter
   ),
-  (
-    "relative created and added ranges",
-    fullyPopulated {
+  PromotedState(
+    name: "relative created and added ranges",
+    state: fullyPopulated {
       $0.searchMode = .titleContent
       $0.searchText = searchText
       $0.date.created = .range(.within(num: -1, interval: .week))
       $0.date.added = .range(.today)
-    }
+    },
+    legacyParameter: legacyTitleContentParameter
+  ),
+  // Title-only search is index-backed on 3.0 too, so it folds identically.
+  PromotedState(
+    name: "title-only search with a relative created range",
+    state: fullyPopulated {
+      $0.searchMode = .title
+      $0.searchText = searchText
+      $0.date.created = .range(.previousYear)
+    },
+    legacyParameter: legacyTitleParameter
   ),
 ]
 
-private let allStates = divergingStates + identicalStates + promotedStates
+private let allStates =
+  divergingStates.map { ($0.name, $0.state) }
+  + identicalStates
+  + promotedStates.map { ($0.name, $0.state) }
 
 @Suite("Legacy vs Tantivy search parameter encoding")
 struct FilterStateSearchApiTest {
@@ -215,30 +276,30 @@ struct FilterStateSearchApiTest {
     "The search text itself survives both encodings unchanged",
     .bug(id: "642"),
     arguments: divergingStates)
-  func searchTextIsPreserved(name: String, state: FilterState) {
-    let legacy = encoded(state, for: .legacy)
-    let tantivy = encoded(state, for: .tantivy)
+  fileprivate func searchTextIsPreserved(fixture: DivergingState) {
+    let legacy = encoded(fixture.state, for: .legacy)
+    let tantivy = encoded(fixture.state, for: .tantivy)
 
-    #expect(legacy[legacySearchParameter] == [state.searchText], "\(name)")
-    #expect(legacy[tantivySearchParameter] == nil, "\(name)")
+    #expect(legacy[fixture.legacyParameter] == [fixture.state.searchText], "\(fixture.name)")
+    #expect(legacy[fixture.tantivyParameter] == nil, "\(fixture.name)")
 
-    #expect(tantivy[tantivySearchParameter] == [state.searchText], "\(name)")
-    #expect(tantivy[legacySearchParameter] == nil, "\(name)")
+    #expect(tantivy[fixture.tantivyParameter] == [fixture.state.searchText], "\(fixture.name)")
+    #expect(tantivy[fixture.legacyParameter] == nil, "\(fixture.name)")
   }
 
   @Test(
     "Renaming the search parameter is the only difference between the encodings",
     .bug(id: "642"),
     arguments: divergingStates)
-  func encodingsDifferOnlyInTheParameterName(name: String, state: FilterState) {
-    var renamed = encoded(state, for: .legacy)
-    renamed[tantivySearchParameter] = renamed.removeValue(forKey: legacySearchParameter)
+  fileprivate func encodingsDifferOnlyInTheParameterName(fixture: DivergingState) {
+    var renamed = encoded(fixture.state, for: .legacy)
+    renamed[fixture.tantivyParameter] = renamed.removeValue(forKey: fixture.legacyParameter)
 
-    #expect(renamed == encoded(state, for: .tantivy), "\(name)")
+    #expect(renamed == encoded(fixture.state, for: .tantivy), "\(fixture.name)")
   }
 
   @Test(
-    "Modes that do not use `title_content` encode identically on both backends",
+    "Modes with no Tantivy counterpart encode identically on both backends",
     .bug(id: "642"),
     arguments: identicalStates)
   func unaffectedStatesAreUnchanged(name: String, state: FilterState) {
@@ -247,42 +308,42 @@ struct FilterStateSearchApiTest {
 
   // - MARK: Where equivalence stops
   //
-  // `text` is answered from the search index and cannot be combined with the
-  // other index-backed parameters, so a full one-to-one translation of every
-  // filter state is not possible.
+  // `text` and `title_search` are answered from the search index and cannot be
+  // combined with the other index-backed parameters, so a full one-to-one
+  // translation of every filter state is not possible.
   //
   // Where a relative date range would collide, the search text is folded into
   // the `query` string instead — the same thing the web UI does in the "carry
   // it over" branch of filter-editor.component.ts, and the same rules this app
-  // produces once the filter has round-tripped through a saved view. Matching
-  // then goes through the advanced query parser rather than a substring scan.
+  // produces once the filter has round-tripped through a saved view.
   //
   // Where a passed-through rule already holds the one search slot, there is
-  // nothing to fold into and the deprecated parameter stays.
+  // nothing to fold into and the ORM parameter stays.
   //
   // The remaining, deliberately untested, difference is server-side: on 3.0
-  // `text` matches per-token substrings against the search index, whereas
-  // `title_content` runs a SQL `icontains` over the live rows. Result sets can
-  // therefore differ for the same query; the app cannot assert that here.
+  // `text`/`title_search` run a regex against the indexed fields, whereas the
+  // ORM filters run a SQL `icontains` over the live rows and the folded `query`
+  // is parsed into whole terms. Result sets therefore differ for the same
+  // query — a partial word matches under `text` but not once folded — and the
+  // app cannot assert any of that here. The web UI has the same behaviour.
 
   @Test(
     "A relative date range folds the search text into `query`",
     .bug(id: "642"),
     arguments: promotedStates)
-  func relativeDateRangePromotesSearchText(name: String, state: FilterState) throws {
-    let tantivy = encoded(state, for: .tantivy)
-    let legacy = encoded(state, for: .legacy)
+  fileprivate func relativeDateRangePromotesSearchText(fixture: PromotedState) throws {
+    let tantivy = encoded(fixture.state, for: .tantivy)
+    let legacy = encoded(fixture.state, for: .legacy)
 
     // No separate search parameter survives — the query carries the text.
-    #expect(tantivy[legacySearchParameter] == nil, "\(name)")
-    #expect(tantivy[tantivySearchParameter] == nil, "\(name)")
+    #expect(Set(tantivy.keys).intersection(searchTextParameters) == ["query"], "\(fixture.name)")
 
     // The legacy encoding is untouched: search parameter plus a query holding
     // only the date terms. Prepending the text to it yields the 3.0 query, so
     // no date term is lost or reordered by the fold.
     let dateTerms = try #require(legacy["query"]?.first)
-    #expect(legacy[legacySearchParameter] == [state.searchText], "\(name)")
-    #expect(tantivy["query"] == ["\(state.searchText),\(dateTerms)"], "\(name)")
+    #expect(legacy[fixture.legacyParameter] == [fixture.state.searchText], "\(fixture.name)")
+    #expect(tantivy["query"] == ["\(fixture.state.searchText),\(dateTerms)"], "\(fixture.name)")
   }
 
   @Test("The folded query matches what a saved-view round trip produces", .bug(id: "642"))
@@ -295,7 +356,7 @@ struct FilterStateSearchApiTest {
 
     // Storing this filter as a saved view and reading it back turns it into an
     // advanced search, because the `query` rule populates that mode.
-    let roundTripped = FilterState.create(using: \.empty, withRules: state.rules)
+    let roundTripped = FilterState.create(using: \.empty, withRules: state.rules(for: .legacy))
     #expect(roundTripped.searchMode == .advanced)
 
     #expect(encoded(state, for: .tantivy) == encoded(roundTripped, for: .tantivy))
@@ -320,7 +381,8 @@ struct FilterStateSearchApiTest {
     let encodedSearch = encoded(searched, for: searchApi)
     #expect(encodedSearch["more_like_id"] == nil)
     #expect(
-      encodedSearch[searchApi == .tantivy ? tantivySearchParameter : legacySearchParameter]
+      encodedSearch[
+        searchApi == .tantivy ? tantivyTitleContentParameter : legacyTitleContentParameter]
         == [searchText])
   }
 
@@ -344,23 +406,23 @@ struct FilterStateSearchApiTest {
     #expect(FilterState.SearchMode.titleContent.ruleType(for: .legacy) == .titleContent)
     #expect(FilterState.SearchMode.titleContent.ruleType(for: .tantivy) == .simpleText)
 
-    // Only the title-and-content mode changed in 3.0.
-    for mode in [FilterState.SearchMode.title, .content, .advanced] {
+    #expect(FilterState.SearchMode.title.ruleType(for: .legacy) == .title)
+    #expect(FilterState.SearchMode.title.ruleType(for: .tantivy) == .simpleTitle)
+
+    // The web UI has no content-only search, and advanced search is the `query`
+    // parameter on both backends, so neither mode has anything to switch to.
+    for mode in [FilterState.SearchMode.content, .advanced] {
       #expect(mode.ruleType(for: .legacy) == mode.ruleType(for: .tantivy))
     }
 
-    // The default stays on the encoding every backend understands.
+    // Only the modes routed through the index need the collision handling.
+    #expect(FilterState.SearchMode.titleContent.isIndexBacked(for: .tantivy))
+    #expect(FilterState.SearchMode.title.isIndexBacked(for: .tantivy))
+    #expect(!FilterState.SearchMode.content.isIndexBacked(for: .tantivy))
+    #expect(!FilterState.SearchMode.advanced.isIndexBacked(for: .tantivy))
     for mode in FilterState.SearchMode.allCases {
-      #expect(mode.ruleType == mode.ruleType(for: .legacy))
+      #expect(!mode.isIndexBacked(for: .legacy))
     }
-  }
-
-  @Test(
-    "The bare `rules` property is the legacy encoding",
-    .bug(id: "642"),
-    arguments: allStates)
-  func bareRulesPropertyIsLegacy(name: String, state: FilterState) {
-    #expect(state.rules == state.rules(for: .legacy), "\(name)")
   }
 
   /// Saved views are stored server-side, so writing rule type 19 to a 3.0
@@ -405,8 +467,8 @@ struct FilterStateSearchApiTest {
     // Not parked in `remaining`, which would have re-sent it verbatim.
     #expect(state.remaining.isEmpty)
 
-    #expect(encoded(state, for: .legacy)[legacySearchParameter] == [searchText])
-    #expect(encoded(state, for: .tantivy)[tantivySearchParameter] == [searchText])
+    #expect(encoded(state, for: .legacy)[legacyTitleContentParameter] == [searchText])
+    #expect(encoded(state, for: .tantivy)[tantivyTitleContentParameter] == [searchText])
   }
 
   @Test(
@@ -420,14 +482,18 @@ struct FilterStateSearchApiTest {
     #expect(state.searchMode == .title)
     #expect(state.searchText == searchText)
     #expect(state.remaining.isEmpty)
+
+    #expect(encoded(state, for: .legacy)[legacyTitleParameter] == [searchText])
+    #expect(encoded(state, for: .tantivy)[tantivyTitleParameter] == [searchText])
   }
 
-  /// On a 3.0 backend the app must never generate the deprecated parameter.
+  /// On a 3.0 backend the app must never generate the superseded parameters.
   /// Sweeping every rule type against every search mode keeps that honest: if a
   /// future rule type stops being handled by `populateWith` and lands in
   /// `remaining`, or a new index-backed one appears, this fails rather than
-  /// quietly reintroducing requests that log a deprecation warning.
-  @Test("`title_content` is never generated for a 3.0 backend", .bug(id: "642"))
+  /// quietly reintroducing requests that log a deprecation warning or diverge
+  /// from the web UI.
+  @Test("The superseded parameters are never generated for a 3.0 backend", .bug(id: "642"))
   func neverGeneratesLegacyParameterForTantivy() {
     var residual: [String] = []
 
@@ -447,8 +513,10 @@ struct FilterStateSearchApiTest {
           $0.searchMode = mode
           $0.searchText = searchText
         }
-        if encoded(state, for: .tantivy)[legacySearchParameter] != nil {
-          residual.append("\(ruleType) + \(mode)")
+        let emitted = Set(encoded(state, for: .tantivy).keys)
+          .intersection(supersededSearchParameters)
+        if !emitted.isEmpty {
+          residual.append("\(ruleType) + \(mode) -> \(emitted.sorted())")
         }
       }
     }

--- a/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
+++ b/DataModel/Tests/DataModelTests/FilterStateSearchApiTest.swift
@@ -425,6 +425,43 @@ struct FilterStateSearchApiTest {
     }
   }
 
+  // - MARK: Retired modes
+
+  /// The web UI has no content-only text-filter target, so the app offers none
+  /// either — but the mode stays representable, because persisted states,
+  /// deeplinks and saved views can all still name it.
+  @Test("Content-only search is retired from the UI but still representable")
+  func contentModeIsRetiredNotRemoved() {
+    #expect(FilterState.SearchMode.selectableCases == [.title, .titleContent, .advanced])
+    #expect(!FilterState.SearchMode.selectableCases.contains(.content))
+
+    // A picker bound to it still has a selection to show, the way the web UI
+    // keeps its own retired targets visible while active.
+    #expect(
+      FilterState.SearchMode.selectableCases(including: .content)
+        == [.title, .titleContent, .advanced, .content])
+
+    // A selectable mode is not duplicated.
+    for mode in FilterState.SearchMode.selectableCases {
+      #expect(
+        FilterState.SearchMode.selectableCases(including: mode) == [
+          .title, .titleContent, .advanced,
+        ])
+    }
+
+    // Still round-trips through a saved view and still encodes on both
+    // backends, so nothing already stored breaks.
+    let state = FilterState.create(
+      using: \.empty,
+      withRules: [FilterRule(ruleType: .content, value: .string(value: searchText))!])
+    #expect(state.searchMode == .content)
+    #expect(state.remaining.isEmpty)
+    #expect(encoded(state, for: .legacy)["content__icontains"] == [searchText])
+    #expect(encoded(state, for: .tantivy)["content__icontains"] == [searchText])
+  }
+
+  // - MARK: Saved views
+
   /// Saved views are stored server-side, so writing rule type 19 to a 3.0
   /// backend would leave a deprecated rule behind for every client that reads
   /// it back. The web UI writes 49 there, and so must we.

--- a/DataModel/Tests/DataModelTests/FilterStateTest.swift
+++ b/DataModel/Tests/DataModelTests/FilterStateTest.swift
@@ -50,9 +50,10 @@ struct FilterStateTest {
 
   @Test("Search mode conversion between FilterRuleType and FilterState.SearchMode")
   func testSearchModeConversion() {
-    #expect(FilterRuleType.title == FilterState.SearchMode.title.ruleType)
-    #expect(FilterRuleType.content == FilterState.SearchMode.content.ruleType)
-    #expect(FilterRuleType.titleContent == FilterState.SearchMode.titleContent.ruleType)
+    #expect(FilterRuleType.title == FilterState.SearchMode.title.ruleType(for: .legacy))
+    #expect(FilterRuleType.content == FilterState.SearchMode.content.ruleType(for: .legacy))
+    #expect(
+      FilterRuleType.titleContent == FilterState.SearchMode.titleContent.ruleType(for: .legacy))
 
     #expect(FilterState.SearchMode(ruleType: .title) == FilterState.SearchMode.title)
     #expect(FilterState.SearchMode(ruleType: .content) == FilterState.SearchMode.content)
@@ -259,9 +260,9 @@ struct FilterStateTest {
       $0.date.modified = .between(start: nil, end: nil)
     }
 
-    #expect(state.rules.isEmpty)
+    #expect(state.rules(for: .legacy).isEmpty)
 
-    let roundTrip = FilterState(rules: state.rules)
+    let roundTrip = FilterState(rules: state.rules(for: .legacy))
     #expect(roundTrip.date.created == .any)
     #expect(roundTrip.date.added == .any)
     #expect(roundTrip.date.modified == .any)
@@ -695,8 +696,9 @@ struct FilterStateTest {
       }
 
       #expect(
-        try state.rules == [
-          #require(FilterRule(ruleType: mode.ruleType, value: .string(value: "hallo")))
+        try state.rules(for: .legacy) == [
+          #require(
+            FilterRule(ruleType: mode.ruleType(for: .legacy), value: .string(value: "hallo")))
         ])
     }
   }
@@ -731,7 +733,9 @@ struct FilterStateTest {
       #require(FilterRule(ruleType: .modifiedBefore, value: .date(value: modifiedEndBackend))),
     ])
 
-    let sortedRules = state.rules.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
+    let sortedRules = state.rules(for: .legacy).sorted(by: {
+      $0.ruleType.rawValue < $1.ruleType.rawValue
+    })
     let sortedExpected = expected.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
     #expect(sortedRules == sortedExpected)
 
@@ -747,7 +751,7 @@ struct FilterStateTest {
       #require(FilterRule(ruleType: .modifiedBefore, value: .date(value: modifiedEndBackend))),
     ])
 
-    let sortedOpenEndedRules = openEndedState.rules.sorted(
+    let sortedOpenEndedRules = openEndedState.rules(for: .legacy).sorted(
       by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
     let sortedOpenEndedExpected = openEndedExpected.sorted(
       by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
@@ -764,7 +768,7 @@ struct FilterStateTest {
       $0.date.modified = .range(.within(num: -3, interval: .year))
     }
 
-    let components = state.rules
+    let components = state.rules(for: .legacy)
       .filter { $0.ruleType == .fulltextQuery }
       .compactMap { stringValue(from: $0) }
       .flatMap { queryComponents(from: $0) }
@@ -784,7 +788,7 @@ struct FilterStateTest {
       $0.date.modified = .range(.yesterday)
     }
 
-    let noSearchComponents = noSearchState.rules
+    let noSearchComponents = noSearchState.rules(for: .legacy)
       .filter { $0.ruleType == .fulltextQuery }
       .compactMap { stringValue(from: $0) }
       .flatMap { queryComponents(from: $0) }
@@ -798,7 +802,7 @@ struct FilterStateTest {
 
   @Test("Empty FilterState produces no rules")
   func testFilterStateToRuleEmpty() {
-    #expect(FilterState.empty.rules == [])
+    #expect(FilterState.empty.rules(for: .legacy) == [])
   }
 
   @Test("Convert FilterState correspondent to rules")
@@ -806,33 +810,33 @@ struct FilterStateTest {
     // Old single rule
     #expect(
       [FilterRule(ruleType: .correspondent, value: .correspondent(id: nil))]
-        == FilterState.empty.with { $0.correspondent = .notAssigned }.rules
+        == FilterState.empty.with { $0.correspondent = .notAssigned }.rules(for: .legacy)
     )
 
     // New anyOf rule
     #expect(
       [FilterRule(ruleType: .hasCorrespondentAny, value: .correspondent(id: 8))]
-        == FilterState.empty.with { $0.correspondent = .anyOf(ids: [8]) }.rules
+        == FilterState.empty.with { $0.correspondent = .anyOf(ids: [8]) }.rules(for: .legacy)
     )
 
     #expect(
       [
         FilterRule(ruleType: .hasCorrespondentAny, value: .correspondent(id: 8)),
         FilterRule(ruleType: .hasCorrespondentAny, value: .correspondent(id: 99)),
-      ] == FilterState.empty.with { $0.correspondent = .anyOf(ids: [8, 99]) }.rules
+      ] == FilterState.empty.with { $0.correspondent = .anyOf(ids: [8, 99]) }.rules(for: .legacy)
     )
 
     // New noneOf rule
     #expect(
       [FilterRule(ruleType: .doesNotHaveCorrespondent, value: .correspondent(id: 8))]
-        == FilterState.empty.with { $0.correspondent = .noneOf(ids: [8]) }.rules
+        == FilterState.empty.with { $0.correspondent = .noneOf(ids: [8]) }.rules(for: .legacy)
     )
 
     #expect(
       [
         FilterRule(ruleType: .doesNotHaveCorrespondent, value: .correspondent(id: 8)),
         FilterRule(ruleType: .doesNotHaveCorrespondent, value: .correspondent(id: 99)),
-      ] == FilterState.empty.with { $0.correspondent = .noneOf(ids: [8, 99]) }.rules
+      ] == FilterState.empty.with { $0.correspondent = .noneOf(ids: [8, 99]) }.rules(for: .legacy)
     )
   }
 
@@ -841,32 +845,32 @@ struct FilterStateTest {
     // Old single rule
     #expect(
       [FilterRule(ruleType: .documentType, value: .documentType(id: nil))]
-        == FilterState.empty.with { $0.documentType = .notAssigned }.rules
+        == FilterState.empty.with { $0.documentType = .notAssigned }.rules(for: .legacy)
     )
 
     // New anyOf rule
     #expect(
       [FilterRule(ruleType: .hasDocumentTypeAny, value: .documentType(id: 8))]
-        == FilterState.empty.with { $0.documentType = .anyOf(ids: [8]) }.rules
+        == FilterState.empty.with { $0.documentType = .anyOf(ids: [8]) }.rules(for: .legacy)
     )
 
     #expect(
       [
         FilterRule(ruleType: .hasDocumentTypeAny, value: .documentType(id: 8)),
         FilterRule(ruleType: .hasDocumentTypeAny, value: .documentType(id: 99)),
-      ] == FilterState.empty.with { $0.documentType = .anyOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.documentType = .anyOf(ids: [8, 99]) }.rules(for: .legacy))
 
     // New noneOf rule
     #expect(
       [
         FilterRule(ruleType: .doesNotHaveDocumentType, value: .documentType(id: 8))
-      ] == FilterState.empty.with { $0.documentType = .noneOf(ids: [8]) }.rules)
+      ] == FilterState.empty.with { $0.documentType = .noneOf(ids: [8]) }.rules(for: .legacy))
 
     #expect(
       [
         FilterRule(ruleType: .doesNotHaveDocumentType, value: .documentType(id: 8)),
         FilterRule(ruleType: .doesNotHaveDocumentType, value: .documentType(id: 99)),
-      ] == FilterState.empty.with { $0.documentType = .noneOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.documentType = .noneOf(ids: [8, 99]) }.rules(for: .legacy))
   }
 
   @Test("Remaining rules are preserved in round-trip conversion")
@@ -876,7 +880,7 @@ struct FilterStateTest {
       FilterRule(ruleType: .addedAfter, value: .date(value: datetime(year: 2023, month: 1, day: 1)))
     )
     #expect(
-      FilterState(rules: [addedAfter]).rules == [addedAfter]
+      FilterState(rules: [addedAfter]).rules(for: .legacy) == [addedAfter]
     )
   }
 
@@ -889,7 +893,9 @@ struct FilterStateTest {
     ])
 
     #expect(
-      tagAll == FilterState.empty.with { $0.tags = .allOf(include: [66, 71], exclude: [75]) }.rules
+      tagAll
+        == FilterState.empty.with { $0.tags = .allOf(include: [66, 71], exclude: [75]) }.rules(
+          for: .legacy)
     )
 
     let tagAny = try [FilterRule]([
@@ -898,12 +904,12 @@ struct FilterStateTest {
     ])
 
     #expect(
-      tagAny == FilterState.empty.with { $0.tags = .anyOf(ids: [66, 71]) }.rules
+      tagAny == FilterState.empty.with { $0.tags = .anyOf(ids: [66, 71]) }.rules(for: .legacy)
     )
 
     #expect(
       [FilterRule(ruleType: .hasAnyTag, value: .boolean(value: false))]
-        == FilterState.empty.with { $0.tags = .notAssigned }.rules
+        == FilterState.empty.with { $0.tags = .notAssigned }.rules(for: .legacy)
     )
   }
 
@@ -912,17 +918,17 @@ struct FilterStateTest {
     #expect(
       [
         FilterRule(ruleType: .ownerIsnull, value: .boolean(value: true))
-      ] == FilterState.empty.with { $0.owner = .notAssigned }.rules)
+      ] == FilterState.empty.with { $0.owner = .notAssigned }.rules(for: .legacy))
 
     // This could theoretically be expressed as:
     // FilterRule(ruleType: .ownerIsnull, value: .boolean(value: false))
     // But this is redundant to just not having a rule, so let's not create one.
-    #expect(FilterState.empty.with { $0.owner = .any }.rules == [])  // we could the
+    #expect(FilterState.empty.with { $0.owner = .any }.rules(for: .legacy) == [])  // we could the
 
     #expect(
       try [
         #require(FilterRule(ruleType: .ownerAny, value: .number(value: 8)))
-      ] == FilterState.empty.with { $0.owner = .anyOf(ids: [8]) }.rules)
+      ] == FilterState.empty.with { $0.owner = .anyOf(ids: [8]) }.rules(for: .legacy))
 
     // Technically, this could also be expressed as a rule .owner with value 8,
     // but that's equivalent
@@ -931,18 +937,18 @@ struct FilterStateTest {
       try [
         #require(FilterRule(ruleType: .ownerAny, value: .number(value: 8))),
         #require(FilterRule(ruleType: .ownerAny, value: .number(value: 99))),
-      ] == FilterState.empty.with { $0.owner = .anyOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.owner = .anyOf(ids: [8, 99]) }.rules(for: .legacy))
 
     #expect(
       try [
         #require(FilterRule(ruleType: .ownerDoesNotInclude, value: .number(value: 8)))
-      ] == FilterState.empty.with { $0.owner = .noneOf(ids: [8]) }.rules)
+      ] == FilterState.empty.with { $0.owner = .noneOf(ids: [8]) }.rules(for: .legacy))
 
     #expect(
       try [
         #require(FilterRule(ruleType: .ownerDoesNotInclude, value: .number(value: 8))),
         #require(FilterRule(ruleType: .ownerDoesNotInclude, value: .number(value: 99))),
-      ] == FilterState.empty.with { $0.owner = .noneOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.owner = .noneOf(ids: [8, 99]) }.rules(for: .legacy))
   }
 
   @Test("Convert FilterState storage path to rules")
@@ -950,32 +956,32 @@ struct FilterStateTest {
     // Old single rule
     #expect(
       try [#require(FilterRule(ruleType: .storagePath, value: .storagePath(id: nil)))]
-        == FilterState.empty.with { $0.storagePath = .notAssigned }.rules
+        == FilterState.empty.with { $0.storagePath = .notAssigned }.rules(for: .legacy)
     )
 
     // New anyOf rule
     #expect(
       try [#require(FilterRule(ruleType: .hasStoragePathAny, value: .storagePath(id: 8)))]
-        == FilterState.empty.with { $0.storagePath = .anyOf(ids: [8]) }.rules
+        == FilterState.empty.with { $0.storagePath = .anyOf(ids: [8]) }.rules(for: .legacy)
     )
 
     #expect(
       try [
         #require(FilterRule(ruleType: .hasStoragePathAny, value: .storagePath(id: 8))),
         #require(FilterRule(ruleType: .hasStoragePathAny, value: .storagePath(id: 99))),
-      ] == FilterState.empty.with { $0.storagePath = .anyOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.storagePath = .anyOf(ids: [8, 99]) }.rules(for: .legacy))
 
     // New noneOf rule
     #expect(
       try [
         #require(FilterRule(ruleType: .doesNotHaveStoragePath, value: .storagePath(id: 8)))
-      ] == FilterState.empty.with { $0.storagePath = .noneOf(ids: [8]) }.rules)
+      ] == FilterState.empty.with { $0.storagePath = .noneOf(ids: [8]) }.rules(for: .legacy))
 
     #expect(
       try [
         #require(FilterRule(ruleType: .doesNotHaveStoragePath, value: .storagePath(id: 8))),
         #require(FilterRule(ruleType: .doesNotHaveStoragePath, value: .storagePath(id: 99))),
-      ] == FilterState.empty.with { $0.storagePath = .noneOf(ids: [8, 99]) }.rules)
+      ] == FilterState.empty.with { $0.storagePath = .noneOf(ids: [8, 99]) }.rules(for: .legacy))
   }
 
   // - MARK: ASN Filtering Tests
@@ -1022,37 +1028,37 @@ struct FilterStateTest {
   func testFilterStateToRuleAsn() throws {
     // Test .any - should produce no rules
     #expect(
-      FilterState.empty.with { $0.asn = .any }.rules == []
+      FilterState.empty.with { $0.asn = .any }.rules(for: .legacy) == []
     )
 
     // Test .isNull
     #expect(
       [FilterRule(ruleType: .asnIsnull, value: .boolean(value: true))]
-        == FilterState.empty.with { $0.asn = .isNull }.rules
+        == FilterState.empty.with { $0.asn = .isNull }.rules(for: .legacy)
     )
 
     // Test .isNotNull
     #expect(
       [FilterRule(ruleType: .asnIsnull, value: .boolean(value: false))]
-        == FilterState.empty.with { $0.asn = .isNotNull }.rules
+        == FilterState.empty.with { $0.asn = .isNotNull }.rules(for: .legacy)
     )
 
     // Test .equalTo
     #expect(
       try [#require(FilterRule(ruleType: .asn, value: .number(value: 42)))]
-        == FilterState.empty.with { $0.asn = .equalTo(42) }.rules
+        == FilterState.empty.with { $0.asn = .equalTo(42) }.rules(for: .legacy)
     )
 
     // Test .greaterThan
     #expect(
       try [#require(FilterRule(ruleType: .asnGt, value: .number(value: 100)))]
-        == FilterState.empty.with { $0.asn = .greaterThan(100) }.rules
+        == FilterState.empty.with { $0.asn = .greaterThan(100) }.rules(for: .legacy)
     )
 
     // Test .lessThan
     #expect(
       try [#require(FilterRule(ruleType: .asnLt, value: .number(value: 50)))]
-        == FilterState.empty.with { $0.asn = .lessThan(50) }.rules
+        == FilterState.empty.with { $0.asn = .lessThan(50) }.rules(for: .legacy)
     )
   }
 
@@ -1062,32 +1068,32 @@ struct FilterStateTest {
 
     // equalTo case
     let equalToState = FilterState.empty.with { $0.asn = .equalTo(42) }
-    let equalToRules = equalToState.rules
+    let equalToRules = equalToState.rules(for: .legacy)
     #expect(FilterState(rules: equalToRules).asn == .equalTo(42))
 
     // isNull case
     let isNullState = FilterState.empty.with { $0.asn = .isNull }
-    let isNullRules = isNullState.rules
+    let isNullRules = isNullState.rules(for: .legacy)
     #expect(FilterState(rules: isNullRules).asn == .isNull)
 
     // isNotNull case
     let isNotNullState = FilterState.empty.with { $0.asn = .isNotNull }
-    let isNotNullRules = isNotNullState.rules
+    let isNotNullRules = isNotNullState.rules(for: .legacy)
     #expect(FilterState(rules: isNotNullRules).asn == .isNotNull)
 
     // greaterThan case
     let greaterThanState = FilterState.empty.with { $0.asn = .greaterThan(100) }
-    let greaterThanRules = greaterThanState.rules
+    let greaterThanRules = greaterThanState.rules(for: .legacy)
     #expect(FilterState(rules: greaterThanRules).asn == .greaterThan(100))
 
     // lessThan case
     let lessThanState = FilterState.empty.with { $0.asn = .lessThan(50) }
-    let lessThanRules = lessThanState.rules
+    let lessThanRules = lessThanState.rules(for: .legacy)
     #expect(FilterState(rules: lessThanRules).asn == .lessThan(50))
 
     // any case (default, produces no rules)
     let anyState = FilterState.empty.with { $0.asn = .any }
-    let anyRules = anyState.rules
+    let anyRules = anyState.rules(for: .legacy)
     #expect(FilterState(rules: anyRules).asn == .any)
   }
 
@@ -1107,7 +1113,9 @@ struct FilterStateTest {
     #expect(state.tags == .allOf(include: [5], exclude: []))
 
     // Verify round-trip preserves all filters
-    let regeneratedRules = state.rules.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
+    let regeneratedRules = state.rules(for: .legacy).sorted(by: {
+      $0.ruleType.rawValue < $1.ruleType.rawValue
+    })
     let originalRules = rules.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
     #expect(regeneratedRules == originalRules)
   }
@@ -1344,7 +1352,7 @@ struct FilterStateTest {
     #expect(state.asn == .lessThan(50))
 
     // Encode back to JSON
-    let encodedRules = state.rules
+    let encodedRules = state.rules(for: .legacy)
     let encodedJson = try JSONEncoder().encode(encodedRules)
 
     struct Payload: Decodable {
@@ -1380,7 +1388,7 @@ struct FilterStateTest {
     let customQuery = CustomFieldQuery.expr(8, .exists, .string("true"))
     let state = FilterState.empty.with { $0.customField = customQuery }
 
-    let rules = state.rules
+    let rules = state.rules(for: .legacy)
     #expect(rules.count == 1)
     #expect(rules[0].ruleType == .customFieldsQuery)
     #expect(rules[0].value == .customFieldQuery(customQuery))
@@ -1415,7 +1423,7 @@ struct FilterStateTest {
     #expect(state.remaining == input.suffix(1))
 
     #expect(
-      state.rules.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
+      state.rules(for: .legacy).sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
         == input.sorted(by: { $0.ruleType.rawValue < $1.ruleType.rawValue })
     )
   }
@@ -1496,7 +1504,7 @@ struct FilterStateTest {
       $0.date.modified = .between(start: userStart, end: userEnd)
     }
 
-    let generatedRules = stateToRuleState.rules
+    let generatedRules = stateToRuleState.rules(for: .legacy)
     #expect(generatedRules.count == 2)
 
     // Backend should get Jan 14 and Jan 26 for exclusive bounds

--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -546,7 +546,7 @@ extension ApiRepository: Repository {
     Logger.networking.notice("Getting document sequence for filter")
     let cursor = try PageCursor<ApiDocument>(
       repository: self,
-      initialURL: url(.documents(page: 1, filter: filter)))
+      initialURL: url(.documents(page: 1, filter: filter, searchApi: searchApi)))
     return ApiPagedSource<ApiDocument, Document>(cursor: cursor, map: { $0.domain })
   }
 

--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -86,9 +86,11 @@ extension Endpoint {
 // MARK: - Document related endpoints
 extension Endpoint {
   public static func documents(
-    page: UInt, filter: FilterState, pageSize: UInt = Self.defaultDocumentPageSize
+    page: UInt, filter: FilterState, pageSize: UInt = Self.defaultDocumentPageSize,
+    searchApi: FilterState.SearchApi = .legacy
   ) -> Endpoint {
-    let endpoint = documents(page: page, rules: filter.rules, pageSize: pageSize)
+    let endpoint = documents(
+      page: page, rules: filter.rules(for: searchApi), pageSize: pageSize)
 
     var ordering: String = filter.sortField.rawValue
     if filter.sortOrder.reverse {

--- a/Networking/Sources/Networking/BackendFeature.swift
+++ b/Networking/Sources/Networking/BackendFeature.swift
@@ -32,6 +32,13 @@ public enum BackendFeature {
   // standard ListResponse envelope; older backends return a top-level array.
   case taskListEnvelope
 
+  // https://github.com/paperless-ngx/paperless-ngx/pull/11884 / API v10, 3.0.0
+  // Tantivy-backed `text` document filter parameter, which supersedes the
+  // deprecated `title_content`. Older backends silently ignore unknown query
+  // parameters, so sending `text` there would return every document instead of
+  // the search results — this must stay gated.
+  case tantivySimpleSearch
+
   func isSupported(on backendVersion: Version, api apiVersion: UInt) -> Bool {
     switch self {
     case .nextAsnEndpoint:
@@ -42,7 +49,7 @@ public enum BackendFeature {
       backendVersion >= Version(2, 19, 0)
     case .dateFilterModified, .dateFilterPreviousIntervals:
       backendVersion >= Version(2, 20, 0)
-    case .savedViewNewVisibility, .savedViewPermissions, .taskListEnvelope:
+    case .savedViewNewVisibility, .savedViewPermissions, .taskListEnvelope, .tantivySimpleSearch:
       apiVersion >= 10 || backendVersion >= Version(3, 0, 0)
     }
   }

--- a/Networking/Sources/Networking/Repository.swift
+++ b/Networking/Sources/Networking/Repository.swift
@@ -179,6 +179,13 @@ extension Repository {
 
 extension Repository {
   public func supports(feature: BackendFeature) -> Bool { true }
+
+  /// The document-search encoding this backend understands. Use it both for
+  /// requests and for the rules written into saved views, so the app does not
+  /// store rule types the backend has deprecated.
+  public var searchApi: FilterState.SearchApi {
+    supports(feature: .tantivySimpleSearch) ? .tantivy : .legacy
+  }
 }
 
 // - MARK: PagedSource

--- a/Networking/Tests/NetworkingTests/SimpleTextSearchTest.swift
+++ b/Networking/Tests/NetworkingTests/SimpleTextSearchTest.swift
@@ -1,0 +1,84 @@
+//
+//  SimpleTextSearchTest.swift
+//  Networking
+//
+//  Version gating for the Tantivy-backed `text` document filter parameter,
+//  which paperless-ngx 3.0 introduced as the replacement for `title_content`.
+//
+
+import Common
+import DataModel
+import Foundation
+import Testing
+
+@testable import Networking
+
+@Suite("Tantivy simple search feature gate")
+struct SimpleTextSearchTest {
+  private static let searchState = FilterState.empty.with {
+    $0.searchMode = .titleContent
+    $0.searchText = "invoice"
+  }
+
+  @Test(
+    "Backends without the feature keep receiving `title_content`",
+    .bug(id: "642"),
+    arguments: [
+      Version(1, 14, 1), Version(2, 0, 0), Version(2, 20, 0), Version(2, 99, 0),
+    ])
+  func unsupportedOnOlderBackends(version: Version) {
+    // Older backends silently ignore unknown query parameters, so sending
+    // `text` there would drop the filter and return every document.
+    #expect(!BackendFeature.tantivySimpleSearch.isSupported(on: version, api: 9))
+  }
+
+  @Test(
+    "Backends at 3.0 / API v10 or newer support `text`",
+    .bug(id: "642"),
+    arguments: [
+      (Version(3, 0, 0), UInt(10)),
+      (Version(3, 0, 2), UInt(10)),
+      // Version string unavailable but the API version says v10.
+      (Version(2, 20, 0), UInt(10)),
+      // API version unavailable but the version string says 3.x.
+      (Version(3, 1, 0), UInt(9)),
+    ])
+  func supportedOnNewerBackends(version: Version, api: UInt) {
+    #expect(BackendFeature.tantivySimpleSearch.isSupported(on: version, api: api))
+  }
+
+  @Test(
+    "The document endpoint defaults to the parameter every backend understands", .bug(id: "642"))
+  func endpointDefaultsToLegacy() {
+    let endpoint = Endpoint.documents(page: 1, filter: Self.searchState)
+    #expect(endpoint.queryItems.contains(URLQueryItem(name: "title_content", value: "invoice")))
+    #expect(!endpoint.queryItems.contains { $0.name == "text" })
+  }
+
+  @Test("The document endpoint emits `text` when asked for the 3.0 encoding", .bug(id: "642"))
+  func endpointUsesTextForTantivy() {
+    let endpoint = Endpoint.documents(page: 1, filter: Self.searchState, searchApi: .tantivy)
+    #expect(endpoint.queryItems.contains(URLQueryItem(name: "text", value: "invoice")))
+    #expect(!endpoint.queryItems.contains { $0.name == "title_content" })
+  }
+
+  @Test("Switching the encoding leaves the rest of the URL alone", .bug(id: "642"))
+  func endpointIsOtherwiseUnchanged() throws {
+    let base = URL(string: "https://example.com")!
+
+    func queryNames(_ searchApi: FilterState.SearchApi) throws -> Set<String> {
+      let url = try #require(
+        Endpoint.documents(page: 3, filter: Self.searchState, pageSize: 25, searchApi: searchApi)
+          .url(url: base))
+      let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+      return Set((components.queryItems ?? []).map(\.name))
+    }
+
+    let legacy = try queryNames(.legacy)
+    let tantivy = try queryNames(.tantivy)
+
+    #expect(legacy.subtracting(tantivy) == ["title_content"])
+    #expect(tantivy.subtracting(legacy) == ["text"])
+    #expect(legacy.intersection(tantivy) == ["page", "page_size", "truncate_content", "ordering"])
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,3 +1,4 @@
 - Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart
 - Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version
 - Title search and title and content search now use the new search API on Paperless-ngx v3.0 and later, matching what the web interface does. The same search now returns the same documents in both. Older servers are unaffected.
+- The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,2 +1,3 @@
 - Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart
 - Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version
+- Title and content search now uses the new search API on Paperless-ngx v3.0 and later, instead of the parameter that server deprecated. Older servers are unaffected.

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,3 +1,3 @@
 - Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart
 - Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version
-- Title and content search now uses the new search API on Paperless-ngx v3.0 and later, instead of the parameter that server deprecated. Older servers are unaffected.
+- Title search and title and content search now use the new search API on Paperless-ngx v3.0 and later, matching what the web interface does. The same search now returns the same documents in both. Older servers are unaffected.

--- a/swift-paperless/Views/Document/FilterAssembly.swift
+++ b/swift-paperless/Views/Document/FilterAssembly.swift
@@ -27,7 +27,10 @@ struct FilterAssembly: View {
 
   private var searchModeMenu: some View {
     Menu {
-      ForEach(FilterState.SearchMode.allCases, id: \.self) { searchMode in
+      ForEach(
+        FilterState.SearchMode.selectableCases(
+          including: filterModel.filterState.searchMode), id: \.self
+      ) { searchMode in
         if filterModel.filterState.searchMode == searchMode {
           Label(searchMode.localizedName, systemImage: "checkmark")
         } else {

--- a/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
+++ b/swift-paperless/Views/Document/FilterAssemblyiOS18.swift
@@ -30,7 +30,10 @@ struct FilterAssemblyiOS18: View {
         ) {}
 
         Menu {
-          ForEach(FilterState.SearchMode.allCases, id: \.self) { searchMode in
+          ForEach(
+            FilterState.SearchMode.selectableCases(
+              including: filterModel.filterState.searchMode), id: \.self
+          ) { searchMode in
             if filterModel.filterState.searchMode == searchMode {
               Label(searchMode.localizedName, systemImage: "checkmark")
             } else {

--- a/swift-paperless/Views/Filter/FilterBar.swift
+++ b/swift-paperless/Views/Filter/FilterBar.swift
@@ -45,7 +45,7 @@ private struct FilterMenu<Content: View>: View {
       return
     }
 
-    updated.filterRules = filterModel.filterState.rules
+    updated.filterRules = filterModel.filterState.rules(for: store.repository.searchApi)
     updated.sortOrder = filterModel.filterState.sortOrder
     updated.sortField = filterModel.filterState.sortField
     Task {
@@ -106,7 +106,7 @@ private struct FilterMenu<Content: View>: View {
                 name: "",
                 sortField: filterModel.filterState.sortField,
                 sortOrder: filterModel.filterState.sortOrder,
-                filterRules: filterModel.filterState.rules
+                filterRules: filterModel.filterState.rules(for: store.repository.searchApi)
               )
 
               savedView = proto

--- a/swift-paperless/Views/Settings/PreferencesView.swift
+++ b/swift-paperless/Views/Settings/PreferencesView.swift
@@ -47,7 +47,10 @@ struct PreferencesView: View {
         }
 
         Picker(selection: $appSettings.defaultSearchMode) {
-          ForEach(FilterState.SearchMode.allCases, id: \.self) { mode in
+          ForEach(
+            FilterState.SearchMode.selectableCases(
+              including: appSettings.defaultSearchMode), id: \.self
+          ) { mode in
             Text(mode.localizedName).tag(mode)
           }
         } label: {


### PR DESCRIPTION
This pull request refactors the filter rule generation and search mode handling in the data model to support both legacy and Tantivy-backed (paperless-ngx 3.0+) search APIs. It introduces explicit backend-aware rule encoding, updates search mode logic to match backend capabilities, and ensures compatibility with both persisted and in-flight filter states. The changes also update tests to use the new API.

**Backend-aware filter rule generation and search mode logic:**

* Added a `SearchApi` enum to `FilterState` to distinguish between legacy (ORM-based) and Tantivy (index-backed) search parameters, and updated rule generation to require specifying the target backend. The new `rules(for:)` method replaces the old backend-agnostic `rules` property, ensuring correct encoding for each backend. [[1]](diffhunk://#diff-b161e8efa931e0a1ee63bb2f56cebce0c3645f3d78c8f2163fd38fb62dfc4fc0L11-R81) [[2]](diffhunk://#diff-b161e8efa931e0a1ee63bb2f56cebce0c3645f3d78c8f2163fd38fb62dfc4fc0L26-R113)
* Updated `FilterState.SearchMode` to provide backend-specific rule types via `ruleType(for:)`, and to determine if a mode is index-backed with `isIndexBacked(for:)`. The mapping from rule types to modes is now many-to-one to ensure compatibility with saved views and deeplinks from different backend versions.
* Added logic to prevent sending multiple exclusive search parameters (e.g., `text`, `title_search`, `query`, `more_like_id`) in a single request to Tantivy backends, mirroring the web UI's behavior and avoiding backend errors. [[1]](diffhunk://#diff-0345522b642e76104b215a901a40ff06d3027719913ee83b26153c1b184e1aa9R1-R23) [[2]](diffhunk://#diff-b161e8efa931e0a1ee63bb2f56cebce0c3645f3d78c8f2163fd38fb62dfc4fc0L11-R81)

**Compatibility and migration improvements:**

* Retained the `.content` search mode (now retired in the UI) for compatibility with persisted states and saved views, ensuring old links and data still decode correctly. Added utility methods to manage selectable cases in pickers.
* Updated rule population logic to recognize both legacy and Tantivy rule types when reconstructing `FilterState` from rules, ensuring seamless round-tripping and migration.

**Test suite updates:**

* Refactored all usages of the old `rules` property in tests to use the new `rules(for:)` method, ensuring tests are backend-aware and validating correct behavior for both legacy and Tantivy encodings. [[1]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL53-R56) [[2]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL262-R265) [[3]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL698-R701) [[4]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL734-R738) [[5]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL750-R754) [[6]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL767-R771) [[7]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL787-R791) [[8]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL801-R839) [[9]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL844-R873) [[10]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL879-R883) [[11]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL892-R898) [[12]](diffhunk://#diff-bf6fa3591fa5407ac0b9fae3096f0ba30f414362f569a2a428a06c487c4823ebL901-R912)

Closes #642.
