### PR TITLE
refactor: replace the app-settings layer with a scoped settings store

### DIFF
--- a/AppShared/Sources/AppShared/Model/FilterBarComponent.swift
+++ b/AppShared/Sources/AppShared/Model/FilterBarComponent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum FilterBarComponent: String, CaseIterable, Codable {
+public enum FilterBarComponent: String, CaseIterable, Codable, Sendable {
   case tags
   case documentType
   case correspondent
@@ -31,7 +31,7 @@ public enum FilterBarComponent: String, CaseIterable, Codable {
   }
 }
 
-public enum FilterBarConfiguration: Equatable, Codable {
+public enum FilterBarConfiguration: Equatable, Codable, Sendable {
   case `default`
   case configured([FilterBarComponent])
 }

--- a/AppShared/Sources/AppShared/Model/FilterState+defaults.swift
+++ b/AppShared/Sources/AppShared/Model/FilterState+defaults.swift
@@ -13,16 +13,19 @@ import os
 // MARK: - FilterState
 
 extension FilterState {
+  // Read straight from the store rather than through AppSettings: this is
+  // nonisolated, and the store shares one cache and one set of defaults with
+  // the main-actor settings object.
   private static var defaultSearchMode: SearchMode {
-    AppSettings.value(for: .defaultSearchMode, or: .titleContent)
+    SettingsStore.shared[.defaultSearchMode]
   }
 
   private static var defaultSortField: SortField {
-    AppSettings.value(for: .defaultSortField, or: .added)
+    SettingsStore.shared[.defaultSortField]
   }
 
   private static var defaultSortOrder: DataModel.SortOrder {
-    AppSettings.value(for: .defaultSortOrder, or: .descending)
+    SettingsStore.shared[.defaultSortOrder]
   }
 
   // MARK: Initializers

--- a/AppShared/Sources/AppShared/Utilities/AppSettings.swift
+++ b/AppShared/Sources/AppShared/Utilities/AppSettings.swift
@@ -18,8 +18,6 @@ public enum SettingsKeys: String {
   case defaultSortField
   case defaultSortOrder
   case filterBarConfiguration
-
-  case editingUserInterfaceExperiment
 }
 
 extension PublishedUserDefaultsBacked {
@@ -93,22 +91,6 @@ public class AppSettings: ObservableObject {
   @PublishedUserDefaultsBacked(.filterBarConfiguration)
   public var filterBarConfiguration = FilterBarConfiguration.default
 
-  public enum EditingUserInterface: String, Codable, CaseIterable {
-    public static var allCases: [AppSettings.EditingUserInterface] {
-      [.automatic, .v3]
-    }
-
-    case automatic
-    case v3
-
-    // deprecated, kept here so decoding works
-    @available(*, deprecated)
-    case v1, v2
-  }
-
-  @PublishedUserDefaultsBacked(.editingUserInterfaceExperiment)
-  public var editingUserInterface: EditingUserInterface = .automatic
-
   public var lastAppVersion: AppVersion?
   @UserDefaultsBacked(appVersionKey)
   public var currentAppVersion: AppVersion? = nil
@@ -141,68 +123,5 @@ extension AppSettings {
         "AppSettings.value(\(key)): unable to decode, returning default value (\(error))")
       return defaultValue
     }
-  }
-}
-
-@available(*, deprecated)
-@MainActor
-@propertyWrapper
-public class AppSettingsObject: ObservableObject {
-  @ObservedObject private var observed = AppSettings.shared
-
-  private var tasks = Set<AnyCancellable>()
-
-  public var wrappedValue: AppSettings {
-    observed
-  }
-
-  public var projectedValue: ObservedObject<AppSettings>.Wrapper {
-    $observed
-  }
-
-  public init() {
-    observed.objectWillChange
-      .sink { _ in
-        Logger.shared.debug("AppSettings objectwill change from singleton in wrapper")
-        self.objectWillChange.send()
-      }
-      .store(in: &tasks)
-  }
-}
-
-@available(*, deprecated)
-@MainActor
-@propertyWrapper
-public struct AppSetting<Value: Codable>: DynamicProperty {
-  public typealias SettingsKeyPath = KeyPath<AppSettings, PublishedUserDefaultsBacked<Value>>
-  private var keyPath: SettingsKeyPath
-
-  @State private var value: Value
-
-  public var wrappedValue: Value {
-    get {
-      value
-    }
-    nonmutating set {
-      AppSettings.shared.objectWillChange.send()
-      let published = AppSettings.shared[keyPath: self.keyPath]
-      published.$backing.wrappedValue = newValue
-      value = newValue
-      AppSettings.shared.settingsChanged.send()
-    }
-  }
-
-  public var projectedValue: Binding<Value> {
-    Binding<Value>(
-      get: {
-        wrappedValue
-      },
-      set: { wrappedValue = $0 }
-    )
-  }
-
-  public init(_ keyPath: SettingsKeyPath) {
-    self.keyPath = keyPath
-    _value = State(initialValue: AppSettings.shared[keyPath: keyPath].$backing.wrappedValue)
   }
 }

--- a/AppShared/Sources/AppShared/Utilities/AppSettings.swift
+++ b/AppShared/Sources/AppShared/Utilities/AppSettings.swift
@@ -1,48 +1,41 @@
 //
-//  SettingsKeys.swift
+//  AppSettings.swift
 //  swift-paperless
 //
 //  Created by Paul Gessinger on 13.08.23.
 //
-import Combine
 import Common
 import DataModel
 import Foundation
-import SwiftUI
 import os
 
-public enum SettingsKeys: String {
-  case documentDeleteConfirmation
-  case enableBiometricAppLock
-  case defaultSearchMode
-  case defaultSortField
-  case defaultSortOrder
-  case filterBarConfiguration
-}
-
-extension PublishedUserDefaultsBacked {
-  public convenience init(
-    wrappedValue defaultValue: Value, _ key: SettingsKeys, storage: UserDefaults = .standard
-  ) {
-    self.init(wrappedValue: defaultValue, key.rawValue, storage: storage)
-  }
-}
-
+/// The app's global settings.
+///
+/// Every setting is a computed property over ``SettingsStore``, which owns
+/// encoding, caching and the choice of `UserDefaults` suite. The keys, with
+/// their defaults, are declared in `SettingKeys.swift`.
+///
+/// Settings that belong to a single server connection do not live here — those
+/// are stored with the connection in the database.
 @MainActor
-public class AppSettings: ObservableObject {
-  private static let appVersionKey = "currentAppVersion"
-  private init() {
-    let lastVersion: AppVersion?
-    do {
-      lastVersion = try UserDefaults.standard.load(AppVersion.self, key: Self.appVersionKey)
-    } catch {
-      Logger.shared.error("Last app version could not be read: \(error)")
-      lastVersion = nil
-    }
+@Observable
+public final class AppSettings {
+  public static let shared = AppSettings()
 
-    Logger.shared.info("Last app version was: \(lastVersion?.description ?? "?", privacy: .public)")
+  @ObservationIgnored
+  private let store: SettingsStore
 
-    lastAppVersion = lastVersion
+  /// The version this install ran before the current launch, or `nil` on a
+  /// fresh install. Read once at startup, before the current version is
+  /// recorded.
+  public private(set) var lastAppVersion: AppVersion?
+
+  private init(store: SettingsStore = .shared) {
+    self.store = store
+
+    lastAppVersion = store[.currentAppVersion]
+    Logger.shared.info(
+      "Last app version was: \(self.lastAppVersion?.description ?? "?", privacy: .public)")
 
     var release = Bundle.main.releaseVersionNumber
     if release == nil {
@@ -55,73 +48,106 @@ public class AppSettings: ObservableObject {
       build = "1"
     }
 
-    guard let currentVersion = AppVersion(version: release!, build: build!) else {
+    guard let release, let build, let currentVersion = AppVersion(version: release, build: build)
+    else {
       return
     }
 
     Logger.shared.info("Current app version is: \(currentVersion, privacy: .public)")
+    store[.currentAppVersion] = currentVersion
+  }
 
-    do {
-      try UserDefaults.standard.store(currentVersion, key: Self.appVersionKey)
-    } catch {
-      Logger.shared.error(
-        "Unable to store current version (\(String(describing: currentVersion), privacy: .public): \(error)"
-      )
+  public var documentDeleteConfirmation: Bool {
+    get {
+      access(keyPath: \.documentDeleteConfirmation)
+      return store[.documentDeleteConfirmation]
+    }
+    set {
+      withMutation(keyPath: \.documentDeleteConfirmation) {
+        store[.documentDeleteConfirmation] = newValue
+      }
     }
   }
 
-  public static var shared = AppSettings()
+  public var enableBiometricAppLock: Bool {
+    get {
+      access(keyPath: \.enableBiometricAppLock)
+      return store[.enableBiometricAppLock]
+    }
+    set {
+      withMutation(keyPath: \.enableBiometricAppLock) {
+        store[.enableBiometricAppLock] = newValue
+      }
+    }
+  }
 
-  @PublishedUserDefaultsBacked(.documentDeleteConfirmation)
-  public var documentDeleteConfirmation = true
+  public var defaultSearchMode: FilterState.SearchMode {
+    get {
+      access(keyPath: \.defaultSearchMode)
+      return store[.defaultSearchMode]
+    }
+    set {
+      withMutation(keyPath: \.defaultSearchMode) {
+        store[.defaultSearchMode] = newValue
+      }
+    }
+  }
 
-  @PublishedUserDefaultsBacked(.enableBiometricAppLock)
-  public var enableBiometricAppLock = false
+  public var defaultSortField: SortField {
+    get {
+      access(keyPath: \.defaultSortField)
+      return store[.defaultSortField]
+    }
+    set {
+      withMutation(keyPath: \.defaultSortField) {
+        store[.defaultSortField] = newValue
+      }
+    }
+  }
 
-  @PublishedUserDefaultsBacked(.defaultSearchMode)
-  public var defaultSearchMode = FilterState.SearchMode.titleContent
+  public var defaultSortOrder: DataModel.SortOrder {
+    get {
+      access(keyPath: \.defaultSortOrder)
+      return store[.defaultSortOrder]
+    }
+    set {
+      withMutation(keyPath: \.defaultSortOrder) {
+        store[.defaultSortOrder] = newValue
+      }
+    }
+  }
 
-  @PublishedUserDefaultsBacked(.defaultSortField)
-  public var defaultSortField = SortField.added
+  public var filterBarConfiguration: FilterBarConfiguration {
+    get {
+      access(keyPath: \.filterBarConfiguration)
+      return store[.filterBarConfiguration]
+    }
+    set {
+      withMutation(keyPath: \.filterBarConfiguration) {
+        store[.filterBarConfiguration] = newValue
+      }
+    }
+  }
 
-  @PublishedUserDefaultsBacked(.defaultSortOrder)
-  public var defaultSortOrder = DataModel.SortOrder.descending
+  public var currentAppVersion: AppVersion? {
+    get {
+      access(keyPath: \.currentAppVersion)
+      return store[.currentAppVersion]
+    }
+    set {
+      withMutation(keyPath: \.currentAppVersion) {
+        store[.currentAppVersion] = newValue
+      }
+    }
+  }
 
-  // @TODO: We need a sentinel here that's just "all defaults"
-  @PublishedUserDefaultsBacked(.filterBarConfiguration)
-  public var filterBarConfiguration = FilterBarConfiguration.default
-
-  public var lastAppVersion: AppVersion?
-  @UserDefaultsBacked(appVersionKey)
-  public var currentAppVersion: AppVersion? = nil
-
+  /// Forgets the recorded app version, so the next launch behaves like an
+  /// upgrade from an unknown version. Used by the debug menu to bring the
+  /// release notes back.
   public func resetAppVersion() {
     Logger.shared.info("Resetting stored app version")
-    currentAppVersion = nil
-    UserDefaults.standard.synchronize()
-  }
-
-  public let settingsChanged = PassthroughSubject<Void, Never>()
-}
-
-extension AppSettings {
-  public nonisolated
-    static func value<Value: Codable>(for key: SettingsKeys, or defaultValue: Value) -> Value
-  {
-    let key = key.rawValue
-    guard let obj = UserDefaults.standard.object(forKey: key) as? Data else {
-      return defaultValue
-    }
-    do {
-      let value = try JSONDecoder().decode(Value.self, from: obj)
-      Logger.shared.trace(
-        "AppSettings.value(\(key, privacy: .public)) value read: \(String(describing: value), privacy: .private)"
-      )
-      return value
-    } catch {
-      Logger.shared.error(
-        "AppSettings.value(\(key)): unable to decode, returning default value (\(error))")
-      return defaultValue
+    withMutation(keyPath: \.currentAppVersion) {
+      store.remove(.currentAppVersion)
     }
   }
 }

--- a/AppShared/Sources/AppShared/Utilities/AppSettings.swift
+++ b/AppShared/Sources/AppShared/Utilities/AppSettings.swift
@@ -7,23 +7,29 @@
 import Common
 import DataModel
 import Foundation
+import Observation
 import os
 
 /// The app's global settings.
 ///
-/// Every setting is a computed property over ``SettingsStore``, which owns
+/// Every setting is `@Setting`-expanded access to ``SettingsStore``, which owns
 /// encoding, caching and the choice of `UserDefaults` suite. The keys, with
 /// their defaults, are declared in `SettingKeys.swift`.
+///
+/// Observation is wired up by hand rather than with `@Observable`: the macro
+/// claims the accessors of every stored property, which collides with
+/// `@Setting`. Conforming directly costs one registrar and the two forwarding
+/// methods below, and nothing is lost — there are no stored settings for
+/// `@Observable` to manage.
 ///
 /// Settings that belong to a single server connection do not live here — those
 /// are stored with the connection in the database.
 @MainActor
-@Observable
-public final class AppSettings {
+public final class AppSettings: Observable {
   public static let shared = AppSettings()
 
-  @ObservationIgnored
   private let store: SettingsStore
+  private let registrar = ObservationRegistrar()
 
   /// The version this install ran before the current launch, or `nil` on a
   /// fresh install. Read once at startup, before the current version is
@@ -57,89 +63,36 @@ public final class AppSettings {
     store[.currentAppVersion] = currentVersion
   }
 
-  public var documentDeleteConfirmation: Bool {
-    get {
-      access(keyPath: \.documentDeleteConfirmation)
-      return store[.documentDeleteConfirmation]
-    }
-    set {
-      withMutation(keyPath: \.documentDeleteConfirmation) {
-        store[.documentDeleteConfirmation] = newValue
-      }
-    }
+  nonisolated func access<Member>(keyPath: KeyPath<AppSettings, Member>) {
+    registrar.access(self, keyPath: keyPath)
   }
 
-  public var enableBiometricAppLock: Bool {
-    get {
-      access(keyPath: \.enableBiometricAppLock)
-      return store[.enableBiometricAppLock]
-    }
-    set {
-      withMutation(keyPath: \.enableBiometricAppLock) {
-        store[.enableBiometricAppLock] = newValue
-      }
-    }
+  nonisolated func withMutation<Member, Result>(
+    keyPath: KeyPath<AppSettings, Member>, _ mutation: () throws -> Result
+  ) rethrows -> Result {
+    try registrar.withMutation(of: self, keyPath: keyPath, mutation)
   }
 
-  public var defaultSearchMode: FilterState.SearchMode {
-    get {
-      access(keyPath: \.defaultSearchMode)
-      return store[.defaultSearchMode]
-    }
-    set {
-      withMutation(keyPath: \.defaultSearchMode) {
-        store[.defaultSearchMode] = newValue
-      }
-    }
-  }
+  @Setting(.documentDeleteConfirmation)
+  public var documentDeleteConfirmation: Bool
 
-  public var defaultSortField: SortField {
-    get {
-      access(keyPath: \.defaultSortField)
-      return store[.defaultSortField]
-    }
-    set {
-      withMutation(keyPath: \.defaultSortField) {
-        store[.defaultSortField] = newValue
-      }
-    }
-  }
+  @Setting(.enableBiometricAppLock)
+  public var enableBiometricAppLock: Bool
 
-  public var defaultSortOrder: DataModel.SortOrder {
-    get {
-      access(keyPath: \.defaultSortOrder)
-      return store[.defaultSortOrder]
-    }
-    set {
-      withMutation(keyPath: \.defaultSortOrder) {
-        store[.defaultSortOrder] = newValue
-      }
-    }
-  }
+  @Setting(.defaultSearchMode)
+  public var defaultSearchMode: FilterState.SearchMode
 
-  public var filterBarConfiguration: FilterBarConfiguration {
-    get {
-      access(keyPath: \.filterBarConfiguration)
-      return store[.filterBarConfiguration]
-    }
-    set {
-      withMutation(keyPath: \.filterBarConfiguration) {
-        store[.filterBarConfiguration] = newValue
-      }
-    }
-  }
+  @Setting(.defaultSortField)
+  public var defaultSortField: SortField
 
-  public var currentAppVersion: AppVersion? {
-    get {
-      access(keyPath: \.currentAppVersion)
-      return store[.currentAppVersion]
-    }
-    set {
-      withMutation(keyPath: \.currentAppVersion) {
-        store[.currentAppVersion] = newValue
-      }
-    }
-  }
+  @Setting(.defaultSortOrder)
+  public var defaultSortOrder: DataModel.SortOrder
+
+  @Setting(.filterBarConfiguration)
+  public var filterBarConfiguration: FilterBarConfiguration
+
+  @Setting(.currentAppVersion)
+  public var currentAppVersion: AppVersion?
 
   /// Forgets the recorded app version, so the next launch behaves like an
   /// upgrade from an unknown version. Used by the debug menu to bring the

--- a/AppShared/Sources/AppShared/Utilities/SettingKeys.swift
+++ b/AppShared/Sources/AppShared/Utilities/SettingKeys.swift
@@ -1,0 +1,53 @@
+//
+//  SettingKeys.swift
+//  swift-paperless
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Common
+import DataModel
+import Foundation
+
+// The app's settings, declared once each. The name is the key the value is
+// stored under: it is persisted user data, so renaming one orphans what users
+// already have stored.
+//
+// Everything is `.device` for now, which is where these values have always
+// been written. Moving a key to `.shared` (so the ShareExtension can read it)
+// needs a migration of the existing value and is deliberately not part of this
+// change.
+extension SettingKey {
+  public static var documentDeleteConfirmation: SettingKey<Bool> {
+    .init("documentDeleteConfirmation", default: true)
+  }
+
+  /// Not a candidate for syncing across devices: the enrolled biometrics
+  /// differ per device, so syncing this would arm the lock on a device the
+  /// user never configured.
+  public static var enableBiometricAppLock: SettingKey<Bool> {
+    .init("enableBiometricAppLock", default: false)
+  }
+
+  public static var defaultSearchMode: SettingKey<FilterState.SearchMode> {
+    .init("defaultSearchMode", default: .titleContent)
+  }
+
+  public static var defaultSortField: SettingKey<SortField> {
+    .init("defaultSortField", default: .added)
+  }
+
+  public static var defaultSortOrder: SettingKey<DataModel.SortOrder> {
+    .init("defaultSortOrder", default: .descending)
+  }
+
+  public static var filterBarConfiguration: SettingKey<FilterBarConfiguration> {
+    .init("filterBarConfiguration", default: .default)
+  }
+
+  /// The version this install last launched, which drives the release-notes
+  /// sheet. Per-install by definition.
+  public static var currentAppVersion: SettingKey<AppVersion?> {
+    .init("currentAppVersion", default: nil)
+  }
+}

--- a/AppShared/Sources/AppShared/ViewModel/FilterModel.swift
+++ b/AppShared/Sources/AppShared/ViewModel/FilterModel.swift
@@ -5,7 +5,6 @@
 //  Created by Paul Gessinger on 12.08.23.
 //
 
-import Combine
 import DataModel
 import Foundation
 import Observation
@@ -14,8 +13,6 @@ import os
 @MainActor
 @Observable
 public final class FilterModel {
-  @ObservationIgnored private var tasks = Set<AnyCancellable>()
-
   public var ready: Bool = true
 
   public var filterState: FilterState = {
@@ -62,30 +59,50 @@ public final class FilterModel {
   }
 
   public init() {
-    AppSettings.shared.settingsChanged
-      .sink { [weak self] in
+    observeDefaults()
+  }
+
+  /// Applies changes to the filtering defaults (made in Preferences) to the
+  /// filter that is currently in effect.
+  ///
+  /// `withObservationTracking` fires once, so the tracking is re-armed after
+  /// every change. `onChange` runs *before* the new value is in place, hence
+  /// the hop to the next main-actor turn before reading it.
+  private func observeDefaults() {
+    let settings = AppSettings.shared
+    withObservationTracking {
+      _ = settings.defaultSearchMode
+      _ = settings.defaultSortField
+      _ = settings.defaultSortOrder
+    } onChange: { [weak self] in
+      Task { @MainActor in
         guard let self else { return }
-
-        var filterState = filterState
-
-        if self.filterState.searchText.isEmpty {
-          Logger.shared.debug(
-            "Applying search mode default change to: \(String(describing: AppSettings.shared.defaultSearchMode), privacy: .public)"
-          )
-          // User has not typed any search text yet -> we're not changing the mode under them
-          filterState.searchMode = AppSettings.shared.defaultSearchMode
-
-          // Reset modified to what it was before, we're not actually modifying anything
-          filterState.modified = self.filterState.modified
-        }
-
-        if !self.filterState.modified, self.filterState.savedView == nil {
-          filterState.sortField = AppSettings.shared.defaultSortField
-          filterState.sortOrder = AppSettings.shared.defaultSortOrder
-        }
-
-        self.filterState = filterState
+        self.applyDefaults()
+        self.observeDefaults()
       }
-      .store(in: &tasks)
+    }
+  }
+
+  private func applyDefaults() {
+    let settings = AppSettings.shared
+    var filterState = filterState
+
+    if self.filterState.searchText.isEmpty {
+      Logger.shared.debug(
+        "Applying search mode default change to: \(String(describing: settings.defaultSearchMode), privacy: .public)"
+      )
+      // User has not typed any search text yet -> we're not changing the mode under them
+      filterState.searchMode = settings.defaultSearchMode
+
+      // Reset modified to what it was before, we're not actually modifying anything
+      filterState.modified = self.filterState.modified
+    }
+
+    if !self.filterState.modified, self.filterState.savedView == nil {
+      filterState.sortField = settings.defaultSortField
+      filterState.sortOrder = settings.defaultSortOrder
+    }
+
+    self.filterState = filterState
   }
 }

--- a/Common/Sources/Common/Settings/SettingKey.swift
+++ b/Common/Sources/Common/Settings/SettingKey.swift
@@ -1,0 +1,49 @@
+//
+//  SettingKey.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+
+/// Where a setting is persisted.
+///
+/// The scope is a property of the key, not of the store: some settings are
+/// meaningful only on the install that wrote them, while others have to be
+/// visible to the ShareExtension as well.
+public enum SettingScope: String, Sendable, CaseIterable {
+  /// `UserDefaults.standard` — never leaves this install, and is invisible to
+  /// app extensions.
+  ///
+  /// Correct for anything tied to the device or the install: biometric lock
+  /// (the enrolled biometrics differ per device) and the stored app version
+  /// (it drives the release-notes sheet, which should show up once per
+  /// install).
+  case device
+
+  /// The app group suite — shared with the ShareExtension.
+  case shared
+}
+
+/// The declaration of a single setting: its name on disk, its default, and
+/// where it is persisted.
+///
+/// Keys are declared once, in one place, and read through ``SettingsStore``.
+/// The default value lives on the key rather than at each call site, so
+/// readers cannot disagree about what "unset" means.
+public struct SettingKey<Value: Codable & Sendable>: Sendable {
+  /// The key as written to `UserDefaults`. This is persisted user data:
+  /// renaming it orphans the stored value.
+  public let name: String
+
+  public let defaultValue: Value
+
+  public let scope: SettingScope
+
+  public init(_ name: String, default defaultValue: Value, scope: SettingScope = .device) {
+    self.name = name
+    self.defaultValue = defaultValue
+    self.scope = scope
+  }
+}

--- a/Common/Sources/Common/Settings/SettingKey.swift
+++ b/Common/Sources/Common/Settings/SettingKey.swift
@@ -47,3 +47,18 @@ public struct SettingKey<Value: Codable & Sendable>: Sendable {
     self.scope = scope
   }
 }
+
+/// Turns a property into storage-backed, observable access to a ``SettingKey``.
+///
+/// ```swift
+/// @Setting(.documentDeleteConfirmation)
+/// public var documentDeleteConfirmation: Bool
+/// ```
+///
+/// The enclosing type has to provide a `store` (a ``SettingsStore``) and the
+/// `access(keyPath:)` / `withMutation(keyPath:_:)` pair. Note that this cannot
+/// be combined with the `@Observable` macro, which claims the accessors of
+/// every stored property for itself: conform to `Observable` by hand instead.
+@attached(accessor)
+public macro Setting<Value>(_ key: SettingKey<Value>) =
+  #externalMacro(module: "CommonMacros", type: "SettingMacro")

--- a/Common/Sources/Common/Settings/SettingsStore+shared.swift
+++ b/Common/Sources/Common/Settings/SettingsStore+shared.swift
@@ -1,0 +1,20 @@
+//
+//  SettingsStore+shared.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+
+extension SettingsStore {
+  /// The store the app and the ShareExtension read their settings from.
+  ///
+  /// Tests construct their own store with dedicated suites instead.
+  public static let shared = SettingsStore(
+    suites: [
+      .device: .standard,
+      .shared: UserDefaults(suiteName: AppGroup.identifier) ?? .standard,
+    ]
+  )
+}

--- a/Common/Sources/Common/Settings/SettingsStore.swift
+++ b/Common/Sources/Common/Settings/SettingsStore.swift
@@ -1,0 +1,146 @@
+//
+//  SettingsStore.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+import os
+
+/// Persists ``SettingKey`` values, routing each key to the suite its
+/// ``SettingScope`` asks for.
+///
+/// The store is deliberately free of actor isolation: `FilterState.default` is
+/// a nonisolated static and has to be able to read the sort/search defaults.
+/// Decoded values are cached behind a lock and dropped whenever `UserDefaults`
+/// reports a change, so a read is a dictionary lookup rather than a `JSONDecoder`
+/// allocation.
+///
+/// Values are stored as JSON `Data`, which is the format the app has always
+/// written.
+public final class SettingsStore: @unchecked Sendable {
+  private let suites: [SettingScope: UserDefaults]
+
+  /// Boxed so that a cached `nil` (for a key whose `Value` is an optional) is
+  /// distinguishable from an absent cache entry: casting a plain `Any?` to an
+  /// optional `Value` succeeds for both.
+  private struct Box {
+    let value: Any
+  }
+
+  private let lock = NSLock()
+  private var cache: [String: Box] = [:]
+
+  private var observer: NSObjectProtocol?
+
+  private static let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "swift-paperless", category: "Settings")
+
+  public init(suites: [SettingScope: UserDefaults]) {
+    self.suites = suites
+
+    // Someone else in the process (or the ShareExtension, for the shared
+    // suite) may have written a value we have cached.
+    observer = NotificationCenter.default.addObserver(
+      forName: UserDefaults.didChangeNotification,
+      object: nil,
+      queue: nil
+    ) { [weak self] _ in
+      self?.invalidate()
+    }
+  }
+
+  deinit {
+    if let observer {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+
+  private func suite(for scope: SettingScope) -> UserDefaults {
+    guard let suite = suites[scope] else {
+      Self.logger.error(
+        "No suite configured for scope \(scope.rawValue, privacy: .public), using standard")
+      return .standard
+    }
+    return suite
+  }
+
+  public func invalidate() {
+    lock.lock()
+    defer { lock.unlock() }
+    cache.removeAll()
+  }
+
+  public subscript<Value>(key: SettingKey<Value>) -> Value {
+    get { value(for: key) }
+    set { set(newValue, for: key) }
+  }
+
+  public func value<Value>(for key: SettingKey<Value>) -> Value {
+    lock.lock()
+    let cached = cache[key.name]
+    lock.unlock()
+
+    if let cached, let value = cached.value as? Value {
+      return value
+    }
+
+    let value = decode(key)
+
+    lock.lock()
+    cache[key.name] = Box(value: value)
+    lock.unlock()
+
+    return value
+  }
+
+  private func decode<Value>(_ key: SettingKey<Value>) -> Value {
+    guard let data = suite(for: key.scope).object(forKey: key.name) as? Data else {
+      Self.logger.trace("Setting \(key.name, privacy: .public) not set, using default")
+      return key.defaultValue
+    }
+
+    do {
+      let value = try JSONDecoder().decode(Value.self, from: data)
+      Self.logger.trace(
+        "Setting \(key.name, privacy: .public) read: \(String(describing: value), privacy: .private)"
+      )
+      return value
+    } catch {
+      Self.logger.error(
+        "Setting \(key.name, privacy: .public) could not be decoded, using default: \(error)")
+      return key.defaultValue
+    }
+  }
+
+  public func set<Value>(_ value: Value, for key: SettingKey<Value>) {
+    Self.logger.trace(
+      "Setting \(key.name, privacy: .public) written: \(String(describing: value), privacy: .private)"
+    )
+
+    do {
+      let data = try JSONEncoder().encode(value)
+      // Outside the lock: writing posts didChangeNotification synchronously,
+      // which invalidates the cache.
+      suite(for: key.scope).set(data, forKey: key.name)
+    } catch {
+      Self.logger.error("Setting \(key.name, privacy: .public) could not be encoded: \(error)")
+      return
+    }
+
+    lock.lock()
+    cache[key.name] = Box(value: value)
+    lock.unlock()
+  }
+
+  /// Removes the stored value, so subsequent reads see the key's default.
+  public func remove<Value>(_ key: SettingKey<Value>) {
+    Self.logger.info("Setting \(key.name, privacy: .public) removed")
+    suite(for: key.scope).removeObject(forKey: key.name)
+
+    lock.lock()
+    cache.removeValue(forKey: key.name)
+    lock.unlock()
+  }
+}

--- a/Common/Sources/Common/Settings/SettingsStore.swift
+++ b/Common/Sources/Common/Settings/SettingsStore.swift
@@ -97,7 +97,6 @@ public final class SettingsStore: @unchecked Sendable {
 
   private func decode<Value>(_ key: SettingKey<Value>) -> Value {
     guard let data = suite(for: key.scope).object(forKey: key.name) as? Data else {
-      Self.logger.trace("Setting \(key.name, privacy: .public) not set, using default")
       return key.defaultValue
     }
 

--- a/Common/Sources/Common/UserDefaults.swift
+++ b/Common/Sources/Common/UserDefaults.swift
@@ -5,7 +5,6 @@
 //  Created by Paul Gessinger on 03.05.23.
 //
 
-import Combine
 import Foundation
 import os
 
@@ -89,48 +88,5 @@ public class UserDefaultsBacked<Value> where Value: Codable {
     self.key = key
     self.storage = storage
     self.defaultValue = defaultValue
-  }
-}
-
-@propertyWrapper
-public class PublishedUserDefaultsBacked<Value> where Value: Codable {
-  public static subscript<T: ObservableObject>(
-    _enclosingInstance instance: T,
-    wrapped _: ReferenceWritableKeyPath<T, Value>,
-    storage storageKeyPath: ReferenceWritableKeyPath<T, PublishedUserDefaultsBacked<Value>>
-  ) -> Value {
-    get {
-      instance[keyPath: storageKeyPath].backing
-    }
-    set {
-      if let publisher = instance.objectWillChange as? ObservableObjectPublisher {
-        publisher.send()
-      } else {
-        logger.warning(
-          "objectWillChange was not ObservableObjectPublisher but \(String(describing: instance.objectWillChange))"
-        )
-      }
-      instance[keyPath: storageKeyPath].backing = newValue
-    }
-  }
-
-  @UserDefaultsBacked
-  public internal(set) var backing: Value
-
-  public var key: String { $backing.key }
-
-  @available(
-    *, unavailable,
-    message: "Can only be applied to classes"
-  )
-  public var wrappedValue: Value {
-    get { fatalError() }
-    set { fatalError() }
-  }
-
-  public var projectedValue: PublishedUserDefaultsBacked<Value> { self }
-
-  public init(wrappedValue defaultValue: Value, _ key: String, storage: UserDefaults = .standard) {
-    _backing = .init(wrappedValue: defaultValue, key, storage: storage)
   }
 }

--- a/Common/Sources/Common/Version.swift
+++ b/Common/Sources/Common/Version.swift
@@ -55,7 +55,7 @@ public
 }
 
 public
-  struct AppVersion: CustomStringConvertible, Codable, Equatable
+  struct AppVersion: CustomStringConvertible, Codable, Equatable, Sendable
 {
   public let version: Version
   public let build: UInt

--- a/Common/Sources/CommonMacros/Main.swift
+++ b/Common/Sources/CommonMacros/Main.swift
@@ -11,6 +11,7 @@ import SwiftSyntaxMacros
 @main
 struct CommonMacrosPlugin: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
-    URLMacro.self
+    URLMacro.self,
+    SettingMacro.self,
   ]
 }

--- a/Common/Sources/CommonMacros/SettingMacro.swift
+++ b/Common/Sources/CommonMacros/SettingMacro.swift
@@ -1,0 +1,71 @@
+//
+//  SettingMacro.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum SettingMacroError: DiagnosticMessage, Error {
+  case notAProperty
+  case noKey
+
+  public var message: String {
+    switch self {
+    case .notAProperty:
+      "@Setting can only be applied to a variable declaration"
+    case .noKey:
+      "@Setting needs the SettingKey to read and write, e.g. @Setting(.documentDeleteConfirmation)"
+    }
+  }
+
+  public var diagnosticID: MessageID {
+    switch self {
+    case .notAProperty:
+      MessageID(domain: "Common", id: "settingNotAProperty")
+    case .noKey:
+      MessageID(domain: "Common", id: "settingNoKey")
+    }
+  }
+
+  public var severity: DiagnosticSeverity { .error }
+}
+
+/// Expands a property into a computed one over `store`, reporting reads and
+/// writes to the observation registrar.
+public enum SettingMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in _: some MacroExpansionContext
+  ) throws(SettingMacroError) -> [AccessorDeclSyntax] {
+    guard let binding = declaration.as(VariableDeclSyntax.self)?.bindings.first,
+      let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier
+    else {
+      throw .notAProperty
+    }
+
+    guard let key = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression else {
+      throw .noKey
+    }
+
+    return [
+      """
+      get {
+        access(keyPath: \\.\(name))
+        return store[\(key)]
+      }
+      """,
+      """
+      set {
+        withMutation(keyPath: \\.\(name)) {
+          store[\(key)] = newValue
+        }
+      }
+      """,
+    ]
+  }
+}

--- a/Common/Tests/CommonTests/SettingMacroTest.swift
+++ b/Common/Tests/CommonTests/SettingMacroTest.swift
@@ -1,0 +1,99 @@
+//
+//  SettingMacroTest.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+import MacroTesting
+import SwiftSyntax
+import XCTest
+
+@testable import Common
+@testable import CommonMacros
+
+final class SettingMacroTest: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      record: false,
+      macros: ["Setting": SettingMacro.self]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansion() throws {
+    assertMacro {
+      """
+      final class Settings {
+        @Setting(.documentDeleteConfirmation)
+        var documentDeleteConfirmation: Bool
+      }
+      """
+    } expansion: {
+      #"""
+      final class Settings {
+        var documentDeleteConfirmation: Bool {
+          get {
+            access(keyPath: \.documentDeleteConfirmation)
+            return store[.documentDeleteConfirmation]
+          }
+          set {
+            withMutation(keyPath: \.documentDeleteConfirmation) {
+              store[.documentDeleteConfirmation] = newValue
+            }
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  func testOptionalValue() throws {
+    assertMacro {
+      """
+      final class Settings {
+        @Setting(.currentAppVersion)
+        var currentAppVersion: AppVersion?
+      }
+      """
+    } expansion: {
+      #"""
+      final class Settings {
+        var currentAppVersion: AppVersion? {
+          get {
+            access(keyPath: \.currentAppVersion)
+            return store[.currentAppVersion]
+          }
+          set {
+            withMutation(keyPath: \.currentAppVersion) {
+              store[.currentAppVersion] = newValue
+            }
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  func testNoKey() throws {
+    assertMacro {
+      """
+      final class Settings {
+        @Setting
+        var documentDeleteConfirmation: Bool
+      }
+      """
+    } diagnostics: {
+      """
+      final class Settings {
+        @Setting
+        ┬───────
+        ╰─ 🛑 @Setting needs the SettingKey to read and write, e.g. @Setting(.documentDeleteConfirmation)
+        var documentDeleteConfirmation: Bool
+      }
+      """
+    }
+  }
+}

--- a/Common/Tests/CommonTests/SettingsStoreTest.swift
+++ b/Common/Tests/CommonTests/SettingsStoreTest.swift
@@ -5,9 +5,10 @@
 //  Created by Paul Gessinger on 26.07.26.
 //
 
-@testable import Common
 import Foundation
 import Testing
+
+@testable import Common
 
 private enum Fixture {
   enum Mode: String, Codable, Sendable, Equatable {

--- a/Common/Tests/CommonTests/SettingsStoreTest.swift
+++ b/Common/Tests/CommonTests/SettingsStoreTest.swift
@@ -1,0 +1,168 @@
+//
+//  SettingsStoreTest.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+@testable import Common
+import Foundation
+import Testing
+
+private enum Fixture {
+  enum Mode: String, Codable, Sendable, Equatable {
+    case titleContent
+    case advanced
+  }
+
+  struct Composite: Codable, Sendable, Equatable {
+    var components: [String]
+    var enabled: Bool
+  }
+
+  static let flag = SettingKey("flag", default: true)
+  static let mode = SettingKey("mode", default: Mode.titleContent)
+  static let composite = SettingKey(
+    "composite", default: Composite(components: ["a"], enabled: false))
+  static let sharedFlag = SettingKey("sharedFlag", default: false, scope: .shared)
+  static let optional = SettingKey<Int?>("optional", default: nil)
+  static let optionalWithDefault = SettingKey<Int?>("optionalWithDefault", default: 7)
+}
+
+/// Gives each test its own pair of suites, so nothing leaks between tests or
+/// into the developer's actual preferences.
+private struct Suites: ~Copyable {
+  let device: UserDefaults
+  let shared: UserDefaults
+  let store: SettingsStore
+
+  private let deviceName: String
+  private let sharedName: String
+
+  init() {
+    deviceName = "SettingsStoreTest.device.\(UUID().uuidString)"
+    sharedName = "SettingsStoreTest.shared.\(UUID().uuidString)"
+    device = UserDefaults(suiteName: deviceName)!
+    shared = UserDefaults(suiteName: sharedName)!
+    store = SettingsStore(suites: [.device: device, .shared: shared])
+  }
+
+  deinit {
+    device.removePersistentDomain(forName: deviceName)
+    shared.removePersistentDomain(forName: sharedName)
+  }
+}
+
+@Suite("SettingsStore")
+struct SettingsStoreTest {
+  @Test("unset keys read as their declared default")
+  func defaults() {
+    let suites = Suites()
+    #expect(suites.store[Fixture.flag] == true)
+    #expect(suites.store[Fixture.mode] == .titleContent)
+    #expect(suites.store[Fixture.composite].components == ["a"])
+    #expect(suites.store[Fixture.optional] == nil)
+  }
+
+  @Test("values round-trip through the suite")
+  func roundTrip() {
+    let suites = Suites()
+
+    suites.store[Fixture.flag] = false
+    suites.store[Fixture.mode] = .advanced
+    suites.store[Fixture.composite] = .init(components: ["b", "c"], enabled: true)
+    suites.store[Fixture.optional] = 42
+
+    #expect(suites.store[Fixture.flag] == false)
+    #expect(suites.store[Fixture.mode] == .advanced)
+    #expect(suites.store[Fixture.composite] == .init(components: ["b", "c"], enabled: true))
+    #expect(suites.store[Fixture.optional] == 42)
+
+    // A second store over the same suites sees the persisted values, i.e. they
+    // really went to disk rather than only into the cache.
+    let other = SettingsStore(suites: [.device: suites.device, .shared: suites.shared])
+    #expect(other[Fixture.flag] == false)
+    #expect(other[Fixture.mode] == .advanced)
+    #expect(other[Fixture.optional] == 42)
+  }
+
+  @Test("an optional value can be set back to nil, which is not the default")
+  func optionalNil() {
+    let suites = Suites()
+    #expect(suites.store[Fixture.optionalWithDefault] == 7)
+
+    suites.store[Fixture.optionalWithDefault] = nil
+    // Cached...
+    #expect(suites.store[Fixture.optionalWithDefault] == nil)
+    // ...and persisted: an explicit nil is not the same as "never set"
+    let other = SettingsStore(suites: [.device: suites.device, .shared: suites.shared])
+    #expect(other[Fixture.optionalWithDefault] == nil)
+
+    suites.store.remove(Fixture.optionalWithDefault)
+    #expect(suites.store[Fixture.optionalWithDefault] == 7)
+  }
+
+  @Test("the scope decides which suite is written")
+  func scopeRouting() {
+    let suites = Suites()
+
+    suites.store[Fixture.flag] = false
+    suites.store[Fixture.sharedFlag] = true
+
+    #expect(suites.device.object(forKey: "flag") != nil)
+    #expect(suites.shared.object(forKey: "flag") == nil)
+
+    #expect(suites.shared.object(forKey: "sharedFlag") != nil)
+    #expect(suites.device.object(forKey: "sharedFlag") == nil)
+  }
+
+  @Test("removing a value restores the default")
+  func remove() {
+    let suites = Suites()
+
+    suites.store[Fixture.flag] = false
+    #expect(suites.store[Fixture.flag] == false)
+
+    suites.store.remove(Fixture.flag)
+    #expect(suites.store[Fixture.flag] == true)
+    #expect(suites.device.object(forKey: "flag") == nil)
+  }
+
+  @Test("a value written behind the store's back is picked up")
+  func externalWrite() {
+    let suites = Suites()
+
+    // Prime the cache
+    #expect(suites.store[Fixture.mode] == .titleContent)
+
+    suites.device.set(try! JSONEncoder().encode(Fixture.Mode.advanced), forKey: "mode")
+
+    #expect(suites.store[Fixture.mode] == .advanced)
+  }
+
+  @Test("undecodable data falls back to the default instead of trapping")
+  func corruptValue() {
+    let suites = Suites()
+
+    suites.device.set(Data("not json".utf8), forKey: "mode")
+    #expect(suites.store[Fixture.mode] == .titleContent)
+
+    // A non-Data value (e.g. written by an older @AppStorage) is tolerated too
+    suites.device.set("advanced", forKey: "mode")
+    #expect(suites.store[Fixture.mode] == .titleContent)
+  }
+
+  @Test("the on-disk format is the JSON the app has always written")
+  func storageFormat() {
+    let suites = Suites()
+
+    suites.store[Fixture.mode] = .advanced
+
+    let data = suites.device.object(forKey: "mode") as? Data
+    #expect(data == Data(#""advanced""#.utf8))
+
+    // ...and a value written by the previous UserDefaultsBacked wrapper reads back
+    suites.device.set(try! JSONEncoder().encode(true), forKey: "flag")
+    #expect(suites.store[Fixture.flag] == true)
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,0 +1,1 @@
+- Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart

--- a/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
+++ b/swift-paperless/Views/Document/Detail/V4/DocumentDetailViewV4.swift
@@ -90,7 +90,7 @@ struct DocumentDetailViewV4: DocumentDetailViewProtocol {
   @State private var deleted = false
   @State private var sharedFile: NamedShareItem?
 
-  @ObservedObject private var appSettings = AppSettings.shared
+  private let appSettings = AppSettings.shared
 
   var navPath: Binding<[NavigationState]>? = nil
 

--- a/swift-paperless/Views/Document/DocumentList.swift
+++ b/swift-paperless/Views/Document/DocumentList.swift
@@ -53,7 +53,7 @@ struct DocumentList: View {
 
   @EnvironmentObject private var errorController: ErrorController
 
-  @ObservedObject private var appSettings = AppSettings.shared
+  private let appSettings = AppSettings.shared
 
   init(
     store: DocumentStore, onSelect: @escaping (Document) -> Void, filterModel: FilterModel,

--- a/swift-paperless/Views/Settings/DebugMenuView.swift
+++ b/swift-paperless/Views/Settings/DebugMenuView.swift
@@ -14,7 +14,7 @@ import os
 
 struct DebugMenuView: View {
   @Environment(ConnectionManager.self) private var connectionManager
-  @ObservedObject private var appSettings = AppSettings.shared
+  private let appSettings = AppSettings.shared
   @State private var showResetConfirmation = false
   @State private var exportResult: ExportResult?
 

--- a/swift-paperless/Views/Settings/PreferencesView.swift
+++ b/swift-paperless/Views/Settings/PreferencesView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import os
 
 struct PreferencesView: View {
-  @ObservedObject private var appSettings = AppSettings.shared
+  @Bindable private var appSettings = AppSettings.shared
 
   @EnvironmentObject private var biometricLockManager: BiometricLockManager
   @Environment(DocumentStore.self) private var store

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -32,8 +32,6 @@ struct MainView: View {
 
   @Environment(\.scenePhase) var scenePhase
 
-  @ObservedObject private var appSettings = AppSettings.shared
-
   @State private var releaseNotesModel = ReleaseNotesViewModel()
 
   @StateObject private var biometricLockManager: BiometricLockManager


### PR DESCRIPTION
Replaces the `AppSettings` + `UserDefaultsBacked` / `PublishedUserDefaultsBacked` stack with a key-descriptor store, as proposed in #641.

Fixes one user-facing bug on the way; the rest is structural.

Based directly on `main`. #646 is stacked on top of this and moves the stored values off JSON. The offline-sync stack (#597 and up) also sits on these commits locally, so it will want a rebase once this lands.

## Commits

1. **Remove dead app-settings property wrappers** — `@AppSetting`, `@AppSettingsObject`, `editingUserInterfaceExperiment`. All three had zero call sites, and `@AppSetting` was the only sender of `settingsChanged`.
2. **Add a scoped settings store to `Common`** — `SettingKey` (name, default, scope) and `SettingsStore`. Nonisolated so `FilterState.default` can read it, decoded values cached behind a lock, cache dropped on `UserDefaults.didChangeNotification`. 8 tests.
3. **Rebuild `AppSettings` on the store** — one computed property per setting over the store, `Observable` instead of `ObservableObject`.
4. **Collapse the boilerplate into a `@Setting` macro** — `@Setting(.documentDeleteConfirmation)` expands to the get/set plumbing, so a setting is its declaration and nothing else.

## The user-facing fix

`FilterModel` subscribed to `AppSettings.settingsChanged`, which nothing ever sent — `@AppSetting`, its only writer, had no call sites. Changing the default sort field, sort order or search mode in Preferences therefore did nothing until the filter model was rebuilt. It now tracks those three settings through the observation machinery, so the change reaches the live filter.

## Notes for review

- **`@Setting` and `@Observable` are mutually exclusive.** `@Observable` claims the accessors of every stored property, and `@ObservationIgnored` is itself an accessor macro, so neither combines with a custom accessor macro. `AppSettings` conforms to `Observable` by hand — one registrar plus two forwarding methods. Nothing is lost: there are no stored settings for `@Observable` to manage.
- **The on-disk format is unchanged.** Values are still JSON `Data` under the same keys, so existing installs read back exactly what they had. #646 changes that separately, so a format change and a structural change are not being reviewed at once.
- **Every key stays `.device`.** The `scope` mechanism exists and is tested, but moving a key to the app group needs a migration of the stored value, and iCloud KVS needs entitlements — both are separate PRs, per the sequencing in #641.
- **Keys stay explicitly declared** in `SettingKeys.swift` rather than macro-generated. The name string is persisted user data; deriving it from a Swift identifier would let a rename silently orphan a stored value.
- `FilterBarConfiguration`, `FilterBarComponent` and `AppVersion` gain `Sendable` conformances so they can be setting values.

## Verification

Builds on the iOS 26 simulator at each of the four commits standalone, and runs against a live server with no settings decode errors in the log. All package tests pass (586 + 8 macro tests). Re-verified after rebasing onto current `main`.

Not verified: the Preferences pickers were not driven by hand, so the live-defaults fix is confirmed structurally and by build, not by clicking through the UI.

---

*Written by an AI agent (Claude Code) on @paulgessinger's request. The build, test and launch results above were run and observed; the UI-level behaviour of the Preferences fix was not.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UifXQhoVcktmnFLYu55Vs
