### PR TITLE
feat: store scalar settings natively, migrating off JSON on read

### DIFF
--- a/Common/Sources/Common/Settings/SettingValueCoder.swift
+++ b/Common/Sources/Common/Settings/SettingValueCoder.swift
@@ -1,0 +1,79 @@
+//
+//  SettingValueCoder.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+
+/// Translates a setting value to and from what is actually put in
+/// `UserDefaults`.
+///
+/// Settings used to be stored as JSON `Data` without exception, so a `Bool`
+/// was the four bytes `true`. That is invisible in a defaults dump, cannot be
+/// observed with KVO, is not readable by `@AppStorage`, and would go into
+/// `NSUbiquitousKeyValueStore` as an opaque blob.
+///
+/// Values whose JSON form is a single scalar are therefore stored as the
+/// native type instead. The scalar is derived from the value's own `Codable`
+/// conformance rather than from a separate mapping, so what is written matches
+/// what the JSON form has always contained — no type can drift between the two
+/// representations. Anything composite (an object or an array) stays `Data`.
+enum SettingValueCoder {
+  /// What a value looks like in `UserDefaults`.
+  enum Stored: Equatable {
+    case bool(Bool)
+    case string(String)
+    case json(Data)
+  }
+
+  static func encode(_ value: some Encodable) throws -> Stored {
+    let data = try JSONEncoder().encode(value)
+
+    // A JSON scalar: store it as the matching native type. The decode attempts
+    // are cheap and unambiguous — JSONDecoder does not coerce between a bool,
+    // a string and a container.
+    if let bool = try? JSONDecoder().decode(Bool.self, from: data) {
+      return .bool(bool)
+    }
+    if let string = try? JSONDecoder().decode(String.self, from: data) {
+      return .string(string)
+    }
+    return .json(data)
+  }
+
+  static func decode<Value: Decodable>(_ type: Value.Type, from stored: Stored) throws -> Value {
+    switch stored {
+    case .bool(let bool):
+      try JSONDecoder().decode(type, from: JSONEncoder().encode(bool))
+    case .string(let string):
+      // Re-encoded rather than quoted by hand, so escaping stays the
+      // encoder's problem.
+      try JSONDecoder().decode(type, from: JSONEncoder().encode(string))
+    case .json(let data):
+      try JSONDecoder().decode(type, from: data)
+    }
+  }
+
+  /// Reads whatever is under `key`, in either the native or the legacy form.
+  ///
+  /// `Data` is checked first: a value written before the migration is JSON,
+  /// and only a genuinely composite value stays that way afterwards.
+  static func read(from suite: UserDefaults, key: String) -> Stored? {
+    switch suite.object(forKey: key) {
+    case let data as Data: .json(data)
+    case let string as String: .string(string)
+    case let bool as Bool: .bool(bool)
+    default: nil
+    }
+  }
+
+  static func write(_ stored: Stored, to suite: UserDefaults, key: String) {
+    switch stored {
+    case .bool(let bool): suite.set(bool, forKey: key)
+    case .string(let string): suite.set(string, forKey: key)
+    case .json(let data): suite.set(data, forKey: key)
+    }
+  }
+}

--- a/Common/Sources/Common/Settings/SettingsStore.swift
+++ b/Common/Sources/Common/Settings/SettingsStore.swift
@@ -96,15 +96,17 @@ public final class SettingsStore: @unchecked Sendable {
   }
 
   private func decode<Value>(_ key: SettingKey<Value>) -> Value {
-    guard let data = suite(for: key.scope).object(forKey: key.name) as? Data else {
+    let suite = suite(for: key.scope)
+    guard let stored = SettingValueCoder.read(from: suite, key: key.name) else {
       return key.defaultValue
     }
 
     do {
-      let value = try JSONDecoder().decode(Value.self, from: data)
+      let value = try SettingValueCoder.decode(Value.self, from: stored)
       Self.logger.trace(
         "Setting \(key.name, privacy: .public) read: \(String(describing: value), privacy: .private)"
       )
+      migrateIfNeeded(value, key: key, stored: stored, in: suite)
       return value
     } catch {
       Self.logger.error(
@@ -113,16 +115,32 @@ public final class SettingsStore: @unchecked Sendable {
     }
   }
 
+  /// Rewrites a legacy JSON value in its native form the first time it is
+  /// read, so the migration costs one write per key rather than needing a
+  /// version stamp or a migration pass at launch.
+  private func migrateIfNeeded<Value>(
+    _ value: Value, key: SettingKey<Value>, stored: SettingValueCoder.Stored, in suite: UserDefaults
+  ) {
+    guard case .json = stored,
+      let native = try? SettingValueCoder.encode(value), native != stored
+    else {
+      return
+    }
+
+    Self.logger.info("Setting \(key.name, privacy: .public) migrated to its native representation")
+    SettingValueCoder.write(native, to: suite, key: key.name)
+  }
+
   public func set<Value>(_ value: Value, for key: SettingKey<Value>) {
     Self.logger.trace(
       "Setting \(key.name, privacy: .public) written: \(String(describing: value), privacy: .private)"
     )
 
     do {
-      let data = try JSONEncoder().encode(value)
+      let stored = try SettingValueCoder.encode(value)
       // Outside the lock: writing posts didChangeNotification synchronously,
       // which invalidates the cache.
-      suite(for: key.scope).set(data, forKey: key.name)
+      SettingValueCoder.write(stored, to: suite(for: key.scope), key: key.name)
     } catch {
       Self.logger.error("Setting \(key.name, privacy: .public) could not be encoded: \(error)")
       return

--- a/Common/Tests/CommonTests/SettingsStoreMigrationTest.swift
+++ b/Common/Tests/CommonTests/SettingsStoreMigrationTest.swift
@@ -1,0 +1,156 @@
+//
+//  SettingsStoreMigrationTest.swift
+//  Common
+//
+//  Created by Paul Gessinger on 26.07.26.
+//
+
+import Foundation
+import Testing
+
+@testable import Common
+
+private enum Fixture {
+  /// Encodes as a JSON string, like SortField and FilterState.SearchMode.
+  enum Mode: String, Codable, Sendable, Equatable {
+    case titleContent
+    case advanced
+  }
+
+  /// Encodes as a JSON bool, like DataModel.SortOrder.
+  struct Reversed: Codable, Sendable, Equatable {
+    var reversed: Bool
+    init(_ reversed: Bool) { self.reversed = reversed }
+    init(from decoder: any Decoder) throws {
+      reversed = try decoder.singleValueContainer().decode(Bool.self)
+    }
+    func encode(to encoder: any Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(reversed)
+    }
+  }
+
+  struct Composite: Codable, Sendable, Equatable {
+    var components: [String]
+  }
+
+  static let flag = SettingKey("flag", default: true)
+  static let mode = SettingKey("mode", default: Mode.titleContent)
+  static let order = SettingKey("order", default: Reversed(false))
+  static let composite = SettingKey("composite", default: Composite(components: ["a"]))
+  static let text = SettingKey("text", default: "")
+  static let optional = SettingKey<Int?>("optional", default: nil)
+}
+
+private struct Suites: ~Copyable {
+  let device: UserDefaults
+  let store: SettingsStore
+  private let name: String
+
+  init() {
+    name = "SettingsStoreMigrationTest.\(UUID().uuidString)"
+    device = UserDefaults(suiteName: name)!
+    store = SettingsStore(suites: [.device: device])
+  }
+
+  /// Writes a value the way the app stored settings before the migration.
+  func writeLegacy(_ value: some Encodable, key: String) {
+    device.set(try! JSONEncoder().encode(value), forKey: key)
+  }
+
+  deinit { device.removePersistentDomain(forName: name) }
+}
+
+@Suite("SettingsStore native storage")
+struct SettingsStoreMigrationTest {
+  @Test("scalars are written as native types, not as JSON blobs")
+  func nativeWrites() {
+    let suites = Suites()
+
+    suites.store[Fixture.flag] = false
+    suites.store[Fixture.mode] = .advanced
+    suites.store[Fixture.order] = .init(true)
+
+    #expect(suites.device.object(forKey: "flag") as? Bool == false)
+    #expect(suites.device.object(forKey: "mode") as? String == "advanced")
+    #expect(suites.device.object(forKey: "order") as? Bool == true)
+
+    // ...which is what makes them readable the ordinary way
+    #expect(suites.device.string(forKey: "mode") == "advanced")
+  }
+
+  @Test("composite values stay JSON")
+  func compositeStaysJSON() {
+    let suites = Suites()
+
+    suites.store[Fixture.composite] = .init(components: ["b", "c"])
+
+    let stored = suites.device.object(forKey: "composite")
+    #expect(stored is Data)
+    #expect(suites.store[Fixture.composite] == .init(components: ["b", "c"]))
+  }
+
+  @Test("a value stored by the previous build is read and rewritten natively")
+  func migratesOnRead() {
+    let suites = Suites()
+
+    suites.writeLegacy(Fixture.Mode.advanced, key: "mode")
+    suites.writeLegacy(false, key: "flag")
+    #expect(suites.device.object(forKey: "mode") is Data)
+
+    #expect(suites.store[Fixture.mode] == .advanced)
+    #expect(suites.store[Fixture.flag] == false)
+
+    #expect(suites.device.object(forKey: "mode") as? String == "advanced")
+    #expect(suites.device.object(forKey: "flag") as? Bool == false)
+
+    // The rewrite did not change what the value reads back as
+    let other = SettingsStore(suites: [.device: suites.device])
+    #expect(other[Fixture.mode] == .advanced)
+    #expect(other[Fixture.flag] == false)
+  }
+
+  @Test("a legacy composite value is left as JSON")
+  func compositeNotMigrated() {
+    let suites = Suites()
+
+    suites.writeLegacy(Fixture.Composite(components: ["x"]), key: "composite")
+    #expect(suites.store[Fixture.composite] == .init(components: ["x"]))
+    #expect(suites.device.object(forKey: "composite") is Data)
+  }
+
+  @Test("strings needing escaping survive the round trip")
+  func escaping() {
+    let suites = Suites()
+
+    let awkward = #"quote " backslash \ newline"# + "\n\u{1F600}"
+    suites.store[Fixture.text] = awkward
+
+    #expect(suites.device.object(forKey: "text") as? String == awkward)
+    #expect(suites.store[Fixture.text] == awkward)
+
+    let other = SettingsStore(suites: [.device: suites.device])
+    #expect(other[Fixture.text] == awkward)
+  }
+
+  @Test("an optional value still round-trips")
+  func optionals() {
+    let suites = Suites()
+
+    suites.store[Fixture.optional] = 42
+    #expect(suites.store[Fixture.optional] == 42)
+
+    suites.store[Fixture.optional] = nil
+    let other = SettingsStore(suites: [.device: suites.device])
+    #expect(other[Fixture.optional] == nil)
+  }
+
+  @Test("a corrupt native value falls back to the default")
+  func corruptNative() {
+    let suites = Suites()
+
+    // A string that is not one of the enum's cases
+    suites.device.set("nonsense", forKey: "mode")
+    #expect(suites.store[Fixture.mode] == .titleContent)
+  }
+}

--- a/Common/Tests/CommonTests/SettingsStoreTest.swift
+++ b/Common/Tests/CommonTests/SettingsStoreTest.swift
@@ -147,23 +147,16 @@ struct SettingsStoreTest {
 
     suites.device.set(Data("not json".utf8), forKey: "mode")
     #expect(suites.store[Fixture.mode] == .titleContent)
-
-    // A non-Data value (e.g. written by an older @AppStorage) is tolerated too
-    suites.device.set("advanced", forKey: "mode")
-    #expect(suites.store[Fixture.mode] == .titleContent)
   }
 
-  @Test("the on-disk format is the JSON the app has always written")
-  func storageFormat() {
+  @Test("values written by the previous UserDefaultsBacked wrapper read back")
+  func legacyStorageFormat() {
     let suites = Suites()
 
-    suites.store[Fixture.mode] = .advanced
-
-    let data = suites.device.object(forKey: "mode") as? Data
-    #expect(data == Data(#""advanced""#.utf8))
-
-    // ...and a value written by the previous UserDefaultsBacked wrapper reads back
     suites.device.set(try! JSONEncoder().encode(true), forKey: "flag")
     #expect(suites.store[Fixture.flag] == true)
+
+    suites.device.set(try! JSONEncoder().encode(Fixture.Mode.advanced), forKey: "mode")
+    #expect(suites.store[Fixture.mode] == .advanced)
   }
 }


### PR DESCRIPTION
Stacked on #645 — review that one first; this PR's diff is one commit.

Moves settings off blanket JSON storage, which is the remaining prerequisite from #641 for a `NSUbiquitousKeyValueStore` mirror.

## The problem

Every setting was stored as JSON `Data`, so `documentDeleteConfirmation` was the four bytes `true`. That is invisible in a defaults dump, not observable with KVO, unreadable by `@AppStorage`, and would go into the KVS as an opaque blob.

## What changes

Values whose JSON form is a single scalar are stored as the native type; composites stay `Data`:

| setting | before | after |
|---|---|---|
| `documentDeleteConfirmation`, `enableBiometricAppLock` | `Data` | `Bool` |
| `defaultSortOrder` (encodes as a JSON bool) | `Data` | `Bool` |
| `defaultSortField`, `defaultSearchMode` | `Data` | `String` |
| `filterBarConfiguration`, `currentAppVersion` | `Data` | `Data` |

The scalar is derived from the value type's own `Codable` conformance rather than from a second, parallel mapping. That matters for fidelity: the native form cannot disagree with what the JSON form has always contained, no per-type conformance has to be written and kept in sync, and re-encoding through `JSONEncoder` leaves string escaping to the encoder. `AppSettings` and the key declarations are untouched — the dispatch is entirely inside the store.

## Migration

Lazy and one write per key: a legacy JSON value is decoded, returned, and rewritten in native form the first time it is read. No version stamp, no launch-time migration pass.

**This is one-way.** An older build reading a natively stored value finds no `Data`, so it falls back to the default — a downgrade (or a TestFlight rollback) resets the migrated settings. That is the accepted cost of the change, but it is worth knowing before this ships.

## Verification

- 7 new tests covering native writes, composites staying JSON, legacy values migrating on read, awkward string escaping, optionals, and corrupt values. Two tests from #645 that asserted the old write format are updated — that behaviour is what this PR changes.
- End-to-end on the simulator: legacy JSON values were planted in the app's defaults with `defaults write -data`, the app was launched, and the sandboxed preferences plist afterwards reads

  ```
  "defaultSortField" => "added"                 # was: {length = 7, bytes = 0x22616464656422}
  "documentDeleteConfirmation" => false         # was: {length = 5, bytes = 0x66616c7365}
  "currentAppVersion" => {length = 32, bytes = 0x7b22...}   # composite, unchanged
  ```

  with `Setting documentDeleteConfirmation migrated to its native representation` in the log. Value and type both as intended.
- All 61 `Common` tests and the app build pass.

---

*Written by an AI agent (Claude Code) on @paulgessinger's request. The test, build and simulator results above were run and observed; the downgrade behaviour is stated from the code path, not exercised against an older build.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UifXQhoVcktmnFLYu55Vs
