### PR TITLE
fix: Another case of API version mis-detection

### DIFF
--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -50,16 +50,23 @@ public class ApiRepository {
 
   private var inFlightDownloads: [DownloadKey: Task<URL, Error>] = [:]
 
-  nonisolated
-    private let apiVersion: UInt?
+  // Detected API/backend versions. Mutable because detection can be re-run at
+  // runtime: if the backend is unreachable at init we lock in the minimum API
+  // version, and a later 406 (`unsupportedVersion`) triggers a re-probe so the
+  // repository recovers once the backend comes back online.
+  private var apiVersion: UInt?
   nonisolated
     public static let minimumApiVersion: UInt = 3
   nonisolated
     public static let minimumVersion = Version(1, 14, 1)
   nonisolated
     public static let maximumApiVersion: UInt = 10
-  nonisolated
-    public let backendVersion: Version?
+  public private(set) var backendVersion: Version?
+
+  // Single-flight guard for runtime re-probing: when several in-flight requests
+  // 406 at once (e.g. the backend just came back online) they share one probe
+  // rather than each hammering the backend through the full version sweep.
+  private var versionReprobeTask: Task<UInt?, Never>?
 
   public var effectiveApiVersion: UInt {
     // If X-Api-Version can't be read (e.g. 401 before middleware), apiVersion is nil.
@@ -233,10 +240,80 @@ public class ApiRepository {
     progress: (@Sendable (Double) -> Void)? = nil,
     cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalCacheData
   ) async throws -> (Data, URLResponse) {
-    try await Self.fetchData(
-      for: request, expectedStatus: expectedStatus, progress: progress, cachePolicy: cachePolicy,
-      urlSession: urlSession
-    )
+    do {
+      return try await Self.fetchData(
+        for: request, expectedStatus: expectedStatus, progress: progress, cachePolicy: cachePolicy,
+        urlSession: urlSession
+      )
+    } catch RequestError.unsupportedVersion(let sentVersion) {
+      // The backend rejected our API version. This is the recovery path for a
+      // version that was locked in against an unreachable backend (app launched
+      // offline → minimum API version). Re-probe the live backend; if a
+      // different version comes back, retry the request once with a corrected
+      // Accept header. The retried call goes straight to the static helper, so a
+      // second 406 propagates instead of looping.
+      Logger.networking.warning(
+        "Request rejected as unsupported API version (sent \(String(describing: sentVersion), privacy: .public)); re-probing backend"
+      )
+
+      guard await reprobeVersion() != nil else {
+        Logger.networking.error(
+          "Re-probe failed to detect a working API version; propagating unsupportedVersion")
+        throw RequestError.unsupportedVersion(sentVersion: sentVersion)
+      }
+
+      let retryVersion = effectiveApiVersion
+      guard retryVersion != sentVersion else {
+        Logger.networking.error(
+          "Re-probe yielded the same API version (\(retryVersion)); propagating unsupportedVersion to avoid a retry loop"
+        )
+        throw RequestError.unsupportedVersion(sentVersion: sentVersion)
+      }
+
+      Logger.networking.notice(
+        "Re-probe selected API version \(retryVersion); retrying request once")
+      var retry = request
+      retry.setValue(
+        "application/json; version=\(retryVersion)", forHTTPHeaderField: "Accept")
+      return try await Self.fetchData(
+        for: retry, expectedStatus: expectedStatus, progress: progress,
+        cachePolicy: cachePolicy, urlSession: urlSession
+      )
+    }
+  }
+
+  // Re-runs API-version detection after the backend rejected a request with 406
+  // (`unsupportedVersion`) — typically because the version was locked in while
+  // the backend was unreachable. Updates `apiVersion`/`backendVersion` in place
+  // and returns the detected API version, or nil if detection failed (e.g. the
+  // backend is still unreachable). Concurrent callers share one in-flight probe.
+  private func reprobeVersion() async -> UInt? {
+    if let versionReprobeTask {
+      return await versionReprobeTask.value
+    }
+
+    let task = Task<UInt?, Never> {
+      if let versions = await Self.loadBackendVersions(
+        urlSession: urlSession, connection: connection)
+      {
+        apiVersion = versions.apiVersion
+        backendVersion = versions.backendVersion
+        return versions.apiVersion
+      }
+      if let detected = await Self.iterateAcceptedApiVersion(
+        urlSession: urlSession, connection: connection)
+      {
+        // The iteration probe can't learn the backend version string; keep any
+        // previously-known value rather than clobbering feature support to nil.
+        apiVersion = detected
+        return detected
+      }
+      return nil
+    }
+
+    versionReprobeTask = task
+    defer { versionReprobeTask = nil }
+    return await task.value
   }
 
   private static func fetchData(

--- a/Networking/Tests/NetworkingTests/ApiRepositoryVersionReprobeTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryVersionReprobeTest.swift
@@ -1,0 +1,216 @@
+//
+//  ApiRepositoryVersionReprobeTest.swift
+//  Networking
+//
+//  Exercises the runtime API-version re-probe: when a request is rejected with
+//  406 (`unsupportedVersion`) — e.g. the version was locked in against an
+//  unreachable backend — the repository re-detects the version and retries the
+//  request once with a corrected Accept header.
+//
+
+import Common
+import DataModel
+import Foundation
+import Testing
+
+@testable import Networking
+
+// Dedicated URLProtocol subclass with its own static responder so this suite
+// doesn't race against other suites that share a mock URLProtocol global.
+final class VersionMockURLProtocol: URLProtocol, @unchecked Sendable {
+  typealias Responder = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var _responder: Responder?
+
+  static var responder: Responder? {
+    get { lock.withLock { _responder } }
+    set { lock.withLock { _responder = newValue } }
+  }
+
+  static func reset() { responder = nil }
+
+  static func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [VersionMockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  override class func canInit(with _: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let responder = Self.responder else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    do {
+      let (response, data) = try responder(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+@MainActor
+@Suite(.serialized)
+struct ApiRepositoryVersionReprobeTest {
+  nonisolated static let baseURL = URL(string: "https://example.com")!
+  nonisolated static let serverID = UUID(
+    uuidString: "99999999-8888-7777-6666-555555555555")!
+
+  // Atomic counter for request-count assertions across concurrent callbacks.
+  final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int { lock.withLock { _value } }
+    func bump() { lock.withLock { _value += 1 } }
+  }
+
+  static func makeRepo(apiVersion: UInt?, backendVersion: Version? = nil) -> ApiRepository {
+    ApiRepository(
+      connection: Connection(
+        url: baseURL, token: "t", identityName: nil, serverID: serverID),
+      mode: .release,
+      contentStore: nil,
+      urlSession: VersionMockURLProtocol.makeSession(),
+      apiVersion: apiVersion,
+      backendVersion: backendVersion)
+  }
+
+  nonisolated static func dataURL() -> URL {
+    baseURL.appendingPathComponent("api/documents/")
+  }
+
+  nonisolated static func uiSettingsResponse(
+    for request: URLRequest, apiVersion: String, backendVersion: String = "2.14.0"
+  ) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+      headerFields: [
+        "X-Api-Version": apiVersion,
+        "X-Version": backendVersion,
+      ])!
+  }
+
+  nonisolated static func response(
+    for request: URLRequest, status: Int, body: Data = Data()
+  ) -> (HTTPURLResponse, Data) {
+    (
+      HTTPURLResponse(
+        url: request.url!, statusCode: status, httpVersion: "HTTP/1.1",
+        headerFields: nil)!,
+      body
+    )
+  }
+
+  // The backend was unreachable at init (version locked in at the minimum). A
+  // request 406s; the re-probe learns the real version and the retry succeeds.
+  @Test
+  func reprobesAndRetriesOnUnsupportedVersion() async throws {
+    let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
+    let uiSettingsHits = Counter()
+    VersionMockURLProtocol.responder = { req in
+      let accept = req.value(forHTTPHeaderField: "Accept") ?? ""
+      if (req.url?.path ?? "").contains("ui_settings") {
+        uiSettingsHits.bump()
+        return (Self.uiSettingsResponse(for: req, apiVersion: "7"), Data("{}".utf8))
+      }
+      // Data endpoint: reject the locked-in minimum, accept the re-probed version.
+      if accept.contains("version=7") {
+        return Self.response(for: req, status: 200, body: Data("[\"ok\"]".utf8))
+      }
+      return Self.response(for: req, status: 406)
+    }
+    defer { VersionMockURLProtocol.reset() }
+
+    let request = repo.request(url: Self.dataURL())
+    let result = try await repo.fetchData(for: request, as: [String].self)
+
+    #expect(result == ["ok"])
+    #expect(repo.effectiveApiVersion == 7)
+    #expect(uiSettingsHits.value == 1)
+  }
+
+  // Several requests 406 at once (backend just came back online): they must
+  // share a single re-probe rather than each running the version sweep.
+  @Test
+  func concurrentUnsupportedVersionShareSingleProbe() async throws {
+    let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
+    let uiSettingsHits = Counter()
+    VersionMockURLProtocol.responder = { req in
+      let accept = req.value(forHTTPHeaderField: "Accept") ?? ""
+      if (req.url?.path ?? "").contains("ui_settings") {
+        uiSettingsHits.bump()
+        return (Self.uiSettingsResponse(for: req, apiVersion: "7"), Data("{}".utf8))
+      }
+      if accept.contains("version=7") {
+        return Self.response(for: req, status: 200, body: Data("[\"ok\"]".utf8))
+      }
+      return Self.response(for: req, status: 406)
+    }
+    defer { VersionMockURLProtocol.reset() }
+
+    let request = repo.request(url: Self.dataURL())
+    async let a = repo.fetchData(for: request, as: [String].self)
+    async let b = repo.fetchData(for: request, as: [String].self)
+    let results = try await [a, b]
+
+    #expect(results[0] == ["ok"])
+    #expect(results[1] == ["ok"])
+    #expect(repo.effectiveApiVersion == 7)
+    #expect(uiSettingsHits.value == 1)
+  }
+
+  // The backend is still unreachable: re-probe can't find a working version, so
+  // the original unsupportedVersion error propagates and the version is unchanged.
+  @Test
+  func propagatesWhenReprobeFails() async throws {
+    let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
+    VersionMockURLProtocol.responder = { req in
+      if (req.url?.path ?? "").contains("ui_settings") {
+        throw URLError(.cannotConnectToHost)
+      }
+      return Self.response(for: req, status: 406)
+    }
+    defer { VersionMockURLProtocol.reset() }
+
+    let request = repo.request(url: Self.dataURL())
+    await #expect(throws: RequestError.self) {
+      _ = try await repo.fetchData(for: request, as: [String].self)
+    }
+    #expect(repo.effectiveApiVersion == ApiRepository.minimumApiVersion)
+  }
+
+  // Re-probe returns the same version we already sent: don't retry (it would
+  // just 406 again) — propagate the error instead of looping.
+  @Test
+  func propagatesWhenReprobeYieldsSameVersion() async throws {
+    let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
+    let uiSettingsHits = Counter()
+    VersionMockURLProtocol.responder = { req in
+      if (req.url?.path ?? "").contains("ui_settings") {
+        uiSettingsHits.bump()
+        return (
+          Self.uiSettingsResponse(
+            for: req, apiVersion: String(ApiRepository.minimumApiVersion)),
+          Data("{}".utf8)
+        )
+      }
+      return Self.response(for: req, status: 406)
+    }
+    defer { VersionMockURLProtocol.reset() }
+
+    let request = repo.request(url: Self.dataURL())
+    await #expect(throws: RequestError.self) {
+      _ = try await repo.fetchData(for: request, as: [String].self)
+    }
+    #expect(uiSettingsHits.value == 1)
+    #expect(repo.effectiveApiVersion == ApiRepository.minimumApiVersion)
+  }
+}

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -1,1 +1,2 @@
 - Changing the default sort field, sort order or search mode in Preferences now applies to the document list right away, instead of only after a restart
+- Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version


### PR DESCRIPTION
See https://github.com/paulgessinger/swift-paperless/issues/652

<!-- jjp:description -->

<!-- /jjp:description -->
<!-- jjp:body-fp e4a6a0577479b2b4 -->

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)  👈
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership
- #627 feat/background-sync
<!-- /jjp:stack-nav -->
