### PR TITLE
feat: support TOTP second factor in OIDC login (#632)

### DIFF
--- a/AppShared/Sources/AppShared/Networking/Error/OIDCError+LocalizedError.swift
+++ b/AppShared/Sources/AppShared/Networking/Error/OIDCError+LocalizedError.swift
@@ -43,6 +43,12 @@ extension OIDCError: @retroactive LocalizedError {
         let base = String(localized: .login(.oidcErrorPaperlessRejected("\(statusCode)")))
         return body.isEmpty ? base : "\(base) \(body)"
       }()
+    case .invalidCode:
+      String(localized: .login(.oidcErrorInvalidCode))
+    case .mfaSessionMissing:
+      String(localized: .login(.oidcErrorMfaSessionMissing))
+    case .mfaSessionExpired:
+      String(localized: .login(.oidcErrorMfaSessionExpired))
     }
   }
 }

--- a/AppShared/Sources/AppShared/Resources/Localization/Login.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Login.xcstrings
@@ -3460,6 +3460,168 @@
           }
         }
       }
+    },
+    "oidcErrorInvalidCode" : {
+      "comment" : "OIDC login error: the entered second factor (TOTP) code was rejected by Paperless.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den indtastede kode er ikke gyldig."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der eingegebene Code ist nicht gültig."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The entered code is not valid."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le code saisi n'est pas valide."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il codice inserito non è valido."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De ingevoerde code is niet geldig."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wprowadzony kod jest nieprawidłowy."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Girilen kod geçerli değil."
+          }
+        }
+      }
+    },
+    "oidcErrorMfaSessionMissing" : {
+      "comment" : "OIDC login error: a second factor was required but no pending login session was available.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der kræves en anden faktor, men der er ingen aktiv loginsession. Prøv venligst igen."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein zweiter Faktor ist erforderlich, aber es ist keine aktive Anmeldesitzung vorhanden. Bitte versuchen Sie es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A second factor is required, but no active login session is available. Please try again."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un second facteur est requis, mais aucune session de connexion active n'est disponible. Veuillez réessayer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È richiesto un secondo fattore, ma non è disponibile alcuna sessione di accesso attiva. Riprova."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Een tweede factor is vereist, maar er is geen actieve loginsessie beschikbaar. Probeer het opnieuw."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wymagany jest drugi czynnik, ale nie ma aktywnej sesji logowania. Spróbuj ponownie."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İkinci bir doğrulama faktörü gerekli, ancak aktif oturum yok. Lütfen tekrar deneyin."
+          }
+        }
+      }
+    },
+    "oidcErrorMfaSessionExpired" : {
+      "comment" : "OIDC login error: the pending second factor login session expired before the code was confirmed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sessionslogningen for den anden faktor er udløbet. Log venligst ind igen."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Anmeldesitzung für den zweiten Faktor ist abgelaufen. Bitte melden Sie sich erneut an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The second factor login session has expired. Please log in again."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La session de connexion du second facteur a expiré. Veuillez vous reconnecter."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sessione di accesso del secondo fattore è scaduta. Accedi di nuovo."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De loginsessie voor de tweede factor is verlopen. Log opnieuw in."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesja logowania drugim czynnikiem wygasła. Zaloguj się ponownie."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İkinci faktör oturumu süresi doldu. Lütfen tekrar giriş yapın."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Networking/Sources/Networking/OIDCClient.swift
+++ b/Networking/Sources/Networking/OIDCClient.swift
@@ -177,8 +177,15 @@ public final class OIDCClient {
         statusCode: 0, body: String(data: data, encoding: .utf8) ?? "")
     }
 
-    switch http.statusCode {
-    case 200..<300:
+    guard let status = http.status else {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      logger.error(
+        "2fa/authenticate returned unknown status \(http.statusCode): \(body, privacy: .private)")
+      throw OIDCError.paperlessTokenExchangeFailed(statusCode: http.statusCode, body: body)
+    }
+
+    switch status {
+    case .ok:
       let decoded = try JSONDecoder().decode(PaperlessTokenResponse.self, from: data)
       guard let apiToken = decoded.meta?.access_token else {
         logger.error("2fa/authenticate succeeded but no access_token in meta")
@@ -190,7 +197,7 @@ public final class OIDCClient {
       self.token = apiToken
       return apiToken
 
-    case 400:
+    case .badRequest:
       if let errorResponse = try? JSONDecoder().decode(OIDCErrorResponse.self, from: data),
         errorResponse.errors?.contains(where: { $0.code == "incorrect_code" }) == true
       {
@@ -201,7 +208,7 @@ public final class OIDCClient {
       logger.error("MFA code confirm returned 400: \(body, privacy: .private)")
       throw OIDCError.paperlessTokenExchangeFailed(statusCode: 400, body: body)
 
-    case 401:
+    case .unauthorized:
       // The pending login session is gone (expired or already consumed).
       logger.error("Pending MFA session is no longer valid (401)")
       throw OIDCError.mfaSessionExpired
@@ -209,7 +216,7 @@ public final class OIDCClient {
     default:
       let body = String(data: data, encoding: .utf8) ?? ""
       logger.error(
-        "MFA code confirm returned \(http.statusCode): \(body, privacy: .private)")
+        "MFA code confirm returned \(status): \(body, privacy: .private)")
       throw OIDCError.paperlessTokenExchangeFailed(statusCode: http.statusCode, body: body)
     }
   }

--- a/Networking/Sources/Networking/OIDCClient.swift
+++ b/Networking/Sources/Networking/OIDCClient.swift
@@ -209,8 +209,10 @@ public final class OIDCClient {
       throw OIDCError.paperlessTokenExchangeFailed(statusCode: 400, body: body)
 
     case .unauthorized:
-      // The pending login session is gone (expired or already consumed).
+      // The pending login session is gone (expired or already consumed). Clear
+      // it so a retry does not reuse the stale session.
       logger.error("Pending MFA session is no longer valid (401)")
+      self.pendingMFASessionToken = nil
       throw OIDCError.mfaSessionExpired
 
     default:
@@ -370,7 +372,13 @@ public final class OIDCClient {
     request.httpBody = try JSONSerialization.data(withJSONObject: payload)
     let (data, response) = try await session.data(for: request)
 
-    if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+    guard let http = response as? HTTPURLResponse else {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      logger.error("Token exchange response was not an HTTP response: \(body, privacy: .private)")
+      throw OIDCError.paperlessTokenExchangeFailed(statusCode: 0, body: body)
+    }
+
+    guard (200..<300).contains(http.statusCode) else {
       // A 401 carrying a pending `mfa_authenticate` flow means the login was
       // accepted but a second factor (TOTP) is required to finish it. The
       // session token lets us continue via `confirmMFA(code:)`.
@@ -396,7 +404,7 @@ public final class OIDCClient {
     guard let apiToken = decoded.meta?.access_token else {
       logger.error("Token response did not contain an access token")
       throw OIDCError.paperlessTokenExchangeFailed(
-        statusCode: 200, body: String(data: data, encoding: .utf8) ?? "")
+        statusCode: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
     }
     return .success(token: apiToken)
   }
@@ -543,7 +551,8 @@ struct PaperlessTokenResponse: Decodable, Equatable {
     let access_token: String?
     let session_token: String?
   }
-  struct Data: Decodable, Equatable {
+  // Named `Payload` rather than `Data` to not shadow `Foundation.Data`.
+  struct Payload: Decodable, Equatable {
     struct Flow: Decodable, Equatable {
       let id: String
       let is_pending: Bool?
@@ -551,7 +560,7 @@ struct PaperlessTokenResponse: Decodable, Equatable {
     let flows: [Flow]?
   }
   let meta: Meta?
-  let data: Data?
+  let data: Payload?
 }
 
 /// Error envelope used by allauth headless responses (e.g. the 400 returned

--- a/Networking/Sources/Networking/OIDCClient.swift
+++ b/Networking/Sources/Networking/OIDCClient.swift
@@ -23,6 +23,11 @@ public final class OIDCClient {
 
   public private(set) var token: String? = nil
 
+  /// Session token captured when Paperless required a second factor (TOTP) to
+  /// finish the OIDC login. It is sent back as the `x-session-token` header when
+  /// confirming the code via `confirmMFA(code:)`.
+  var pendingMFASessionToken: String?
+
   public private(set) var providers: [OIDCProvider] = []
 
   private let logger = Logger(subsystem: "com.paulgessinger.swift-paperless", category: "OIDC")
@@ -50,9 +55,12 @@ public final class OIDCClient {
     }
   }
 
-  public func login(provider: OIDCProvider, auth: WebAuthenticationSession) async throws -> String {
+  public func login(
+    provider: OIDCProvider, auth: WebAuthenticationSession
+  ) async throws -> OIDCLoginResult {
     logger.info("Initiating OIDC flow with provider \(provider.id, privacy: .public)")
     self.token = nil
+    self.pendingMFASessionToken = nil
 
     // Paperless-ngx requires us to go through CSRF protection to talk to the allauth headless endpoints
     let csrf = try await fetchCSRF()
@@ -115,17 +123,95 @@ public final class OIDCClient {
 
     logger.debug("Have received OIDC token from provider: \(token.id_token)")
 
-    let apiToken = try await exchangeIdTokenWithPaperless(
+    let result = try await exchangeIdTokenWithPaperless(
       providerId: provider.id,
       clientId: provider.clientId,
       idToken: token.id_token,
       csrf: csrf
     )
 
-    logger.debug("Have received Paperless api token: \(apiToken)")
+    switch result {
+    case .success(let apiToken):
+      logger.debug("Have received Paperless api token: \(apiToken)")
+      self.token = apiToken
+      return .success(token: apiToken)
 
-    self.token = apiToken
-    return apiToken
+    case .mfaRequired(let sessionToken):
+      logger.info(
+        "Paperless requires a second factor (TOTP) to complete the OIDC login")
+      self.pendingMFASessionToken = sessionToken
+      return .mfaRequired
+    }
+  }
+
+  /// Confirm a second factor (TOTP) code for an OIDC login that was suspended
+  /// with `.mfaRequired`. Posts the code to allauth's `2fa/authenticate`
+  /// endpoint using the pending session token captured during the login, and
+  /// returns the Paperless API token once the code is accepted.
+  public func confirmMFA(code: String) async throws -> String {
+    logger.info("Confirming MFA code with Paperless")
+    guard let sessionToken = pendingMFASessionToken else {
+      logger.error("No pending MFA session to confirm against")
+      throw OIDCError.mfaSessionMissing
+    }
+
+    guard
+      let url = URL(
+        string: "\(Self.urlFragment)/app/v1/auth/2fa/authenticate", relativeTo: baseURL)
+    else {
+      logger.error("Failed to build 2fa/authenticate url")
+      throw OIDCError.invalidURL
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(sessionToken, forHTTPHeaderField: "x-session-token")
+    request.httpBody = try JSONSerialization.data(withJSONObject: ["code": code])
+
+    let (data, response) = try await session.data(for: request)
+
+    guard let http = response as? HTTPURLResponse else {
+      logger.error("2fa/authenticate response was not an HTTP response")
+      throw OIDCError.paperlessTokenExchangeFailed(
+        statusCode: 0, body: String(data: data, encoding: .utf8) ?? "")
+    }
+
+    switch http.statusCode {
+    case 200..<300:
+      let decoded = try JSONDecoder().decode(PaperlessTokenResponse.self, from: data)
+      guard let apiToken = decoded.meta?.access_token else {
+        logger.error("2fa/authenticate succeeded but no access_token in meta")
+        throw OIDCError.paperlessTokenExchangeFailed(
+          statusCode: http.statusCode,
+          body: String(data: data, encoding: .utf8) ?? "")
+      }
+      logger.debug("Have received Paperless api token after MFA: \(apiToken)")
+      self.token = apiToken
+      return apiToken
+
+    case 400:
+      if let errorResponse = try? JSONDecoder().decode(OIDCErrorResponse.self, from: data),
+        errorResponse.errors?.contains(where: { $0.code == "incorrect_code" }) == true
+      {
+        logger.info("Paperless rejected the MFA code")
+        throw OIDCError.invalidCode
+      }
+      let body = String(data: data, encoding: .utf8) ?? ""
+      logger.error("MFA code confirm returned 400: \(body, privacy: .private)")
+      throw OIDCError.paperlessTokenExchangeFailed(statusCode: 400, body: body)
+
+    case 401:
+      // The pending login session is gone (expired or already consumed).
+      logger.error("Pending MFA session is no longer valid (401)")
+      throw OIDCError.mfaSessionExpired
+
+    default:
+      let body = String(data: data, encoding: .utf8) ?? ""
+      logger.error(
+        "MFA code confirm returned \(http.statusCode): \(body, privacy: .private)")
+      throw OIDCError.paperlessTokenExchangeFailed(statusCode: http.statusCode, body: body)
+    }
   }
 
   private func fetchCSRF() async throws -> String {
@@ -256,7 +342,7 @@ public final class OIDCClient {
     clientId: String,
     idToken: String,
     csrf: String
-  ) async throws -> String {
+  ) async throws -> PaperlessTokenExchangeResult {
     guard
       let url = URL(string: "\(Self.urlFragment)/app/v1/auth/provider/token", relativeTo: baseURL)
     else {
@@ -278,6 +364,20 @@ public final class OIDCClient {
     let (data, response) = try await session.data(for: request)
 
     if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+      // A 401 carrying a pending `mfa_authenticate` flow means the login was
+      // accepted but a second factor (TOTP) is required to finish it. The
+      // session token lets us continue via `confirmMFA(code:)`.
+      if http.statusCode == 401,
+        let decoded = try? JSONDecoder().decode(PaperlessTokenResponse.self, from: data),
+        decoded.data?.flows?.contains(where: {
+          $0.id == "mfa_authenticate" && $0.is_pending == true
+        }) == true,
+        let sessionToken = decoded.meta?.session_token
+      {
+        logger.info("Paperless token exchange requires MFA (TOTP) to continue")
+        return .mfaRequired(sessionToken: sessionToken)
+      }
+
       let body = String(data: data, encoding: .utf8) ?? ""
       logger.error(
         "Paperless token exchange returned status \(http.statusCode): \(body, privacy: .private)"
@@ -286,7 +386,12 @@ public final class OIDCClient {
     }
 
     let decoded = try JSONDecoder().decode(PaperlessTokenResponse.self, from: data)
-    return decoded.meta.access_token
+    guard let apiToken = decoded.meta?.access_token else {
+      logger.error("Token response did not contain an access token")
+      throw OIDCError.paperlessTokenExchangeFailed(
+        statusCode: 200, body: String(data: data, encoding: .utf8) ?? "")
+    }
+    return .success(token: apiToken)
   }
 
   private func buildAuthorizationURL(
@@ -427,8 +532,29 @@ struct OAuth2ErrorResponse: Decodable, Equatable {
 }
 
 struct PaperlessTokenResponse: Decodable, Equatable {
-  struct Meta: Decodable, Equatable { let access_token: String }
-  let meta: Meta
+  struct Meta: Decodable, Equatable {
+    let access_token: String?
+    let session_token: String?
+  }
+  struct Data: Decodable, Equatable {
+    struct Flow: Decodable, Equatable {
+      let id: String
+      let is_pending: Bool?
+    }
+    let flows: [Flow]?
+  }
+  let meta: Meta?
+  let data: Data?
+}
+
+/// Error envelope used by allauth headless responses (e.g. the 400 returned
+/// when an MFA code is rejected).
+struct OIDCErrorResponse: Decodable, Equatable {
+  struct Item: Decodable, Equatable {
+    let code: String
+    let message: String?
+  }
+  let errors: [Item]?
 }
 
 private
@@ -459,4 +585,23 @@ public enum OIDCError: Error, Equatable {
   case formBodyEncodingFailed
   case tokenExchangeFailed(error: String, description: String?)
   case paperlessTokenExchangeFailed(statusCode: Int, body: String)
+  /// The submitted MFA (TOTP) code was rejected by Paperless.
+  case invalidCode
+  /// An MFA step was expected but no pending login session was available.
+  case mfaSessionMissing
+  /// The pending MFA login session expired before the code was confirmed.
+  case mfaSessionExpired
+}
+
+/// Result of an OIDC login attempt. `.mfaRequired` means the login was
+/// accepted by Paperless but a second factor (TOTP) still needs to be
+/// confirmed via `OIDCClient.confirmMFA(code:)`.
+public enum OIDCLoginResult: Equatable, Sendable {
+  case success(token: String)
+  case mfaRequired
+}
+
+enum PaperlessTokenExchangeResult: Equatable {
+  case success(token: String)
+  case mfaRequired(sessionToken: String)
 }

--- a/Networking/Tests/NetworkingTests/OIDCClientTest.swift
+++ b/Networking/Tests/NetworkingTests/OIDCClientTest.swift
@@ -184,14 +184,14 @@ struct OIDCClientTest {
     defer { MockURLProtocol.reset() }
 
     let client = try makeClient()
-    let token = try await client.exchangeIdTokenWithPaperless(
+    let result = try await client.exchangeIdTokenWithPaperless(
       providerId: "authentik",
       clientId: "client-123",
       idToken: "the-id-token",
       csrf: "csrf-value"
     )
 
-    #expect(token == "paperless-api-token")
+    #expect(result == .success(token: "paperless-api-token"))
   }
 
   // Regression for #559: this POST hits the same Django CSRF middleware as
@@ -254,6 +254,212 @@ struct OIDCClientTest {
       }
       #expect(statusCode == 400)
       #expect(raw.contains("Invalid id_token"))
+    } catch {
+      Issue.record("expected OIDCError, got \(type(of: error)): \(error)")
+    }
+  }
+
+  // MARK: - exchangeIdTokenWithPaperless (MFA)
+
+  @Test func exchangeIdTokenWithPaperless_returnsMfaRequiredOnPendingMfa() async throws {
+    // allauth headless returns 401 with a pending `mfa_authenticate` flow and
+    // a session token when a second factor (TOTP) is required to finish the
+    // login.
+    let body = #"""
+      {"status":401,"data":{"flows":[{"id":"login"},{"id":"mfa_authenticate","is_pending":true,"types":["totp"]}]},"meta":{"is_authenticated":false,"session_token":"pending-session-token"}}
+      """#
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/provider/token")
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 401, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data(body.utf8)
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+    let result = try await client.exchangeIdTokenWithPaperless(
+      providerId: "authentik",
+      clientId: "client-123",
+      idToken: "the-id-token",
+      csrf: "csrf-value"
+    )
+
+    #expect(result == .mfaRequired(sessionToken: "pending-session-token"))
+  }
+
+  @Test func exchangeIdTokenWithPaperless_throwsOn401WithoutMfaFlow() async throws {
+    // A 401 that is not a pending MFA stage (e.g. a genuinely rejected token)
+    // must keep surfacing as a regular token exchange failure.
+    let body = #"""
+      {"status":401,"data":{"flows":[{"id":"login"}]},"meta":{"is_authenticated":false}}
+      """#
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/provider/token")
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 401, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data(body.utf8)
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+
+    do {
+      _ = try await client.exchangeIdTokenWithPaperless(
+        providerId: "authentik",
+        clientId: "client-123",
+        idToken: "the-id-token",
+        csrf: "csrf-value"
+      )
+      Issue.record("expected exchangeIdTokenWithPaperless to throw")
+    } catch let error as OIDCError {
+      guard case .paperlessTokenExchangeFailed(let statusCode, _) = error else {
+        Issue.record("expected OIDCError.paperlessTokenExchangeFailed, got \(error)")
+        return
+      }
+      #expect(statusCode == 401)
+    } catch {
+      Issue.record("expected OIDCError, got \(type(of: error)): \(error)")
+    }
+  }
+
+  // MARK: - confirmMFA
+
+  @Test func confirmMFA_returnsTokenOnSuccess() async throws {
+    let body = #"""
+      {"status":200,"data":{"user":{"id":1}},"meta":{"is_authenticated":true,"access_token":"paperless-api-token"}}
+      """#
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/2fa/authenticate")
+    MockURLProtocol.responder = { request in
+      #expect(request.url == expectedURL)
+      #expect(request.httpMethod == "POST")
+      #expect(request.value(forHTTPHeaderField: "x-session-token") == "pending-session-token")
+      // URLProtocol observes the body through httpBodyStream; read it back so
+      // the responder can inspect the JSON payload.
+      var bodyData = request.httpBody
+      if bodyData == nil, let stream = request.httpBodyStream {
+        stream.open()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        var read = stream.read(&buffer, maxLength: buffer.count)
+        while read > 0 {
+          bodyData = (bodyData ?? Data()) + Data(buffer.prefix(read))
+          read = stream.read(&buffer, maxLength: buffer.count)
+        }
+      }
+      if let bodyData,
+        let body = try? JSONSerialization.jsonObject(with: bodyData) as? [String: String]
+      {
+        #expect(body["code"] == "123456")
+      } else {
+        Issue.record("confirmMFA request did not carry a JSON code body")
+      }
+      return (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 200, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data(body.utf8)
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+    client.pendingMFASessionToken = "pending-session-token"
+
+    let token = try await client.confirmMFA(code: "123456")
+
+    #expect(token == "paperless-api-token")
+  }
+
+  @Test func confirmMFA_surfacesIncorrectCodeOn400() async throws {
+    let body = #"""
+      {"status":400,"errors":[{"code":"incorrect_code","param":"code","message":"The entered code is not valid."}]}
+      """#
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/2fa/authenticate")
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 400, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data(body.utf8)
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+    client.pendingMFASessionToken = "pending-session-token"
+
+    do {
+      _ = try await client.confirmMFA(code: "000000")
+      Issue.record("expected confirmMFA to throw")
+    } catch let error as OIDCError {
+      guard case .invalidCode = error else {
+        Issue.record("expected OIDCError.invalidCode, got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected OIDCError, got \(type(of: error)): \(error)")
+    }
+  }
+
+  @Test func confirmMFA_surfacesSessionExpiredOn401() async throws {
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/2fa/authenticate")
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 401, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data()
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+    client.pendingMFASessionToken = "pending-session-token"
+
+    do {
+      _ = try await client.confirmMFA(code: "123456")
+      Issue.record("expected confirmMFA to throw")
+    } catch let error as OIDCError {
+      guard case .mfaSessionExpired = error else {
+        Issue.record("expected OIDCError.mfaSessionExpired, got \(error)")
+        return
+      }
+    } catch {
+      Issue.record("expected OIDCError, got \(type(of: error)): \(error)")
+    }
+  }
+
+  @Test func confirmMFA_throwsWithoutPendingSession() async {
+    let url = URL(string: "https://example.com")!
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!,
+        Data()
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try! makeClient()
+
+    do {
+      _ = try await client.confirmMFA(code: "123456")
+      Issue.record("expected confirmMFA to throw")
+    } catch let error as OIDCError {
+      guard case .mfaSessionMissing = error else {
+        Issue.record("expected OIDCError.mfaSessionMissing, got \(error)")
+        return
+      }
     } catch {
       Issue.record("expected OIDCError, got \(type(of: error)): \(error)")
     }

--- a/Networking/Tests/NetworkingTests/OIDCClientTest.swift
+++ b/Networking/Tests/NetworkingTests/OIDCClientTest.swift
@@ -439,6 +439,33 @@ struct OIDCClientTest {
     }
   }
 
+  // The stale pending session must not be reused for a retry once the session
+  // is reported as expired.
+  @Test func confirmMFA_clearsSessionTokenOnExpired() async throws {
+    let expectedURL = Self.baseURL.appendingPathComponent(
+      "api/auth/headless/app/v1/auth/2fa/authenticate")
+    MockURLProtocol.responder = { _ in
+      (
+        HTTPURLResponse(
+          url: expectedURL, statusCode: 401, httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"])!,
+        Data()
+      )
+    }
+    defer { MockURLProtocol.reset() }
+
+    let client = try makeClient()
+    client.pendingMFASessionToken = "pending-session-token"
+
+    do {
+      _ = try await client.confirmMFA(code: "123456")
+    } catch {
+      // expected
+    }
+
+    #expect(client.pendingMFASessionToken == nil)
+  }
+
   @Test func confirmMFA_throwsWithoutPendingSession() async {
     let url = URL(string: "https://example.com")!
     MockURLProtocol.responder = { _ in

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -2,3 +2,4 @@
 - Recover the correct API version after launching while the server is unreachable, instead of staying stuck on the minimum version
 - Title search and title and content search now use the new search API on Paperless-ngx v3.0 and later, matching what the web interface does. The same search now returns the same documents in both. Older servers are unaffected.
 - The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.
+- OIDC logins now support TOTP (two-factor authentication) codes from Paperless-ngx

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -28,3 +28,13 @@ x-paperless://oidc-callback
 
 The app listens for this callback to capture the authorization code and
 complete the token exchange.
+
+## Second Factor (TOTP)
+
+If the Paperless-ngx account the OIDC login maps to has TOTP (two-factor
+authentication) enabled, the app detects the pending second-factor step after
+the provider exchange and asks for the authenticator code. The code is then
+confirmed against the pending login session before the app stores the API
+token. Both 6-digit TOTP codes and 8-digit recovery codes are accepted. This
+works for both the initial login and re-authentication of an existing
+connection.

--- a/swift-paperless/ViewModel/LoginViewModel.swift
+++ b/swift-paperless/ViewModel/LoginViewModel.swift
@@ -627,23 +627,48 @@ class LoginViewModel {
       connection = makeConnection(token)
 
     case .oidc:
-      guard let client = oidcClient, let auth, let provider else {
+      guard let client = oidcClient else {
         Logger.shared.warning(
-          "Somehow ended up in validateCredentials with OIDC mode, but no auth and no provider (internal error)"
+          "Somehow ended up in validateCredentials with OIDC mode, but no OIDC client (internal error)"
         )
         credentialState = .none
         return nil
       }
 
       do {
-        let token = try await client.login(provider: provider, auth: auth)
+        let token: String
+        if otpEnabled {
+          // A second factor (TOTP) was requested during the OIDC login; confirm
+          // the code against the pending session instead of re-running the
+          // browser flow.
+          token = try await client.confirmMFA(code: otp)
+        } else {
+          guard let auth, let provider else {
+            Logger.shared.warning(
+              "Somehow ended up in validateCredentials with OIDC mode, but no auth and no provider (internal error)"
+            )
+            credentialState = .none
+            return nil
+          }
+
+          switch try await client.login(provider: provider, auth: auth) {
+          case .success(let apiToken):
+            token = apiToken
+          case .mfaRequired:
+            Logger.shared.info("OIDC login requires a second factor (TOTP)")
+            otpEnabled = true
+            otp = ""
+            credentialState = .none
+            return nil
+          }
+        }
         connection = makeConnection(token)
       } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
         Logger.shared.debug("User canceled login")
         credentialState = .none
         return nil
       } catch {
-        Logger.shared.error("Error when executing OIDC flow with provider \(provider.id): \(error)")
+        Logger.shared.error("Error when executing OIDC flow: \(error)")
         // @TODO: Handle cancel separately as that's not really an error
         //        https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsessionerror/canceledlogin
         credentialState = .error(LoginError(other: error))

--- a/swift-paperless/ViewModel/LoginViewModel.swift
+++ b/swift-paperless/ViewModel/LoginViewModel.swift
@@ -669,6 +669,16 @@ class LoginViewModel {
         return nil
       } catch {
         Logger.shared.error("Error when executing OIDC flow: \(error)")
+        // A wrong code is retryable, but if the pending second-factor session
+        // is gone (e.g. expired) the code can no longer be confirmed: reset
+        // the OTP state so the provider list is shown again and the OIDC login
+        // can be started over.
+        if let oidcError = error as? OIDCError,
+          oidcError == .mfaSessionExpired || oidcError == .mfaSessionMissing
+        {
+          otpEnabled = false
+          otp = ""
+        }
         // @TODO: Handle cancel separately as that's not really an error
         //        https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsessionerror/canceledlogin
         credentialState = .error(LoginError(other: error))

--- a/swift-paperless/Views/Login/CredentialsStageView.swift
+++ b/swift-paperless/Views/Login/CredentialsStageView.swift
@@ -126,10 +126,7 @@ struct CredentialsStageView<Preamble: View>: View {
   }
 
   private var otpValid: Bool {
-    let ex = /^[0-9]*$/
-    let isDigits: Bool = (try? ex.wholeMatch(in: viewModel.otp)) != nil
-    // TOTP codes are 6 digits; allauth recovery codes are 8 digits.
-    return isDigits && (viewModel.otp.count == 6 || viewModel.otp.count == 8)
+    OTPCode.isWellFormed(viewModel.otp)
   }
 
   private var availableCredentialModes: [CredentialMode] {
@@ -277,6 +274,25 @@ extension CredentialsStageView where Preamble == EmptyView {
   }
 }
 
+/// Validation shared by the credential-login and OIDC second-factor flows.
+/// TOTP codes are 6 digits; allauth recovery codes are 8 digits.
+private enum OTPCode {
+  static func isWellFormed(_ code: String) -> Bool {
+    let isDigits = (try? /^[0-9]*$/.wholeMatch(in: code)) != nil
+    return isDigits && (code.count == 6 || code.count == 8)
+  }
+
+  /// Returns `new` if it is plausible OTP input (digits, at most 8), otherwise
+  /// the previous value, so the text field only ever holds usable input.
+  static func sanitized(_ new: String, fallback old: String) -> String {
+    let isDigits = (try? /^[0-9]*$/.wholeMatch(in: new)) != nil
+    if (!isDigits && !new.isEmpty) || new.count > 8 {
+      return old
+    }
+    return new
+  }
+}
+
 private struct OtpSection: View {
   @Binding var code: String
   var onSubmit: () -> Void
@@ -288,12 +304,7 @@ private struct OtpSection: View {
         .keyboardType(.numberPad)
         .submitLabel(.go)
         .onChange(of: code) { old, new in
-          let ex = /^[0-9]*$/
-          let isDigits: Bool = (try? ex.wholeMatch(in: new)) != nil
-          // TOTP codes are 6 digits; allauth recovery codes are 8 digits.
-          if (!isDigits && !new.isEmpty) || new.count > 8 {
-            code = old
-          }
+          code = OTPCode.sanitized(new, fallback: old)
         }
         .onSubmit(of: .text) { onSubmit() }
     } header: {

--- a/swift-paperless/Views/Login/CredentialsStageView.swift
+++ b/swift-paperless/Views/Login/CredentialsStageView.swift
@@ -43,6 +43,11 @@ struct CredentialsStageView<Preamble: View>: View {
     case .token:
       return !viewModel.token.isEmpty
     case .oidc:
+      if viewModel.otpEnabled {
+        // A second factor is pending; only allow submission once the code
+        // looks valid.
+        return otpValid
+      }
       return true
     case .none:
       return true
@@ -123,16 +128,8 @@ struct CredentialsStageView<Preamble: View>: View {
   private var otpValid: Bool {
     let ex = /^[0-9]*$/
     let isDigits: Bool = (try? ex.wholeMatch(in: viewModel.otp)) != nil
-    return isDigits && viewModel.otp.count == 6
-  }
-
-  private func checkOtp(_ old: String, _ new: String) {
-    let ex = /^[0-9]*$/
-    let isDigits: Bool = (try? ex.wholeMatch(in: new)) != nil
-    if (!isDigits && !new.isEmpty) || new.count > 6 {
-      viewModel.otp = old
-      return
-    }
+    // TOTP codes are 6 digits; allauth recovery codes are 8 digits.
+    return isDigits && (viewModel.otp.count == 6 || viewModel.otp.count == 8)
   }
 
   private var availableCredentialModes: [CredentialMode] {
@@ -208,19 +205,7 @@ struct CredentialsStageView<Preamble: View>: View {
               }
 
               if viewModel.otpEnabled {
-                Section {
-                  TextField(String("123456"), text: $viewModel.otp)
-                    .textContentType(.oneTimeCode)
-                    .keyboardType(.numberPad)
-                    .submitLabel(.go)
-                    .onChange(of: viewModel.otp) { old, new in checkOtp(old, new) }
-                } header: {
-                  Text(.login(.otp))
-                } footer: {
-                  LoginFooterView(systemImage: "numbers.rectangle") {
-                    Text(.login(.otpDescription))
-                  }
-                }
+                OtpSection(code: $viewModel.otp, onSubmit: validate)
               }
 
             case .token:
@@ -236,7 +221,14 @@ struct CredentialsStageView<Preamble: View>: View {
               }
 
             case .oidc:
-              OIDCView(onSuccess: onSuccess)
+              if viewModel.otpEnabled {
+                // A second factor (TOTP) is pending from the OIDC login; the
+                // provider buttons are replaced by the code input until the
+                // code is confirmed.
+                OtpSection(code: $viewModel.otp, onSubmit: validate)
+              } else {
+                OIDCView(onSuccess: onSuccess)
+              }
 
             case .none:
               EmptyView()
@@ -250,7 +242,10 @@ struct CredentialsStageView<Preamble: View>: View {
                 button
                 errorView(error)
               default:
-                if viewModel.credentialMode != .oidc {
+                // The OIDC provider buttons are the login trigger there, except
+                // while a second factor is pending, where the regular button
+                // submits the code.
+                if viewModel.credentialMode != .oidc || viewModel.otpEnabled {
                   button
                 }
               }
@@ -268,6 +263,10 @@ struct CredentialsStageView<Preamble: View>: View {
     }
     .onChange(of: viewModel.credentialMode) {
       viewModel.credentialState = .none
+      // A pending second factor only makes sense for the credential mode that
+      // requested it.
+      viewModel.otpEnabled = false
+      viewModel.otp = ""
     }
   }
 }
@@ -275,6 +274,35 @@ struct CredentialsStageView<Preamble: View>: View {
 extension CredentialsStageView where Preamble == EmptyView {
   init(onSuccess: @escaping (StoredConnection) -> Void) {
     self.init(onSuccess: onSuccess, preamble: { EmptyView() })
+  }
+}
+
+private struct OtpSection: View {
+  @Binding var code: String
+  var onSubmit: () -> Void
+
+  var body: some View {
+    Section {
+      TextField(String("123456"), text: $code)
+        .textContentType(.oneTimeCode)
+        .keyboardType(.numberPad)
+        .submitLabel(.go)
+        .onChange(of: code) { old, new in
+          let ex = /^[0-9]*$/
+          let isDigits: Bool = (try? ex.wholeMatch(in: new)) != nil
+          // TOTP codes are 6 digits; allauth recovery codes are 8 digits.
+          if (!isDigits && !new.isEmpty) || new.count > 8 {
+            code = old
+          }
+        }
+        .onSubmit(of: .text) { onSubmit() }
+    } header: {
+      Text(.login(.otp))
+    } footer: {
+      LoginFooterView(systemImage: "numbers.rectangle") {
+        Text(.login(.otpDescription))
+      }
+    }
   }
 }
 


### PR DESCRIPTION
When a Paperless-ngx account with TOTP enabled logs in via OIDC, allauth's headless provider-token exchange returns 401 with a pending mfa_authenticate flow and a session token. Detect that state, present the existing OTP input, and confirm the code against /api/auth/headless/app/v1/auth/2fa/authenticate before storing the API token.

Fixes https://github.com/paulgessinger/swift-paperless/issues/632