### PR TITLE
docs: OIDC login requires Paperless-ngx 3.0 or newer

### DIFF
--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,7 +1,7 @@
 # OpenID Connect (OIDC) Login
 
-!!! warning "Beta Feature"
-    OIDC login support is currently only available in the development version of Paperless-ngx. It is planned to be released in version 3.0.0.
+!!! note "Requirement"
+    OIDC login requires Paperless-ngx 3.0 or newer.
 
 Swift Paperless can sign in using OpenID Connect (OIDC) providers configured on
 your Paperless-ngx server. This flow relies on a mobile-friendly OIDC setup


### PR DESCRIPTION
Paperless-ngx 3.0 has been released, so the beta warning that described OIDC as a development-only feature is stale. Replace it with a note stating the minimum backend version required.