### PR TITLE
fix: share the web UI document URL, not the API one

### DIFF
--- a/Networking/Sources/Networking/Api/Endpoint.swift
+++ b/Networking/Sources/Networking/Api/Endpoint.swift
@@ -182,8 +182,10 @@ extension Endpoint {
     Endpoint(path: "/api/documents/\(documentId)/share_links")
   }
 
-  public static func documentUrl(documentId: UInt) -> Endpoint {
-    Endpoint(path: "/api/documents/\(documentId)")
+  /// The web UI route for a document, *not* an API endpoint. This is what a user
+  /// gets when sharing the "document link", so it has to be openable in a browser.
+  public static func documentPage(documentId: UInt) -> Endpoint {
+    Endpoint(path: "/documents/\(documentId)")
   }
 }
 

--- a/Networking/Tests/NetworkingTests/EndpointTest.swift
+++ b/Networking/Tests/NetworkingTests/EndpointTest.swift
@@ -197,9 +197,10 @@ import Testing
     #expect(endpoint.queryItems.isEmpty)
   }
 
-  @Test func testDocumentUrl() {
-    let endpoint = Endpoint.documentUrl(documentId: 456)
-    #expect(endpoint.path == "/api/documents/456")
+  @Test(.bug("https://github.com/paulgessinger/swift-paperless/issues/647", id: 647))
+  func testDocumentPage() {
+    let endpoint = Endpoint.documentPage(documentId: 456)
+    #expect(endpoint.path == "/documents/456")
     #expect(endpoint.queryItems.isEmpty)
   }
 

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -3,3 +3,4 @@
 - Title search and title and content search now use the new search API on Paperless-ngx v3.0 and later, matching what the web interface does. The same search now returns the same documents in both. Older servers are unaffected.
 - The content-only search mode is no longer offered, following the Paperless-ngx web interface, which has dropped it. Existing filters, saved views and links that use it keep working.
 - OIDC logins now support TOTP (two-factor authentication) codes from Paperless-ngx
+- Sharing a document link now shares the web interface URL, which opens in a browser, instead of the API URL that did not

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -158,7 +158,7 @@ class DocumentDetailModel {
 
   var documentUrl: URL? {
     guard let connection else { return nil }
-    return Endpoint.documentUrl(documentId: document.id).url(url: connection.url)
+    return Endpoint.documentPage(documentId: document.id).url(url: connection.url)
   }
 
   // The server URL comes from the injected connection, not from downcasting


### PR DESCRIPTION
Fixes #647.

## Problem

Sharing a document's "Document link" produced `https://<server>/api/documents/<id>/` — the REST API URL, which doesn't render in a browser. Dropping `/api` gives the working link.

The share item was built from `Endpoint.documentUrl(documentId:)`, whose path was `/api/documents/<id>`. That endpoint was added solely for this share action but sat among the API endpoints and duplicated `Endpoint.document(id:)`, so the `/api` prefix was easy to write and easy to miss.

## Fix

Point it at the Paperless-ngx web UI route `/documents/<id>` and rename it to `documentPage(documentId:)`, with a comment stating it's a UI route rather than an API endpoint. `Endpoint.url(url:)` appends with `.isDirectory`, so the result is `https://<server>/documents/<id>/`, and subpath deployments still get the base path prefixed.

The only call site is `DocumentDetailModel.documentUrl`, used by the "Document link" `ShareLink` in `DocumentDetailViewV4`.

## Testing

`swift test --package-path Networking` passes; the existing endpoint test was updated and tagged with `.bug(id: 647)`.

Not verified: the app target wasn't compiled (the `.xcodeproj` is generated and gitignored, so it needs `just generate` plus a cold build). The change there is a one-symbol rename at a single call site, so CI should settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)