### PR TITLE
feat: surface a DEBUG-only schema-mismatch database erase at launch

### DIFF
--- a/AppShared/Sources/AppShared/Views/AppOverlays.swift
+++ b/AppShared/Sources/AppShared/Views/AppOverlays.swift
@@ -9,6 +9,8 @@
 //  - `offlineToast` bridges `NetworkMonitor` online/offline *transitions*
 //    into toasts — no persistent UI for the offline state, just a brief
 //    announcement when the state flips.
+//  - `SchemaChangeEraseToastBridge` surfaces a DEBUG-only database erase
+//    (see `Database.didEraseForSchemaChangeAtLaunch`) once, at launch.
 //
 //  None of this reaches the Share Extension: a toast renders into a
 //  screen-level window, which the extension's sheet doesn't own. Its
@@ -20,6 +22,7 @@
 //  presentation conflict (only one modal per view at a time).
 //
 
+import Persistence
 import SwiftUI
 import Toasts
 
@@ -27,7 +30,8 @@ extension View {
   @MainActor
   public func appOverlays(
     errorController: ErrorController,
-    networkMonitor: NetworkMonitor
+    networkMonitor: NetworkMonitor,
+    database: Database
   ) -> some View {
     self
       // The toast-bridge modifiers read `\.presentToast` from the
@@ -36,6 +40,7 @@ extension View {
       // further out in the chain.
       .errorOverlay(errorController: errorController)
       .modifier(OfflineToastBridge(networkMonitor: networkMonitor))
+      .modifier(SchemaChangeEraseToastBridge(database: database))
       .installToast(position: .top)
   }
 }

--- a/AppShared/Sources/AppShared/Views/Error/SchemaChangeEraseToast.swift
+++ b/AppShared/Sources/AppShared/Views/Error/SchemaChangeEraseToast.swift
@@ -1,0 +1,51 @@
+//
+//  SchemaChangeEraseToast.swift
+//  AppShared
+//
+//  Surfaces `Database.didEraseForSchemaChangeAtLaunch` (DEBUG-only
+//  `eraseDatabaseOnSchemaChange`, see `Migrations.migrator`) as a toast on
+//  the launch it fires on, so a developer who jumped to a revision whose
+//  migrator doesn't know about a migration the on-disk database already has
+//  applied sees "this wasn't a bug, the local database just got reset" —
+//  rather than a silently-emptied database and no explanation.
+//
+//  Must be installed inside a parent that called `.installToast(...)`.
+//
+
+import Persistence
+import SwiftUI
+import Toasts
+
+public struct SchemaChangeEraseToastBridge: ViewModifier {
+  // Passed in explicitly, same reason as `OfflineToastBridge.networkMonitor`:
+  // `.appOverlays(...)` is applied as the outermost modifier on the app's
+  // body, so an `@Environment` read here would look up the value at a
+  // position *above* where it's set.
+  let database: Database
+  @Environment(\.presentToast) private var presentToast
+  @State private var shown = false
+
+  public init(database: Database) {
+    self.database = database
+  }
+
+  public func body(content: Content) -> some View {
+    content
+      .task {
+        guard !shown, database.didEraseForSchemaChangeAtLaunch else { return }
+        shown = true
+        // Debug-only diagnostic text, deliberately not localized (never seen
+        // by a real user — `didEraseForSchemaChangeAtLaunch` is `false` in
+        // Release, where `eraseDatabaseOnSchemaChange` is never enabled).
+        presentToast(
+          ToastValue(
+            icon: Image(systemName: "ladybug.fill")
+              .foregroundStyle(.orange),
+            message:
+              "DEBUG: local database schema changed since last launch — GRDB wiped and recreated it. Not a bug; reconnect your server(s).",
+            duration: 10
+          )
+        )
+      }
+  }
+}

--- a/Persistence/Sources/Persistence/Database.swift
+++ b/Persistence/Sources/Persistence/Database.swift
@@ -20,6 +20,16 @@ public final class Database: Sendable {
   /// `DatabaseQueue` for in-memory test seams. Both conform to ``DatabaseWriter``.
   public let writer: any DatabaseWriter
 
+  /// Whether opening this database found a schema mismatch and DEBUG-only
+  /// `eraseDatabaseOnSchemaChange` (see `Migrations.migrator`) wiped and
+  /// recreated it — e.g. the on-disk database has a migration applied that
+  /// this build's migrator doesn't register (testing an older revision
+  /// against a database a newer one already migrated further). Always
+  /// `false` in a Release build, where that option is never enabled. Read
+  /// once at launch so the app can tell a developer "this wasn't a bug"
+  /// instead of leaving a silently-emptied database unexplained.
+  public let didEraseForSchemaChangeAtLaunch: Bool
+
   // MARK: - Init
 
   /// Production initializer. Opens (or creates) the app-group SQLite file.
@@ -85,9 +95,19 @@ public final class Database: Sendable {
     Self.applyFileProtection(path.deletingPathExtension().appendingPathExtension("sqlite-wal"))
     Self.applyFileProtection(path.deletingPathExtension().appendingPathExtension("sqlite-shm"))
 
+    let migrator = Migrations.migrator(legacyConnectionsUserDefaults: legacyConnectionsUserDefaults)
+    #if DEBUG
+      // Predicts what `eraseDatabaseOnSchemaChange` (enabled below in
+      // `Migrations.migrator`) is about to do, so it can be surfaced instead
+      // of just silently emptying the database. `hasSchemaChanges` is GRDB's
+      // own detector for the same condition — see its doc comment.
+      didEraseForSchemaChangeAtLaunch = (try? pool.read(migrator.hasSchemaChanges)) ?? false
+    #else
+      didEraseForSchemaChangeAtLaunch = false
+    #endif
+
     do {
-      try Migrations.migrator(legacyConnectionsUserDefaults: legacyConnectionsUserDefaults)
-        .migrate(pool)
+      try migrator.migrate(pool)
     } catch {
       throw DatabaseError.migrationFailed(underlying: error)
     }
@@ -125,6 +145,7 @@ public final class Database: Sendable {
   /// Private init used only by ``inMemory()``.
   private init(writer: any DatabaseWriter) {
     self.writer = writer
+    didEraseForSchemaChangeAtLaunch = false
   }
 
   // MARK: - Destructive maintenance

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -363,7 +363,8 @@ struct MainView: View {
     .environment(routeManager)
     .appOverlays(
       errorController: errorController,
-      networkMonitor: networkMonitor
+      networkMonitor: networkMonitor,
+      database: database
     )
   }
 }


### PR DESCRIPTION
Persistence/Migrations.swift's eraseDatabaseOnSchemaChange (DEBUG only) wipes and recreates the local database when it has a migration applied that the current build's migrator doesn't register -- e.g. testing an older revision against a database a newer one already migrated further. It fires silently: no crash, no error screen, just an app that launches with every connection, saved view, and cached document gone, and no visible explanation.

Database.init now predicts this with GRDB's own migrator.hasSchemaChanges(_:), recording it as didEraseForSchemaChangeAtLaunch before migrating (false in Release, where the option is never enabled). SchemaChangeEraseToastBridge surfaces it as a non-auto-dismissing (10s, the toast library's max) toast on that launch, wired into .appOverlays alongside the existing error/offline toast bridges -- so a developer sees "this wasn't a bug" instead of a silently-emptied database.