### PR TITLE
chore: fill in the untranslated strings in da/de/fr/it/nl/pl/tr

### DIFF
--- a/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/App.xcstrings
@@ -167,14 +167,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De godkendte legitimationsoplysninger har ikke tilladelse til at oprette %@. I mange tilfælde er der tale om en rettighedsfejl."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Der konfigurierte Zugang darf %@ nicht anlegen. In den meisten Fällen liegt das an fehlenden Berechtigungen."
           }
         },
         "en" : {
@@ -185,32 +185,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Les identifiants authentifiés ne sont pas autorisés à créer %@. Dans la plupart des cas, il s'agit d'une erreur de permission."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Le credenziali autenticate non sono autorizzate a creare %@. In molti casi si tratta di un errore di autorizzazione."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De gebruikte inloggegevens hebben geen recht om %@ aan te maken. In veel gevallen is dit een fout in de toegewezen rechten."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Uwierzytelnione poświadczenia nie mają uprawnień do tworzenia elementów: %@. W wielu przypadkach jest to błąd uprawnień."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to create %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Doğrulanmış kimlik bilgilerinin %@ kaynağını oluşturma izni yok. Bu çoğunlukla bir izin hatasıdır."
           }
         }
       }
@@ -221,14 +221,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Oprettelse ikke tilladt"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Anlegen nicht erlaubt"
           }
         },
         "en" : {
@@ -239,32 +239,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Création non autorisée"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Creazione non consentita"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Aanmaken niet toegestaan"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Tworzenie niedozwolone"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Create not permitted"
+            "state" : "translated",
+            "value" : "Oluşturma izni yok"
           }
         }
       }
@@ -275,14 +275,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De godkendte legitimationsoplysninger har ikke tilladelse til at redigere %@. I mange tilfælde er der tale om en rettighedsfejl."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Der konfigurierte Zugang darf %@ nicht bearbeiten. In den meisten Fällen liegt das an fehlenden Berechtigungen."
           }
         },
         "en" : {
@@ -293,32 +293,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Les identifiants authentifiés ne sont pas autorisés à modifier %@. Dans la plupart des cas, il s'agit d'une erreur de permission."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Le credenziali autenticate non sono autorizzate a modificare %@. In molti casi si tratta di un errore di autorizzazione."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De gebruikte inloggegevens hebben geen recht om %@ te bewerken. In veel gevallen is dit een fout in de toegewezen rechten."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Uwierzytelnione poświadczenia nie mają uprawnień do edytowania elementów: %@. W wielu przypadkach jest to błąd uprawnień."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to edit %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Doğrulanmış kimlik bilgilerinin %@ kaynağını düzenleme izni yok. Bu çoğunlukla bir izin hatasıdır."
           }
         }
       }
@@ -329,14 +329,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Redigering ikke tilladt"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Bearbeiten nicht erlaubt"
           }
         },
         "en" : {
@@ -347,32 +347,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Modification non autorisée"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Modifica non consentita"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Bewerken niet toegestaan"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Edycja niedozwolona"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Edit not permitted"
+            "state" : "translated",
+            "value" : "Düzenleme izni yok"
           }
         }
       }
@@ -383,14 +383,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De godkendte legitimationsoplysninger har ikke tilladelse til at slette %@. I mange tilfælde er der tale om en rettighedsfejl."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Der konfigurierte Zugang darf %@ nicht löschen. In den meisten Fällen liegt das an fehlenden Berechtigungen."
           }
         },
         "en" : {
@@ -401,32 +401,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Les identifiants authentifiés ne sont pas autorisés à supprimer %@. Dans la plupart des cas, il s'agit d'une erreur de permission."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Le credenziali autenticate non sono autorizzate a eliminare %@. In molti casi si tratta di un errore di autorizzazione."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De gebruikte inloggegevens hebben geen recht om %@ te verwijderen. In veel gevallen is dit een fout in de toegewezen rechten."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Uwierzytelnione poświadczenia nie mają uprawnień do usuwania elementów: %@. W wielu przypadkach jest to błąd uprawnień."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to delete %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Doğrulanmış kimlik bilgilerinin %@ kaynağını silme izni yok. Bu çoğunlukla bir izin hatasıdır."
           }
         }
       }
@@ -437,14 +437,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Sletning ikke tilladt"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Löschen nicht erlaubt"
           }
         },
         "en" : {
@@ -455,32 +455,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Suppression non autorisée"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Eliminazione non consentita"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Verwijderen niet toegestaan"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Usuwanie niedozwolone"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete not permitted"
+            "state" : "translated",
+            "value" : "Silme izni yok"
           }
         }
       }
@@ -599,14 +599,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De godkendte legitimationsoplysninger har ikke tilladelse til at se %@. I mange tilfælde er der tale om en rettighedsfejl."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Der konfigurierte Zugang darf %@ nicht anzeigen. In den meisten Fällen liegt das an fehlenden Berechtigungen."
           }
         },
         "en" : {
@@ -617,32 +617,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Les identifiants authentifiés ne sont pas autorisés à consulter %@. Dans la plupart des cas, il s'agit d'une erreur de permission."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Le credenziali autenticate non sono autorizzate a visualizzare %@. In molti casi si tratta di un errore di autorizzazione."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "De gebruikte inloggegevens hebben geen recht om %@ te bekijken. In veel gevallen is dit een fout in de toegewezen rechten."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Uwierzytelnione poświadczenia nie mają uprawnień do wyświetlania elementów: %@. W wielu przypadkach jest to błąd uprawnień."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The authenticated credentials are not allowed to view %@. In many cases, this is a permissions error."
+            "state" : "translated",
+            "value" : "Doğrulanmış kimlik bilgilerinin %@ kaynağını görüntüleme izni yok. Bu çoğunlukla bir izin hatasıdır."
           }
         }
       }
@@ -653,14 +653,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Visning ikke tilladt"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Anzeigen nicht erlaubt"
           }
         },
         "en" : {
@@ -671,32 +671,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Consultation non autorisée"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Visualizzazione non consentita"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Bekijken niet toegestaan"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Wyświetlanie niedozwolone"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View not permitted"
+            "state" : "translated",
+            "value" : "Görüntüleme izni yok"
           }
         }
       }
@@ -6932,7 +6932,7 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Details"
           }
         },
@@ -6956,7 +6956,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Details"
           }
         },
@@ -12245,14 +12245,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Dit login til denne server er udløbet. Åbn Paperless for at logge ind igen, og del derefter dokumentet på ny."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Deine Anmeldung für diesen Server ist abgelaufen. Öffne Paperless, um dich erneut anzumelden, und teile das Dokument dann noch einmal."
           }
         },
         "en" : {
@@ -12263,32 +12263,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Votre connexion à ce serveur a expiré. Ouvrez Paperless pour vous reconnecter, puis partagez à nouveau ce document."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "L'accesso a questo server è scaduto. Apri Paperless per accedere di nuovo, quindi condividi nuovamente il documento."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Je login voor deze server is verlopen. Open Paperless om opnieuw in te loggen en deel dit document daarna nogmaals."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Twoje logowanie do tego serwera wygasło. Otwórz Paperless, aby zalogować się ponownie, a następnie udostępnij ten dokument jeszcze raz."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your login for this server has expired. Open Paperless to sign in again, then share this document again."
+            "state" : "translated",
+            "value" : "Bu sunucudaki oturumunuz sona erdi. Yeniden giriş yapmak için Paperless'ı açın, ardından bu dokümanı tekrar paylaşın."
           }
         }
       }
@@ -12299,14 +12299,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Log ind igen"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Erneut anmelden"
           }
         },
         "en" : {
@@ -12317,32 +12317,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Reconnectez-vous"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Accedi di nuovo"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Opnieuw inloggen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Zaloguj się ponownie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sign in again"
+            "state" : "translated",
+            "value" : "Tekrar giriş yapın"
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Permissions.xcstrings
@@ -1282,14 +1282,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Dine rettigheder er endnu ikke hentet fra denne server. Indtil de er hentet, antager appen fuld adgang og lader serveren bestemme."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Die Berechtigungen wurden von diesem Server noch nicht geladen. Bis dahin nimmt die App vollen Zugriff an und überlässt die Entscheidung dem Server."
           }
         },
         "en" : {
@@ -1300,32 +1300,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Vos permissions n'ont pas encore été chargées depuis ce serveur. En attendant, l'application suppose un accès complet et laisse le serveur décider."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Le tue autorizzazioni non sono ancora state caricate da questo server. Fino ad allora l'app presume l'accesso completo e lascia decidere il server."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Je rechten zijn nog niet van deze server opgehaald. Tot die tijd gaat de app uit van volledige toegang en laat het de server beslissen."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "Twoje uprawnienia nie zostały jeszcze pobrane z tego serwera. Do tego czasu aplikacja zakłada pełny dostęp i pozostawia decyzję serwerowi."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your permissions have not been loaded from this server yet. Until they arrive the app assumes full access and lets the server decide."
+            "state" : "translated",
+            "value" : "İzinleriniz bu sunucudan henüz yüklenmedi. Gelene kadar uygulama tam erişim varsayar ve kararı sunucuya bırakır."
           }
         }
       }
@@ -1707,14 +1707,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "Mail-konti"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "Mail-Konten"
           }
         },
         "en" : {
@@ -1725,32 +1725,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "Comptes de messagerie"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "Account di posta"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "E-mail accounts"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "Konta pocztowe"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail accounts"
+            "state" : "translated",
+            "value" : "E-posta hesapları"
           }
         }
       }
@@ -1814,14 +1814,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Mail-regler"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Mail-Regeln"
           }
         },
         "en" : {
@@ -1832,32 +1832,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Règles de courriel"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Regole della posta"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Mail regels"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "Reguły poczty"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Mail rules"
+            "state" : "translated",
+            "value" : "E-posta kuralları"
           }
         }
       }
@@ -1921,14 +1921,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Delingslinks"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Freigabelinks"
           }
         },
         "en" : {
@@ -1939,32 +1939,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Liens partagés"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Link di condivisione"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Deellinks"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Linki udostępniania"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Share links"
+            "state" : "translated",
+            "value" : "Paylaşım bağlantıları"
           }
         }
       }
@@ -2028,13 +2028,13 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "Arbejdsgange"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Workflows"
           }
         },
@@ -2046,32 +2046,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "Flux de travail"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "Flussi di lavoro"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "Werkstromen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "Procesy"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Workflows"
+            "state" : "translated",
+            "value" : "İş akışları"
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/Persistence.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Persistence.xcstrings
@@ -7,14 +7,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Prøv igen"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Erneut versuchen"
           }
         },
         "en" : {
@@ -25,32 +25,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Réessayer"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Riprova"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Probeer opnieuw"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Spróbuj ponownie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Try Again"
+            "state" : "translated",
+            "value" : "Tekrar dene"
           }
         }
       }
@@ -61,14 +61,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Databasen er utilgængelig"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Datenbank nicht verfügbar"
           }
         },
         "en" : {
@@ -79,32 +79,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Base de données indisponible"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Database non disponibile"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Database niet beschikbaar"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Baza danych niedostępna"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Database unavailable"
+            "state" : "translated",
+            "value" : "Veritabanı kullanılamıyor"
           }
         }
       }
@@ -115,8 +115,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Vis logfiler"
           }
         },
         "de" : {
@@ -133,32 +133,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Afficher les journaux"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Visualizza i log"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Logboeken bekijken"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Pokaż dzienniki"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "View Logs"
+            "state" : "translated",
+            "value" : "Günlükleri görüntüle"
           }
         }
       }
@@ -169,8 +169,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Slet database"
           }
         },
         "de" : {
@@ -187,32 +187,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Effacer la base de données"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Cancella il database"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Database wissen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Wyczyść bazę danych"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Veritabanını sil"
           }
         }
       }
@@ -223,8 +223,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Slet database"
           }
         },
         "de" : {
@@ -241,32 +241,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Effacer la base de données"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Cancella il database"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Database wissen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Wyczyść bazę danych"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe Database"
+            "state" : "translated",
+            "value" : "Veritabanını sil"
           }
         }
       }
@@ -277,8 +277,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Dette nulstiller appens lokale data. Du skal muligvis logge ind igen bagefter."
           }
         },
         "de" : {
@@ -295,32 +295,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Cela réinitialise l'état local de l'application. Vous devrez peut-être vous reconnecter ensuite."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Questo azzera i dati locali dell'app. Potrebbe essere necessario accedere di nuovo in seguito."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Hiermee wordt de lokale status van de app gewist. Mogelijk moet je daarna opnieuw inloggen."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Spowoduje to zresetowanie lokalnych danych aplikacji. Może być konieczne ponowne zalogowanie się."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This resets the app's local state. You may need to sign in again afterwards."
+            "state" : "translated",
+            "value" : "Bu, uygulamanın yerel verilerini sıfırlar. Ardından tekrar giriş yapmanız gerekebilir."
           }
         }
       }
@@ -331,8 +331,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Slet den lokale database?"
           }
         },
         "de" : {
@@ -349,32 +349,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Effacer la base de données locale ?"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Cancellare il database locale?"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Lokale database wissen?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Wyczyścić lokalną bazę danych?"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Wipe local database?"
+            "state" : "translated",
+            "value" : "Yerel veritabanı silinsin mi?"
           }
         }
       }
@@ -385,8 +385,8 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Kunne ikke slette den lokale database:"
           }
         },
         "de" : {
@@ -403,32 +403,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Impossible d'effacer la base de données locale :"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Impossibile cancellare il database locale:"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Kon de lokale database niet wissen:"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Nie udało się wyczyścić lokalnej bazy danych:"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Couldn't wipe the local database:"
+            "state" : "translated",
+            "value" : "Yerel veritabanı silinemedi:"
           }
         }
       }
@@ -439,14 +439,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Den delte app-container er utilgængelig (%@)."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Der gemeinsame App-Container ist nicht verfügbar (%@)."
           }
         },
         "en" : {
@@ -457,32 +457,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Le conteneur d'application partagé est indisponible (%@)."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Il contenitore condiviso dell'app non è disponibile (%@)."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "De gedeelde app-container is niet beschikbaar (%@)."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Współdzielony kontener aplikacji jest niedostępny (%@)."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The shared app container is unavailable (%@)."
+            "state" : "translated",
+            "value" : "Paylaşılan uygulama kapsayıcısı kullanılamıyor (%@)."
           }
         }
       }
@@ -493,14 +493,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "Den lokale database kunne ikke opdateres."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "Die lokale Datenbank konnte nicht aktualisiert werden."
           }
         },
         "en" : {
@@ -511,32 +511,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "La base de données locale n'a pas pu être mise à jour."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "Non è stato possibile aggiornare il database locale."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "De lokale database kon niet worden bijgewerkt."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "Nie udało się zaktualizować lokalnej bazy danych."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The local database could not be updated."
+            "state" : "translated",
+            "value" : "Yerel veritabanı güncellenemedi."
           }
         }
       }
@@ -547,14 +547,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "Appen kunne ikke gemme i sin lokale database."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "Die App konnte nicht in ihre lokale Datenbank schreiben."
           }
         },
         "en" : {
@@ -565,32 +565,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "L'application n'a pas pu enregistrer dans sa base de données locale."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "L'app non è riuscita a salvare nel proprio database locale."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "De app kon niet opslaan in de lokale database."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "Aplikacja nie mogła zapisać danych w lokalnej bazie danych."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The app could not save to its local database."
+            "state" : "translated",
+            "value" : "Uygulama yerel veritabanına kaydedemedi."
           }
         }
       }
@@ -601,14 +601,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Kunne ikke åbne den lokale database."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Die lokale Datenbank konnte nicht geöffnet werden."
           }
         },
         "en" : {
@@ -619,32 +619,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Impossible d'ouvrir la base de données locale."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Impossibile aprire il database locale."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Kon de lokale database niet openen."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Nie udało się otworzyć lokalnej bazy danych."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Could not open the local database."
+            "state" : "translated",
+            "value" : "Yerel veritabanı açılamadı."
           }
         }
       }

--- a/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
+++ b/AppShared/Sources/AppShared/Resources/Localization/Settings.xcstrings
@@ -753,14 +753,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Cachelagrede data er ryddet"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Daten gelöscht"
           }
         },
         "en" : {
@@ -771,32 +771,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Données en cache effacées"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Dati nella cache eliminati"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Gegevens in cache gewist"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Wyczyszczono dane z pamięci podręcznej"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached data cleared"
+            "state" : "translated",
+            "value" : "Önbellekteki veriler temizlendi"
           }
         }
       }
@@ -1071,14 +1071,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Ryd cachelagrede data"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Daten löschen"
           }
         },
         "en" : {
@@ -1089,32 +1089,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Effacer les données en cache"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Elimina i dati nella cache"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Gegevens in cache wissen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Wyczyść dane z pamięci podręcznej"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Cached Data"
+            "state" : "translated",
+            "value" : "Önbellekteki verileri temizle"
           }
         }
       }
@@ -1124,14 +1124,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Dette fjerner cachelagrede dokumentlister, billeder og hentede filer. Dine serverforbindelser bevares; alt hentes igen efter behov."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Dadurch werden zwischengespeicherte Dokumentlisten, Bilder und heruntergeladene Dateien entfernt. Deine Serververbindungen bleiben erhalten; alles wird bei Bedarf erneut heruntergeladen."
           }
         },
         "en" : {
@@ -1142,32 +1142,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Cela supprime les listes de documents, les images et les fichiers téléchargés en cache. Vos connexions aux serveurs sont conservées ; tout sera retéléchargé au besoin."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Questo rimuove gli elenchi di documenti, le immagini e i file scaricati presenti nella cache. Le connessioni ai server vengono mantenute; tutto viene riscaricato quando serve."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Hiermee worden documentlijsten, afbeeldingen en gedownloade bestanden uit de cache verwijderd. Je serververbindingen blijven behouden; alles wordt opnieuw gedownload wanneer dat nodig is."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Spowoduje to usunięcie zapisanych w pamięci podręcznej list dokumentów, obrazów i pobranych plików. Połączenia z serwerami zostaną zachowane; wszystko zostanie pobrane ponownie w razie potrzeby."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This removes cached document lists, images, and downloaded files. Your server connections are kept; everything re-downloads as needed."
+            "state" : "translated",
+            "value" : "Bu işlem önbellekteki doküman listelerini, görselleri ve indirilen dosyaları kaldırır. Sunucu bağlantılarınız korunur; her şey gerektiğinde yeniden indirilir."
           }
         }
       }
@@ -1177,14 +1177,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Ryd alle cachelagrede data?"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Alle zwischengespeicherten Daten löschen?"
           }
         },
         "en" : {
@@ -1195,32 +1195,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Effacer toutes les données en cache ?"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Eliminare tutti i dati nella cache?"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Alle gegevens in de cache wissen?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Wyczyścić wszystkie dane z pamięci podręcznej?"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear all cached data?"
+            "state" : "translated",
+            "value" : "Önbellekteki tüm veriler temizlensin mi?"
           }
         }
       }
@@ -2290,14 +2290,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Lokal lagring"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Lokaler Speicher"
           }
         },
         "en" : {
@@ -2308,32 +2308,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Stockage local"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Archiviazione locale"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Lokale opslag"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Pamięć lokalna"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Local Storage"
+            "state" : "translated",
+            "value" : "Yerel depolama"
           }
         }
       }
@@ -2343,14 +2343,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Cachelagrede dokumentlister, billeder og hentede filer. Dine servere og indstillinger bevares."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Dokumentlisten, Bilder und heruntergeladene Dateien. Deine Server und Einstellungen bleiben erhalten."
           }
         },
         "en" : {
@@ -2361,32 +2361,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Listes de documents, images et fichiers téléchargés en cache. Vos serveurs et paramètres sont conservés."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Elenchi di documenti, immagini e file scaricati presenti nella cache. I tuoi server e le impostazioni vengono mantenuti."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Documentlijsten, afbeeldingen en gedownloade bestanden in de cache. Je servers en instellingen blijven behouden."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Zapisane w pamięci podręcznej listy dokumentów, obrazy i pobrane pliki. Twoje serwery i ustawienia zostaną zachowane."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached document lists, images, and downloaded files. Your servers and settings are kept."
+            "state" : "translated",
+            "value" : "Önbellekteki doküman listeleri, görseller ve indirilen dosyalar. Sunucularınız ve ayarlarınız korunur."
           }
         }
       }
@@ -2715,14 +2715,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Fjern hentede dokumenter"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Heruntergeladene Dokumente entfernen"
           }
         },
         "en" : {
@@ -2733,32 +2733,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Supprimer les documents téléchargés"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Rimuovi i documenti scaricati"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Gedownloade documenten verwijderen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "Usuń pobrane dokumenty"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Downloaded Documents"
+            "state" : "translated",
+            "value" : "İndirilen dokümanları kaldır"
           }
         }
       }
@@ -2769,14 +2769,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Dokumenter, der er hentet til offlinebrug på denne server, bliver fjernet – bortset fra de nyeste i din dokumentliste. Gemte visninger hentes igen, når du åbner dem."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Dokumente, die auf diesem Server für die Offline-Nutzung heruntergeladen wurden, werden entfernt – mit Ausnahme der neuesten in deiner Dokumentliste. Gespeicherte Ansichten werden erneut heruntergeladen, sobald du sie öffnest."
           }
         },
         "en" : {
@@ -2787,32 +2787,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Les documents téléchargés pour une utilisation hors ligne sur ce serveur seront supprimés, à l'exception des plus récents de votre liste de documents. Les vues enregistrées seront téléchargées à nouveau lorsque vous les ouvrirez."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "I documenti scaricati per l'uso offline su questo server verranno rimossi, tranne i più recenti nel tuo elenco di documenti. Le viste salvate vengono scaricate di nuovo quando le apri."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Documenten die op deze server voor offlinegebruik zijn gedownload, worden verwijderd, behalve de meest recente in je documentenlijst. Opgeslagen weergaven worden opnieuw gedownload zodra je ze opent."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Dokumenty pobrane do użytku offline na tym serwerze zostaną usunięte, z wyjątkiem najnowszych z Twojej listy dokumentów. Zapisane widoki zostaną pobrane ponownie po ich otwarciu."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Documents downloaded for offline use on this server will be removed, apart from the most recent ones in your document list. Saved views download again if you open them."
+            "state" : "translated",
+            "value" : "Bu sunucuda çevrimdışı kullanım için indirilen dokümanlar, doküman listenizdeki en yeni olanlar dışında kaldırılacak. Kayıtlı görünümler açtığınızda yeniden indirilir."
           }
         }
       }
@@ -2823,14 +2823,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Skift til Senest gennemsete?"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Zu „Zuletzt angesehen“ wechseln?"
           }
         },
         "en" : {
@@ -2841,32 +2841,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Passer à « Récemment consultés » ?"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Passare a «Consultati di recente»?"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Overschakelen naar Onlangs bekeken?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Przełączyć na Ostatnio przeglądane?"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Switch to Recently browsed?"
+            "state" : "translated",
+            "value" : "Son görüntülenenler seçeneğine geçilsin mi?"
           }
         }
       }
@@ -2877,14 +2877,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Når Hele biblioteket er valgt, hentes alle gemte visninger og hele din dokumentliste via Wi-Fi, så de kan gennemses offline. Selve dokumentfilerne hentes fortsat kun, når du åbner dem. Skifter du tilbage til Senest gennemsete, fjernes det, der er hentet."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Bei „Gesamte Bibliothek“ werden alle gespeicherten Ansichten und deine vollständige Dokumentliste über WLAN heruntergeladen, damit sie offline durchgesehen werden können. Die Dokumentdateien selbst werden weiterhin erst beim Öffnen heruntergeladen. Beim Wechsel zurück zu „Zuletzt angesehen“ wird das Heruntergeladene entfernt."
           }
         },
         "en" : {
@@ -2895,32 +2895,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Avec « Bibliothèque entière », toutes les vues enregistrées et votre liste de documents complète sont téléchargées en Wi-Fi afin de pouvoir être consultées hors ligne. Les fichiers des documents ne sont toujours téléchargés qu'à leur ouverture. Revenir à « Récemment consultés » supprime ce qui a été téléchargé."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Con «Intera libreria», tutte le viste salvate e l'elenco completo dei documenti vengono scaricati tramite Wi-Fi per poter essere consultati offline. I file dei documenti vengono comunque scaricati solo quando li apri. Tornando a «Consultati di recente» viene rimosso ciò che è stato scaricato."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Bij Volledige bibliotheek worden alle opgeslagen weergaven en je volledige documentenlijst via wifi gedownload, zodat je ze offline kunt bekijken. De documentbestanden zelf worden nog steeds pas gedownload wanneer je ze opent. Terugschakelen naar Onlangs bekeken verwijdert wat is gedownload."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Przy ustawieniu Cała biblioteka wszystkie zapisane widoki i pełna lista dokumentów są pobierane przez Wi-Fi, aby można je było przeglądać offline. Same pliki dokumentów nadal są pobierane dopiero po ich otwarciu. Przełączenie z powrotem na Ostatnio przeglądane usuwa to, co zostało pobrane."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "When set to Entire library, every saved view and your full document list are downloaded over Wi-Fi so they can be browsed offline. Document files are still downloaded only when you open them. Switching back to Recently browsed removes what was downloaded."
+            "state" : "translated",
+            "value" : "Tüm kitaplık seçildiğinde, tüm kayıtlı görünümler ve eksiksiz doküman listeniz çevrimdışı göz atılabilmesi için Wi-Fi üzerinden indirilir. Doküman dosyaları yine yalnızca siz açtığınızda indirilir. Son görüntülenenler seçeneğine geri dönmek indirilenleri kaldırır."
           }
         }
       }
@@ -2931,14 +2931,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Hele biblioteket"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Gesamte Bibliothek"
           }
         },
         "en" : {
@@ -2949,32 +2949,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Bibliothèque entière"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Intera libreria"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Volledige bibliotheek"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Cała biblioteka"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Entire library"
+            "state" : "translated",
+            "value" : "Tüm kitaplık"
           }
         }
       }
@@ -2985,13 +2985,13 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Offline"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Offline"
           }
         },
@@ -3003,32 +3003,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline"
+            "state" : "translated",
+            "value" : "Hors ligne"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Offline"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Offline"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Offline"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline"
+            "state" : "translated",
+            "value" : "Çevrimdışı"
           }
         }
       }
@@ -3039,14 +3039,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Offlinebrug"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Offline-Nutzung"
           }
         },
         "en" : {
@@ -3057,32 +3057,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Consultation hors ligne"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Consultazione offline"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Offlinegebruik"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Przeglądanie offline"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline browsing"
+            "state" : "translated",
+            "value" : "Çevrimdışı kullanım"
           }
         }
       }
@@ -3093,14 +3093,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Senest gennemsete"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Zuletzt angesehen"
           }
         },
         "en" : {
@@ -3111,32 +3111,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Récemment consultés"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Consultati di recente"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Onlangs bekeken"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Ostatnio przeglądane"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Recently browsed"
+            "state" : "translated",
+            "value" : "Son görüntülenenler"
           }
         }
       }
@@ -3147,14 +3147,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Dette bibliotek er lille nok til at kunne gemmes fuldstændigt på din enhed."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Diese Bibliothek ist klein genug, um sie vollständig auf deinem Gerät zu behalten."
           }
         },
         "en" : {
@@ -3165,32 +3165,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Cette bibliothèque est assez petite pour être conservée intégralement sur votre appareil."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Questa libreria è abbastanza piccola da poter essere conservata per intero sul tuo dispositivo."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Deze bibliotheek is klein genoeg om volledig op je apparaat te bewaren."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Ta biblioteka jest na tyle mała, że można ją w całości przechowywać na urządzeniu."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "This library is small enough to keep on your device in full."
+            "state" : "translated",
+            "value" : "Bu kitaplık, cihazınızda tümüyle saklanabilecek kadar küçük."
           }
         }
       }
@@ -3201,14 +3201,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Aktivitet"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Aktivität"
           }
         },
         "en" : {
@@ -3219,32 +3219,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Activité"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Attività"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Activiteit"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Aktywność"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Activity"
+            "state" : "translated",
+            "value" : "Etkinlik"
           }
         }
       }
@@ -3255,14 +3255,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Cachelagrede dokumenter"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Zwischengespeicherte Dokumente"
           }
         },
         "en" : {
@@ -3273,32 +3273,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Documents en cache"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Documenti nella cache"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Documenten in cache"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Dokumenty w pamięci podręcznej"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Cached documents"
+            "state" : "translated",
+            "value" : "Önbellekteki dokümanlar"
           }
         }
       }
@@ -3309,14 +3309,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Tillad, at denne servers offlinedownloads bruger mobildata. Lavdataindstilling sætter dem altid på pause."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Erlaube den Offline-Downloads dieses Servers die Nutzung von Mobilfunkdaten. Der Datensparmodus pausiert sie in jedem Fall."
           }
         },
         "en" : {
@@ -3327,32 +3327,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Autoriser les téléchargements hors ligne de ce serveur à utiliser les données cellulaires. Le mode Données limitées les met toujours en pause."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Consenti ai download offline di questo server di usare la rete cellulare. La modalità Risparmio dati li mette sempre in pausa."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Sta toe dat de offlinedownloads van deze server mobiele data gebruiken. De spaarstand voor data pauzeert ze altijd."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Zezwól, aby pobieranie offline z tego serwera korzystało z danych komórkowych. Tryb niskiego zużycia danych zawsze je wstrzymuje."
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Allow this server's offline downloads to use cellular data. Low Data Mode always pauses them."
+            "state" : "translated",
+            "value" : "Bu sunucunun çevrimdışı indirmelerinin hücresel veri kullanmasına izin verin. Az Veri Modu bunları her zaman duraklatır."
           }
         }
       }
@@ -3363,14 +3363,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Synkroniser via mobildata"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Über Mobilfunk synchronisieren"
           }
         },
         "en" : {
@@ -3381,32 +3381,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Synchroniser via les données cellulaires"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Sincronizza tramite rete cellulare"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Synchroniseren via mobiele data"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Synchronizuj przez sieć komórkową"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync over cellular"
+            "state" : "translated",
+            "value" : "Hücresel veriyle eşitle"
           }
         }
       }
@@ -3417,14 +3417,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Overførte data"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Übertragene Daten"
           }
         },
         "en" : {
@@ -3435,32 +3435,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Données transférées"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Dati trasferiti"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Overgedragen gegevens"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Przesłane dane"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Data transferred"
+            "state" : "translated",
+            "value" : "Aktarılan veri"
           }
         }
       }
@@ -3471,14 +3471,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Siden %@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Seit %@"
           }
         },
         "en" : {
@@ -3489,32 +3489,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Depuis le %@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Dal %@"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Sinds %@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "Od %@"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Since %@"
+            "state" : "translated",
+            "value" : "%@ tarihinden beri"
           }
         }
       }
@@ -3525,14 +3525,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Standardvisning"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Standardansicht"
           }
         },
         "en" : {
@@ -3543,32 +3543,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Vue par défaut"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Vista predefinita"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Standaardweergave"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Widok domyślny"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Default view"
+            "state" : "translated",
+            "value" : "Varsayılan görünüm"
           }
         }
       }
@@ -3579,14 +3579,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Henter dokumentdetaljer…"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Dokumentdetails werden geladen…"
           }
         },
         "en" : {
@@ -3597,32 +3597,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Téléchargement des détails des documents…"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Download dei dettagli dei documenti…"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Documentgegevens downloaden…"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Pobieranie szczegółów dokumentów…"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading document details…"
+            "state" : "translated",
+            "value" : "Doküman ayrıntıları indiriliyor…"
           }
         }
       }
@@ -3633,14 +3633,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Henter bibliotek…"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Bibliothek wird geladen…"
           }
         },
         "en" : {
@@ -3651,32 +3651,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Téléchargement de la bibliothèque…"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Download della libreria…"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Bibliotheek downloaden…"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Pobieranie biblioteki…"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading library…"
+            "state" : "translated",
+            "value" : "Kitaplık indiriliyor…"
           }
         }
       }
@@ -3687,14 +3687,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Inaktiv"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Inaktiv"
           }
         },
         "en" : {
@@ -3705,32 +3705,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Inactif"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Inattivo"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Inactief"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Bezczynny"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Idle"
+            "state" : "translated",
+            "value" : "Boşta"
           }
         }
       }
@@ -3741,14 +3741,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Seneste fulde synkronisering"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Letzte vollständige Synchronisierung"
           }
         },
         "en" : {
@@ -3759,32 +3759,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Dernière synchronisation complète"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Ultima sincronizzazione completa"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Laatste volledige synchronisatie"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Ostatnia pełna synchronizacja"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last full sync"
+            "state" : "translated",
+            "value" : "Son tam eşitleme"
           }
         }
       }
@@ -3795,14 +3795,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Senest opdateret"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Zuletzt aktualisiert"
           }
         },
         "en" : {
@@ -3813,32 +3813,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Dernière actualisation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Ultimo aggiornamento"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Laatst vernieuwd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Ostatnie odświeżenie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Last refreshed"
+            "state" : "translated",
+            "value" : "Son yenileme"
           }
         }
       }
@@ -3849,14 +3849,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Aldrig"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Nie"
           }
         },
         "en" : {
@@ -3867,32 +3867,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Jamais"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Mai"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Nooit"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Nigdy"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Never"
+            "state" : "translated",
+            "value" : "Asla"
           }
         }
       }
@@ -3903,14 +3903,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Synkroniser nu"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Jetzt synchronisieren"
           }
         },
         "en" : {
@@ -3921,32 +3921,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Synchroniser maintenant"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Sincronizza ora"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Nu synchroniseren"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Synchronizuj teraz"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync now"
+            "state" : "translated",
+            "value" : "Şimdi eşitle"
           }
         }
       }
@@ -3957,14 +3957,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Disse visninger kunne ikke hentes til offlinebrug. Det kan skyldes en fejl eller manglende kompatibilitet med serverversionen"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Diese Ansichten konnten nicht für die Offline-Nutzung heruntergeladen werden. Das kann ein Fehler oder eine Inkompatibilität mit der Serverversion sein"
           }
         },
         "en" : {
@@ -3975,32 +3975,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Ces vues n'ont pas pu être téléchargées pour une utilisation hors ligne. Il peut s'agir d'un bogue ou d'une incompatibilité avec la version du serveur"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Non è stato possibile scaricare queste viste per l'uso offline. Potrebbe trattarsi di un bug o di un'incompatibilità con la versione del server"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Deze weergaven konden niet worden gedownload voor offlinegebruik. Dit kan een bug zijn of een incompatibiliteit met de serverversie"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Nie udało się pobrać tych widoków do użytku offline. Może to być błąd lub niezgodność z wersją serwera"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "These views couldn't be downloaded for offline use. This could be a bug or an incompatibility with the server version"
+            "state" : "translated",
+            "value" : "Bu görünümler çevrimdışı kullanım için indirilemedi. Bunun nedeni bir hata ya da sunucu sürümüyle uyumsuzluk olabilir"
           }
         }
       }
@@ -4011,14 +4011,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Synkroniseringsproblemer"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Synchronisierungsprobleme"
           }
         },
         "en" : {
@@ -4029,32 +4029,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Problèmes de synchronisation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Problemi di sincronizzazione"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Synchronisatieproblemen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Problemy z synchronizacją"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync problems"
+            "state" : "translated",
+            "value" : "Eşitleme sorunları"
           }
         }
       }
@@ -4065,14 +4065,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld af %2$lld"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld von %2$lld"
           }
         },
         "en" : {
@@ -4083,32 +4083,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld sur %2$lld"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld di %2$lld"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld van %2$lld"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld z %2$lld"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld"
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld"
           }
         }
       }
@@ -4119,14 +4119,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld af %2$lld ændringer"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld von %2$lld Änderungen"
           }
         },
         "en" : {
@@ -4137,32 +4137,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld sur %2$lld modifications"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld di %2$lld modifiche"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld van %2$lld wijzigingen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld z %2$lld zmian"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld of %2$lld changes"
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld değişiklik"
           }
         }
       }
@@ -4173,14 +4173,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Søger efter ændringer…"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Änderungen werden geprüft…"
           }
         },
         "en" : {
@@ -4191,32 +4191,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Recherche de modifications…"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Ricerca di modifiche…"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Controleren op wijzigingen…"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Sprawdzanie zmian…"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Checking for changes…"
+            "state" : "translated",
+            "value" : "Değişiklikler denetleniyor…"
           }
         }
       }
@@ -4227,14 +4227,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Opdaterer attributter…"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Attribute werden aktualisiert…"
           }
         },
         "en" : {
@@ -4245,32 +4245,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Actualisation des attributs…"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Aggiornamento degli attributi…"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Attributen vernieuwen…"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Odświeżanie atrybutów…"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Refreshing attributes…"
+            "state" : "translated",
+            "value" : "Öznitelikler yenileniyor…"
           }
         }
       }
@@ -4281,14 +4281,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Nulstil statistik"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Statistik zurücksetzen"
           }
         },
         "en" : {
@@ -4299,32 +4299,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Réinitialiser les statistiques"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Azzera le statistiche"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Statistieken resetten"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "Zresetuj statystyki"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset statistics"
+            "state" : "translated",
+            "value" : "İstatistikleri sıfırla"
           }
         }
       }
@@ -4335,13 +4335,13 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
@@ -4353,32 +4353,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Status"
+            "state" : "translated",
+            "value" : "État"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Status"
+            "state" : "translated",
+            "value" : "Stato"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Status"
+            "state" : "translated",
+            "value" : "Stan"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Status"
+            "state" : "translated",
+            "value" : "Durum"
           }
         }
       }
@@ -4389,14 +4389,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Offline og synkronisering"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Offline & Synchronisierung"
           }
         },
         "en" : {
@@ -4407,32 +4407,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Hors ligne et synchronisation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Offline e sincronizzazione"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Offline en synchronisatie"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Offline i synchronizacja"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Offline & Sync"
+            "state" : "translated",
+            "value" : "Çevrimdışı ve eşitleme"
           }
         }
       }
@@ -4443,14 +4443,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "I alt"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "Gesamt"
           }
         },
         "en" : {
@@ -4461,32 +4461,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Total"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "Totale"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "Totaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "Łącznie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Total"
+            "state" : "translated",
+            "value" : "Toplam"
           }
         }
       }
@@ -4497,14 +4497,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "Venter på Wi-Fi"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "Warten auf WLAN"
           }
         },
         "en" : {
@@ -4515,32 +4515,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "En attente du Wi-Fi"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "In attesa del Wi-Fi"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "Wachten op wifi"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "Oczekiwanie na Wi-Fi"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Waiting for Wi-Fi"
+            "state" : "translated",
+            "value" : "Wi-Fi bekleniyor"
           }
         }
       }
@@ -5837,14 +5837,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Biblioteksdownload"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Bibliothek laden"
           }
         },
         "en" : {
@@ -5855,32 +5855,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Remplissage de la bibliothèque"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Download della libreria"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Bibliotheek vullen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Pobieranie biblioteki"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Library fill"
+            "state" : "translated",
+            "value" : "Kitaplık doldurma"
           }
         }
       }
@@ -5891,14 +5891,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Andet"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Sonstiges"
           }
         },
         "en" : {
@@ -5909,32 +5909,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Autre"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Altro"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Overig"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Inne"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
+            "state" : "translated",
+            "value" : "Diğer"
           }
         }
       }
@@ -5945,14 +5945,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Afstemning"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Abgleich"
           }
         },
         "en" : {
@@ -5963,32 +5963,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Réconciliation"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Riconciliazione"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Afstemming"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Uzgadnianie"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconcile"
+            "state" : "translated",
+            "value" : "Uzlaştırma"
           }
         }
       }
@@ -5999,14 +5999,14 @@
       "localizations" : {
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Elementsynkronisering"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Elementsynchronisierung"
           }
         },
         "en" : {
@@ -6017,32 +6017,32 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Synchronisation des éléments"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Sincronizzazione degli elementi"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Elementsynchronisatie"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Synchronizacja elementów"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Element sync"
+            "state" : "translated",
+            "value" : "Öğe eşitlemesi"
           }
         }
       }


### PR DESCRIPTION
493 string units across `App`, `Permissions`, `Persistence` and `Settings` were sitting at `state: "new"` with the English source text copied in — Crowdin's placeholder for strings that have been extracted but not yet translated. This fills all of them in for the seven shipped locales (da, de, fr, it, nl, pl, tr).

| Catalog | Keys | Units |
|---|---:|---:|
| `App.xcstrings` | 11 | 72 |
| `Permissions.xcstrings` | 5 | 35 |
| `Persistence.xcstrings` | 12 | 78 |
| `Settings.xcstrings` | 44 | 308 |

After this, no catalog has any unit left in a non-`translated` state.

## How the translations were informed

- **Translator comments on each key.** For example `apiForbidden*ErrorMessage` is annotated "toast title, truncated to one line: keep it short", so those are terse noun phrases rather than sentences.
- **Existing translations in these catalogs, used as a glossary.** `apiForbiddenDetails` supplied the sentence template for the four new `apiForbidden*Details` strings; `resourceMailAccount` / `resourceMailRule` supplied the singulars that were pluralized.
- **Each locale's established form of address**, measured against the already-translated strings rather than assumed: de/da/pl/it informal, nl `je`, fr `vous`, tr formal `-niz`.
- **Apple's platform terminology** for OS features — "Low Data Mode" → *Datensparmodus*, *Mode Données limitées*, *Tryb niskiego zużycia danych*, *Az Veri Modu*.

## Two choices worth a reviewer's eye

- **`resourceShareLinks`** uses a plural noun instead of following the existing singular `resourceShareLink`, which is an imperative in several locales ("Link teilen", "Del link"). These are resource names substituted into a sentence, so they have to be nouns.
- **`apiForbidden*Details` in pl and tr.** The `%@` is a substituted nominative that cannot decline. Polish uses colon apposition (`…do tworzenia elementów: %@`) and Turkish pins the case suffix to a fixed noun (`%@ kaynağını oluşturma izni yok`) so both stay grammatical.

## Verification

- The applier refused to write unless its table covered exactly the pending units and no others.
- Format specifiers (`%@`, `%1$lld`, `%2$lld`) compared against each source string.
- JSON re-parsed, plus a byte-exact re-serialization check — the diff is purely `state` and `value` lines, with no keys added, removed or reordered.
- `xcodebuild` on the `swift-paperless` scheme: **BUILD SUCCEEDED**, no string-catalog warnings.
- `just lint` whitespace and EOF checks pass.

The commit used `--no-verify`: `pre-commit` currently fails while installing the `swift-format` hook environment (`swift-syntax` version resolution), before any file matching happens. The three hooks that actually match `.xcstrings` — `trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files` — were run individually and pass. No Swift, Python, YAML or workflow files are touched by this change.

## Before merging

These translations are **not in Crowdin**. `scripts/i18n.py pull` extracts over the catalog files wholesale, so the next pull discards all 493 units unless they are also entered upstream. There is no push command in `i18n.py` today.

Separately, and independent of this branch: that same `pull` command defaults `localizations_directory` to `swift-paperless/Localization`, which no longer exists after the AppShared move. With `exists=True` on the option it fails at argument validation. Not touched here.

## Provenance

Drafted by Claude Code (Opus 5). Every claim in the Verification section above was executed, not inferred. The translations themselves are model-generated and have **not** been reviewed by a native speaker of any of the seven languages — that review is the main thing this PR needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYYunTtut84aM63jKG1JQQ
