### PR TITLE
refactor: App-level sync orchestration

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -48,7 +48,10 @@ extension DocumentStore {
       preconditionFailure("Preview database seed failed: \(error)")
     }
     let caching = CachingRepository(wrapping: wrapped, database: database, serverID: serverID)
-    let store = DocumentStore(repository: caching)
+    // Wrapped in a session like every other store: previews exercise the same
+    // ownership path production does, and there is no `init(repository:)` for
+    // production code to reach for.
+    let store = DocumentStore(session: ServerSession(serverID: serverID, repository: caching))
     store.elementStore.refreshUISettings(from: database, serverID: serverID)
     Task { try? await store.sync() }
     return store

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -102,10 +102,11 @@ public final class DocumentStore: Sendable {
   /// When the document reconcile sweep (R2/R3δ/membership) last **succeeded**.
   /// `nil` until the first successful reconcile this session.
   ///
-  /// Observed (not `@ObservationIgnored`) because the Offline & Sync screen
-  /// renders it: untracked storage would leave the row reading "Never" until
-  /// some other observed property happened to fire.
-  public private(set) var lastReconcileAt: Date?
+  /// Owned by the session, not mirrored into stored state here: the session's
+  /// own stamp is observed, so a view reading this through the store still
+  /// repaints when a sweep lands — including a sweep the *scheduler* ran, which
+  /// the store used never to hear about.
+  public var lastReconcileAt: Date? { session?.lastReconcileSuccess }
 
   /// When the active server's library was last fully filled (`nil` if never).
   /// A stored, observed mirror of `server_sync_state.library_coverage_at` —
@@ -175,20 +176,6 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var taskUpdateTask: Task<Void, Never>?
 
-  // The in-flight element sync, if any. Concurrent `sync` callers join this one
-  // task instead of each firing their own `syncElements` (the launch flurry of
-  // sync / fetchUISettings / scenePhase triggers shares a single network
-  // pass). Only ever touched on the main actor.
-  @ObservationIgnored
-  private var syncTask: Task<Void, Error>?
-
-  // The in-flight proactive library fill. Held so it can be cancelled when the
-  // repository is replaced, and so a second request joins it rather than
-  // starting a parallel pass over the same queries. Only touched on the main
-  // actor.
-  @ObservationIgnored
-  private var libraryFillTask: Task<Void, Never>?
-
   // Observes the active server's `library_coverage_at` into `libraryCoverageAt`.
   // Re-pointed alongside the element projection whenever the repository changes.
   @ObservationIgnored
@@ -201,14 +188,6 @@ public final class DocumentStore: Sendable {
   // Observes the active server's cached document count into `cachedDocumentCount`.
   @ObservationIgnored
   private var documentCountObservationTask: Task<Void, Never>?
-
-  // When the reconcile last *ran*, which is what the throttle needs — it has to
-  // advance on every attempt or a failing server would re-sweep its whole id set
-  // on every foreground. `lastReconcileAt` is the separate, user-facing stamp and
-  // only advances on success.
-  @ObservationIgnored
-  private var lastDocumentReconcile: Date?
-  private let reconcileThrottle: TimeInterval = 300
 
   // MARK: Methods
 
@@ -231,10 +210,12 @@ public final class DocumentStore: Sendable {
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
+    session?.progress = { [weak self] activity, stage in
+      self?.report(activity, for: stage)
+    }
   }
 
   deinit {
-    libraryFillTask?.cancel()
     taskUpdateTask?.cancel()
     coverageObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
@@ -366,21 +347,24 @@ public final class DocumentStore: Sendable {
   /// that needs to swap repositories should route through here so the invariant
   /// below keeps covering it.
   private func install(session: ServerSession, reload: Bool) {
-    // The backstop against installing a non-caching repository is gone because
-    // it is now unrepresentable: a session only ever yields a `CachingBackend`.
+    // Nothing is cancelled here any more, and that is the point.
     //
-    // The cancel-on-swap below, however, is still load-bearing *in this commit*.
-    // The store — not the session — still owns the element sync and the fill, so
-    // an in-flight one belongs to the outgoing backend: it writes the old
-    // server's rows, and `runSyncElements` would let the caller's follow-up sync
-    // join it (both `activate` callers do `activate` → `sync()`) and return
-    // without ever fetching the new server's cache. Once the sequence moves onto
-    // the session, that work is simply an *inactive* session's work and should
-    // keep running, and this goes away.
-    syncTask?.cancel()
-    syncTask = nil
-    libraryFillTask?.cancel()
-    libraryFillTask = nil
+    // The store used to cancel the in-flight element sync and library fill on
+    // every swap, because it owned them: they wrote the *outgoing* server's rows
+    // and a follow-up `sync()` would join them and return without ever fetching
+    // the new server's cache. Now that work belongs to the outgoing *session* —
+    // it is simply an inactive server's work, keyed to that server, and there is
+    // no way for the incoming server's sync to join it. So it keeps running, and
+    // switching servers mid-fill no longer throws away the pages already paid
+    // for.
+    //
+    // The progress hook does move, though: the outgoing session must stop
+    // reporting into this store's `syncActivities`, or the Offline & Sync screen
+    // would show the previous server's stages.
+    self.session?.progress = nil
+    session.progress = { [weak self] activity, stage in
+      self?.report(activity, for: stage)
+    }
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()
@@ -528,18 +512,18 @@ public final class DocumentStore: Sendable {
   public func sync(userInitiated: Bool = false) async throws {
     Logger.sync.notice("Sync store (userInitiated: \(userInitiated))")
     do {
-      try await runSyncElements()
+      try await session?.syncElements()
       lastSyncError = nil
       Logger.sync.info("Sync store complete")
       // Reconcile remote deletes alongside the element sync (throttled,
       // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
       let userInitiated = userInitiated
-      Task { [weak self] in await self?.reconcileDocuments(userInitiated: userInitiated) }
+      Task { [weak self] in await self?.session?.reconcileDocuments(force: userInitiated) }
     } catch {
-      // A cancellation is never the user's problem to see: either the caller's
-      // own task went away, or `install(session:)` retired this sync on a
-      // connection switch. Drop it before the userInitiated rethrow so neither
-      // case toasts.
+      // A cancellation is never the user's problem to see: the caller's own task
+      // went away. (A connection switch no longer retires it — that sync belongs
+      // to the outgoing session and runs on.) Drop it before the userInitiated
+      // rethrow so it doesn't toast.
       if error.isCancellationError {
         Logger.sync.debug("Element sync cancelled")
         return
@@ -553,38 +537,6 @@ public final class DocumentStore: Sendable {
       }
       Logger.sync.error("Background sync failed (suppressed): \(error)")
     }
-  }
-
-  /// Run (or join) the single in-flight `syncElements`. Returns when it
-  /// completes; throws its error to every joined caller (who each decide what to
-  /// do with it). A no-op without a caching backend.
-  private func runSyncElements() async throws {
-    if let syncTask {
-      Logger.sync.debug("Joining in-flight element sync")
-      return try await syncTask.value
-    }
-    guard let backend = session?.backend else {
-      // No DB-backed repository (e.g. NullRepository before login). Nothing to
-      // sync; the projection is empty until a caching repository is set.
-      Logger.sync.info("Sync skipped: repository is not a caching backend")
-      return
-    }
-    Logger.sync.debug("Starting element sync")
-    let task = Task { [weak self] in
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements { self?.report($0, for: .elementSync) }
-      }
-    }
-    syncTask = task
-    defer {
-      // Retract only what we installed. `install(session:)` can retire this sync
-      // mid-flight and a replacement can already own `syncTask` by the time we
-      // resume; clearing it blindly would break the replacement's coalescing.
-      if syncTask == task {
-        syncTask = nil
-      }
-    }
-    try await task.value
   }
 
   public func document(id: UInt) async throws -> Document? {
@@ -879,123 +831,28 @@ extension DocumentStore {
     return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
   }
 
-  /// Throttled remote-delete reconcile: drop cached documents that no longer
-  /// exist on the server (so they disappear from every offline list). Soft-fail
-  /// (background); kicked from `sync()`. `userInitiated` bypasses the throttle.
+  /// Throttled remote-delete reconcile on the active server, run by its session:
+  /// drop cached documents that no longer exist on the server (so they disappear
+  /// from every offline list), fold in the changed-metadata delta, then rebuild
+  /// saved-view membership. Soft-fail (background); kicked from `sync()`.
+  /// `userInitiated` bypasses the throttle.
   public func reconcileDocuments(userInitiated: Bool = false) async {
-    guard let backend = session?.backend else { return }
-    if !userInitiated, let last = lastDocumentReconcile,
-      Date().timeIntervalSince(last) < reconcileThrottle
-    {
-      return
-    }
-    lastDocumentReconcile = Date()
-    report(SyncActivity(stage: .reconcile), for: .reconcile)
-    defer { report(nil, for: .reconcile) }
-
-    // Each sweep carries its own catch. The delete sweep is the most
-    // failure-prone of the three — it fetches the server's entire live id set —
-    // and under one shared `do` its failure took the freshness delta *and* the
-    // membership rebuild down with it, so a single flaky request cost the whole
-    // reconcile. Cancellation is the exception: it means the pass as a whole is
-    // unwanted (a repository swap, a background time budget running out), so it
-    // stops the remaining sweeps instead of being logged and stepped over.
-    var succeeded = 0
-    var cancelled = false
-
-    func sweep(_ label: String, _ body: () async throws -> Void) async {
-      guard !cancelled else { return }
-      do {
-        try await body()
-        succeeded += 1
-      } catch {
-        guard !error.isCancellationError else {
-          Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-          cancelled = true
-          return
-        }
-        Logger.sync.info("Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-      }
-    }
-
-    // Deletes first (correctness), then the changed-metadata delta (freshness),
-    // then the saved-view membership sweep (so newly-matched docs — now landed
-    // at detail by the delta — appear in every offline list). The last two are
-    // no-ops unless *Entire library* is enabled.
-    await NetworkTransfer.$category.withValue(.reconcile) {
-      await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-      await sweep("changes") {
-        try await backend.reconcileDocumentChanges { [weak self] in
-          // The delta finishing doesn't end the reconcile — the membership
-          // sweep runs after it — so fall back to the bare stage.
-          self?.report($0 ?? SyncActivity(stage: .reconcile), for: .reconcile)
-        }
-      }
-      await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-    }
-
-    // A pass in which *something* refreshed counts: a server that fails every
-    // sweep must not display a fresh "last refreshed" while nothing is actually
-    // being refreshed, but one failing sweep shouldn't erase the two that
-    // worked. Same policy as `fillLibrary`'s coverage marker. A cancelled pass
-    // stamps nothing — it didn't finish, it was called off.
-    if succeeded > 0, !cancelled {
-      lastReconcileAt = Date()
-    }
+    await session?.reconcileDocuments(force: userInitiated)
   }
 
-  /// Proactive *Entire library* fill, gated by the setting and an unmetered link.
+  /// Proactive *Entire library* fill on the active server, run by its session.
   /// Foreground-only; soft-fail (offline-tolerant). `force` ignores the freshness
   /// marker (e.g. the user just enabled the setting). A no-op when the setting is
-  /// *Recently browsed*, the link is metered, or there's no caching backend.
+  /// *Recently browsed*, the link is metered, or there is no active server.
   public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    guard unmetered, let backend = session?.backend,
-      backend.offlineBrowsingMode == .entireLibrary
-    else { return }
-
-    // Join an in-flight fill rather than starting a second pass over the same
-    // queries. Nothing dedupes these otherwise, and there are five triggers —
-    // launch, foreground, the mode picker, Sync now, and the background run.
-    // `force` is not lost by joining: a fill only runs at all when the coverage
-    // marker is stale or forced, so one is already doing the work.
-    if let existing = libraryFillTask {
-      await existing.value
-      return
-    }
-
-    let task = Task { [weak self] in
-      do {
-        try await backend.fillLibrary(force: force) { [weak self] in
-          self?.report($0, for: .libraryFill)
-        }
-      } catch is CancellationError {
-        Logger.sync.info("Proactive library fill cancelled")
-      } catch {
-        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
-      }
-    }
-    libraryFillTask = task
-    await task.value
-    // Only clear our own: a cancel-and-restart may have installed a newer one
-    // while we were awaiting.
-    if libraryFillTask == task {
-      libraryFillTask = nil
-    }
+    await session?.fillLibrary(unmetered: unmetered, force: force)
   }
 
-  /// Proactive *Entire library* per-document detail fill (notes + file-metadata),
-  /// gated by the setting and an unmetered link. Run after `fillLibraryIfEnabled`
-  /// so the document rows to walk are already on disk. Idempotent and resumable
-  /// (driven off what's still missing), so it needs no `force`. Soft-fail.
+  /// Proactive *Entire library* per-document detail fill (notes + file-metadata)
+  /// on the active server, run by its session. Run after `fillLibraryIfEnabled`
+  /// so the document rows to walk are already on disk. Soft-fail.
   public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    guard unmetered, let backend = session?.backend,
-      backend.offlineBrowsingMode == .entireLibrary
-    else { return }
-    do {
-      try await backend.fillDocumentDetails { [weak self] in self?.report($0, for: .detailFill) }
-    } catch {
-      Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
-    }
+    await session?.fillDocumentDetails(unmetered: unmetered)
   }
 
   /// The server's total for the default document list, from the cached query

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -145,7 +145,30 @@ public final class DocumentStore: Sendable {
 
   public let semaphore = AsyncSemaphore(value: 1)
 
-  public private(set) var repository: any Repository
+  /// The registry this store activates through, or `nil` for a fixture store
+  /// pinned to one session. Holding the registry — rather than a `Database` and
+  /// a `ConnectionManager` to assemble stacks from — is what stops the store
+  /// becoming a *second* owner of a server the registry already drives.
+  @ObservationIgnored
+  private let registry: ServerSessionRegistry?
+
+  /// The session driving this store, or `nil` before login.
+  ///
+  /// Deliberately *not* `@ObservationIgnored`: ``repository`` is computed from
+  /// it, so every view that read the outgoing server's repository has to be
+  /// invalidated when this changes.
+  private var session: ServerSession?
+
+  /// Stands in for "no active server". Held rather than constructed per access
+  /// so ``repository`` keeps a stable identity while the store is serverless.
+  @ObservationIgnored
+  private let nullRepository = NullRepository()
+
+  /// The active server's repository, owned by its ``ServerSession`` rather than
+  /// by this store. Before login there is no session, and this reads as
+  /// `NullRepository` — which detaches the element projection, exactly as it
+  /// always has.
+  public var repository: any Repository { session?.repository ?? nullRepository }
 
   public private(set) var imagePipeline: ImagePipeline
 
@@ -189,9 +212,24 @@ public final class DocumentStore: Sendable {
 
   // MARK: Methods
 
-  public init(repository: some Repository) {
-    self.repository = repository
-    self.imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+  /// The production store: it activates onto servers by asking `registry` for
+  /// their sessions, so neither the app nor the extension can end up driving a
+  /// server the registry already owns.
+  public convenience init(registry: ServerSessionRegistry) {
+    self.init(registry: registry, session: nil)
+  }
+
+  /// A store pinned to one session, for previews and tests. It cannot activate
+  /// onto another server — there is no registry to ask — which is the right
+  /// shape for a fixture.
+  public convenience init(session: ServerSession) {
+    self.init(registry: nil, session: session)
+  }
+
+  private init(registry: ServerSessionRegistry?, session: ServerSession?) {
+    self.registry = registry
+    self.session = session
+    imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
   }
 
@@ -211,7 +249,7 @@ public final class DocumentStore: Sendable {
     coverageObservationTask?.cancel()
     syncErrorObservationTask?.cancel()
     documentCountObservationTask?.cancel()
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       elementStore.repoint(database: backend.database, serverID: backend.serverID)
       // Source-of-truth: observe the coverage timestamp rather than reading it
       // imperatively, so it tracks fills *and* a cache wipe (which clears it).
@@ -292,7 +330,7 @@ public final class DocumentStore: Sendable {
   /// swap. That is only the task list and the last sync error now: documents
   /// aren't held in memory under source-of-truth (the list observes the DB
   /// directly), and the element projection is owned by `elementStore` and
-  /// re-pointed by `wireElementStore()`. `private` because `set(repository:)` is
+  /// re-pointed by `wireElementStore()`. `private` because `install(session:)` is
   /// the one caller — a swap is the only moment this is the right thing to do.
   private func clear() {
     tasks = []
@@ -301,53 +339,50 @@ public final class DocumentStore: Sendable {
 
   /// Point the store at `connection` — the only supported way to put it on a server.
   ///
-  /// The store assembles the stack itself, through ``makeCachingRepository``, so a
-  /// caller cannot hand it a bare uncached repository. That mistake detaches the
-  /// element projection and blanks every element read site until the next relaunch,
-  /// and it shipped once already from `ConnectionsView.updateExtraHeaders`; keeping
-  /// the assembly in here is what makes it unrepresentable rather than merely
-  /// discouraged.
+  /// The stack is assembled by the server's ``ServerSession``, so a caller cannot
+  /// hand the store a bare uncached repository. That mistake detaches the element
+  /// projection and blanks every element read site until the next relaunch, and it
+  /// shipped once already from `ConnectionsView.updateExtraHeaders`; routing every
+  /// activation through the session that owns the server is what makes it
+  /// unrepresentable rather than merely discouraged — and is also what stops two
+  /// owners driving the same server at once.
   public func activate(
     connection: StoredConnection,
-    database: Database,
-    manager: ConnectionManager,
-    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode,
     reload: Bool = true
   ) async throws {
-    let repository = try await makeCachingRepository(
-      for: connection, database: database, manager: manager, mode: mode)
-    install(repository: repository, reload: reload)
+    guard let registry else {
+      preconditionFailure("activate(connection:) called on a store built without a registry")
+    }
+    let session = registry.session(for: connection.id)
+    // Build before installing, not lazily on first use: `repository` reads
+    // straight off the session, and a store published on a session that has not
+    // assembled its stack yet would render one pass against `NullRepository`.
+    try await session.prepareRepository(for: connection)
+    install(session: session, reload: reload)
   }
 
   /// The single chokepoint for swapping the live repository. Private on purpose:
   /// see ``activate(connection:database:manager:mode:reload:)``. Any future path
   /// that needs to swap repositories should route through here so the invariant
   /// below keeps covering it.
-  private func install(repository: some Repository, reload: Bool) {
-    // A repository that doesn't front the DB detaches the element projection (see
-    // `wireElementStore()`). That is legitimate before login, but only via `init`;
-    // replacing a *live* repository with a bare one is always a bug. Unreachable
-    // today — `activate` is the only caller — so this is a backstop, not a guard
-    // against anything currently in the tree.
-    if !(repository is any CachingBackend) {
-      Logger.shared.fault(
-        "Installing non-caching repository \(String(describing: type(of: repository)), privacy: .public) on a live store; element projection will stay detached until relaunch"
-      )
-    }
-    // An element sync in flight belongs to the *outgoing* backend: it writes the
-    // old server's rows, and `runSyncElements` would let the caller's follow-up
-    // sync join it (both `activate` callers do `activate` → `sync()`) and return
-    // without ever fetching the new server's cache. Nothing here is worth
-    // keeping, so cancel rather than detach.
+  private func install(session: ServerSession, reload: Bool) {
+    // The backstop against installing a non-caching repository is gone because
+    // it is now unrepresentable: a session only ever yields a `CachingBackend`.
+    //
+    // The cancel-on-swap below, however, is still load-bearing *in this commit*.
+    // The store — not the session — still owns the element sync and the fill, so
+    // an in-flight one belongs to the outgoing backend: it writes the old
+    // server's rows, and `runSyncElements` would let the caller's follow-up sync
+    // join it (both `activate` callers do `activate` → `sync()`) and return
+    // without ever fetching the new server's cache. Once the sequence moves onto
+    // the session, that work is simply an *inactive* session's work and should
+    // keep running, and this goes away.
     syncTask?.cancel()
     syncTask = nil
-    // The fill belongs to the outgoing backend too: it pages the *old* server
-    // into the old server's rows. Left running it would keep spending network
-    // and main-actor write transactions on a connection the user has left.
     libraryFillTask?.cancel()
     libraryFillTask = nil
-    self.repository = repository
-    imagePipeline = Self.makeImagePipeline(delegate: repository.delegate)
+    self.session = session
+    imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()
     if reload {
       events.emit(.repositoryChanged)
@@ -477,7 +512,7 @@ public final class DocumentStore: Sendable {
   /// permissions (offline-first) instead of aborting the launch load.
   public func fetchUISettings() async throws {
     try await sync()
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       elementStore.refreshUISettings(from: backend.database, serverID: backend.serverID)
     }
   }
@@ -502,7 +537,7 @@ public final class DocumentStore: Sendable {
       Task { [weak self] in await self?.reconcileDocuments(userInitiated: userInitiated) }
     } catch {
       // A cancellation is never the user's problem to see: either the caller's
-      // own task went away, or `set(repository:)` retired this sync on a
+      // own task went away, or `install(session:)` retired this sync on a
       // connection switch. Drop it before the userInitiated rethrow so neither
       // case toasts.
       if error.isCancellationError {
@@ -528,7 +563,7 @@ public final class DocumentStore: Sendable {
       Logger.sync.debug("Joining in-flight element sync")
       return try await syncTask.value
     }
-    guard let backend = repository as? any CachingBackend else {
+    guard let backend = session?.backend else {
       // No DB-backed repository (e.g. NullRepository before login). Nothing to
       // sync; the projection is empty until a caching repository is set.
       Logger.sync.info("Sync skipped: repository is not a caching backend")
@@ -542,7 +577,7 @@ public final class DocumentStore: Sendable {
     }
     syncTask = task
     defer {
-      // Retract only what we installed. `set(repository:)` can retire this sync
+      // Retract only what we installed. `install(session:)` can retire this sync
       // mid-flight and a replacement can already own `syncTask` by the time we
       // resume; clearing it blindly would break the replacement's coalescing.
       if syncTask == task {
@@ -812,14 +847,14 @@ extension DocumentStore {
   /// the list can subscribe to whatever is already cached (offline-first) before
   /// — or independently of — the network fill. `nil` without a caching backend.
   public func documentQueryKey(filter: FilterState) -> QueryKey? {
-    guard let backend = repository as? any CachingBackend else { return nil }
+    guard let backend = session?.backend else { return nil }
     return QueryKey(serverID: backend.serverID, filter: filter)
   }
 
   /// Eager full-fill of a list: await page 1 + count, then background-page the
   /// rest. The returned handle carries the `QueryKey` the list then observes.
   public func fillDocumentQuery(filter: FilterState) async throws -> QueryFillHandle {
-    guard let backend = repository as? any CachingBackend else {
+    guard let backend = session?.backend else {
       throw CachingRepositoryError.cacheMiss
     }
     return try await backend.fillQuery(filter: filter)
@@ -831,7 +866,7 @@ extension DocumentStore {
   public func observeDocumentPrefix(
     queryKey: QueryKey, limit: Int
   ) -> AsyncThrowingStream<[DocumentEntry], Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeDocumentPrefix(
       queryKey: queryKey, serverID: backend.serverID, limit: limit)
   }
@@ -840,7 +875,7 @@ extension DocumentStore {
   public func observeQueryStatus(
     queryKey: QueryKey
   ) -> AsyncThrowingStream<QueryStatus, Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeQueryStatus(queryKey: queryKey, serverID: backend.serverID)
   }
 
@@ -848,7 +883,7 @@ extension DocumentStore {
   /// exist on the server (so they disappear from every offline list). Soft-fail
   /// (background); kicked from `sync()`. `userInitiated` bypasses the throttle.
   public func reconcileDocuments(userInitiated: Bool = false) async {
-    guard let backend = repository as? any CachingBackend else { return }
+    guard let backend = session?.backend else { return }
     if !userInitiated, let last = lastDocumentReconcile,
       Date().timeIntervalSince(last) < reconcileThrottle
     {
@@ -914,7 +949,7 @@ extension DocumentStore {
   /// marker (e.g. the user just enabled the setting). A no-op when the setting is
   /// *Recently browsed*, the link is metered, or there's no caching backend.
   public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    guard unmetered, let backend = repository as? any CachingBackend,
+    guard unmetered, let backend = session?.backend,
       backend.offlineBrowsingMode == .entireLibrary
     else { return }
 
@@ -953,7 +988,7 @@ extension DocumentStore {
   /// so the document rows to walk are already on disk. Idempotent and resumable
   /// (driven off what's still missing), so it needs no `force`. Soft-fail.
   public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    guard unmetered, let backend = repository as? any CachingBackend,
+    guard unmetered, let backend = session?.backend,
       backend.offlineBrowsingMode == .entireLibrary
     else { return }
     do {
@@ -984,7 +1019,7 @@ extension DocumentStore {
   /// Live single document by id, for detail/preview surfaces that must repaint on
   /// mutation/sync.
   public func observeDocument(id: UInt) -> AsyncThrowingStream<Document?, Error> {
-    guard let backend = repository as? any CachingBackend else { return Self.emptyStream() }
+    guard let backend = session?.backend else { return Self.emptyStream() }
     return backend.database.observeDocument(serverID: backend.serverID, id: id)
   }
 
@@ -1000,7 +1035,7 @@ extension DocumentStore {
   /// keeping the configured server connections. The live observations repaint
   /// empty immediately; the next sync / list open refills from the network.
   public func wipeLocalCache() throws {
-    if let backend = repository as? any CachingBackend {
+    if let backend = session?.backend {
       try backend.database.clearCache()
     }
     // Downloaded originals/archives/thumbnails (app-group blob store). Rooted at

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -84,6 +84,11 @@ public final class DocumentStore: Sendable {
   /// while the only reporter was this store.
   public var syncActivities: [SyncActivity] { session?.syncActivities ?? [] }
 
+  /// Whether the active server has any sync work in flight. Distinct from
+  /// ``syncActivities`` being non-empty, which only says whether a stage is
+  /// currently *reporting* — see ``ServerSession/isSyncing``.
+  public var isSyncing: Bool { session?.isSyncing ?? false }
+
   /// When the document reconcile sweep (R2/R3δ/membership) last **succeeded**.
   /// `nil` until the first successful reconcile this session.
   ///

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -486,7 +486,7 @@ public final class DocumentStore: Sendable {
 
   /// Network → DB via the caching backend; the live element observation repaints
   /// the projection. Concurrent calls coalesce onto a single in-flight
-  /// `syncElements` (see `syncTask`); each caller still applies its own
+  /// `syncElements` (the session's `elementSyncTask`); each caller still applies its own
   /// `userInitiated` policy to the shared outcome — automatic syncs fail soft
   /// into `lastSyncError`, user-initiated syncs rethrow so the caller can
   /// surface the failure (toast). So a user-initiated call joining a background
@@ -494,14 +494,20 @@ public final class DocumentStore: Sendable {
   /// appear, and what pull-to-refresh calls with `userInitiated: true`.
   public func sync(userInitiated: Bool = false) async throws {
     Logger.sync.notice("Sync store (userInitiated: \(userInitiated))")
+    // Pinned for the whole call, not re-read after the await. A server switch
+    // during the element sync would otherwise sync one server's elements and
+    // then reconcile a *different* server — harmless (each session owns its own
+    // repository, and the outgoing one's work is meant to run on) but
+    // incoherent, and a pull-to-refresh on A would force-reconcile B.
+    guard let session else { return }
     do {
-      try await session?.syncElements()
+      try await session.syncElements()
       lastSyncError = nil
       Logger.sync.info("Sync store complete")
       // Reconcile remote deletes alongside the element sync (throttled,
       // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
       let userInitiated = userInitiated
-      Task { [weak self] in await self?.session?.reconcileDocuments(force: userInitiated) }
+      Task { await session.reconcileDocuments(force: userInitiated) }
     } catch {
       // A cancellation is never the user's problem to see: the caller's own task
       // went away. (A connection switch no longer retires it — that sync belongs
@@ -843,8 +849,11 @@ extension DocumentStore {
   /// leaving notes and file metadata to wait for the next launch.
   public func fillIfEnabled(phases: SyncPhases, force: Bool = false) async {
     guard phases.contains(.fill) else { return }
-    await session?.fillLibrary(force: force)
-    await session?.fillDocumentDetails()
+    // One session for both halves: re-reading it between them would page one
+    // server's library and then walk a different server's details.
+    guard let session else { return }
+    await session.fillLibrary(force: force)
+    await session.fillDocumentDetails()
   }
 
   /// The server's total for the default document list, from the cached query

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -823,23 +823,27 @@ extension DocumentStore {
     await session?.reconcileDocuments(force: userInitiated)
   }
 
-  /// Proactive *Entire library* fill on the active server, run by its session.
-  /// Foreground-only; soft-fail (offline-tolerant). `force` ignores the freshness
-  /// marker (e.g. the user just enabled the setting). A no-op when the setting is
-  /// *Recently browsed*, the link is metered, or there is no active server.
-  public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    // The link gate lives here, at the boundary, rather than inside the session:
-    // the session runs phases it is told to run. Views keep passing `unmetered`
-    // because that is the fact they have to hand.
-    guard unmetered else { return }
+  /// Run the active server's proactive *Entire library* fill — every query's
+  /// pages, then the per-document details — when `phases` calls for it.
+  /// Foreground-only; soft-fail (offline-tolerant). `force` ignores the
+  /// freshness marker (e.g. the user just enabled the setting).
+  ///
+  /// Takes the planner's decision rather than an `unmetered` flag. The flag was
+  /// the last survivor of the vocabulary ``SyncPhases`` replaced: every caller
+  /// held a raw fact about the link, re-derived the fill rule from it, and
+  /// passed the answer down — the same shape, one layer lower, that the sweep
+  /// stopped doing when `SyncPlan` began emitting phases. Callers now ask
+  /// ``SyncPlan/phases(isEntireLibrary:condition:)`` the question the sweep
+  /// asks, and a caller that means "everything, the user said so" says `.full`
+  /// instead of lying about the network.
+  ///
+  /// The two fills are one call because they are one decision: `.fill` covers
+  /// both, and the details must be walked *after* the pages that put their rows
+  /// on disk. Every caller already paired them — except the one that forgot,
+  /// leaving notes and file metadata to wait for the next launch.
+  public func fillIfEnabled(phases: SyncPhases, force: Bool = false) async {
+    guard phases.contains(.fill) else { return }
     await session?.fillLibrary(force: force)
-  }
-
-  /// Proactive *Entire library* per-document detail fill (notes + file-metadata)
-  /// on the active server, run by its session. Run after `fillLibraryIfEnabled`
-  /// so the document rows to walk are already on disk. Soft-fail.
-  public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    guard unmetered else { return }
     await session?.fillDocumentDetails()
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -504,8 +504,11 @@ public final class DocumentStore: Sendable {
       try await session.syncElements()
       lastSyncError = nil
       Logger.sync.info("Sync store complete")
-      // Reconcile remote deletes alongside the element sync (throttled,
-      // non-blocking). Pull-to-refresh (userInitiated) bypasses the throttle.
+      // Kick the reconcile alongside the element sync (throttled,
+      // non-blocking). Not just remote deletes, despite the name it used to
+      // carry: it is all three sweeps — deletions, the changed-metadata delta,
+      // then the saved-view membership rebuild. Pull-to-refresh
+      // (userInitiated) bypasses the throttle.
       let userInitiated = userInitiated
       Task { await session.reconcileDocuments(force: userInitiated) }
     } catch {

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -828,14 +828,19 @@ extension DocumentStore {
   /// marker (e.g. the user just enabled the setting). A no-op when the setting is
   /// *Recently browsed*, the link is metered, or there is no active server.
   public func fillLibraryIfEnabled(unmetered: Bool, force: Bool = false) async {
-    await session?.fillLibrary(unmetered: unmetered, force: force)
+    // The link gate lives here, at the boundary, rather than inside the session:
+    // the session runs phases it is told to run. Views keep passing `unmetered`
+    // because that is the fact they have to hand.
+    guard unmetered else { return }
+    await session?.fillLibrary(force: force)
   }
 
   /// Proactive *Entire library* per-document detail fill (notes + file-metadata)
   /// on the active server, run by its session. Run after `fillLibraryIfEnabled`
   /// so the document rows to walk are already on disk. Soft-fail.
   public func fillDocumentDetailsIfEnabled(unmetered: Bool) async {
-    await session?.fillDocumentDetails(unmetered: unmetered)
+    guard unmetered else { return }
+    await session?.fillDocumentDetails()
   }
 
   /// The server's total for the default document list, from the cached query

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -75,29 +75,14 @@ public final class DocumentStore: Sendable {
   /// User-initiated syncs rethrow instead (the caller toasts, as before).
   public private(set) var lastSyncError: (any DisplayableError)?
 
-  /// Every sync stage running right now, in a fixed order; empty when idle.
-  /// Drives the stage rows and progress bars on the Offline & Sync screen.
+  /// Every sync stage running right now on the active server, in a fixed order;
+  /// empty when idle. Drives the stage rows and progress bars on the Offline &
+  /// Sync screen.
   ///
-  /// A list rather than one "current" stage because they genuinely overlap:
-  /// `sync()` starts the reconcile in its own task and returns, so a reconcile
-  /// is usually still running when the library fill begins. Publishing one of
-  /// them meant whichever finished first blanked the screen to "Idle" while the
-  /// other carried on — and, because progress is reported coarsely, it stayed
-  /// blank until the survivor reached its next checkpoint.
-  public private(set) var syncActivities: [SyncActivity] = []
-
-  // One entry per sweep currently running. Keyed by stage because each sweep
-  // owns exactly one, and because a sweep reporting "done" says only *that* —
-  // it can't say which stage it was, so the key has to come from the call site.
-  @ObservationIgnored
-  private var activeStages: [SyncActivity.Stage: SyncActivity] = [:]
-
-  /// Fold one sweep's progress into the published activity. `nil` retires the
-  /// stage; the screen keeps showing whatever else is still running.
-  private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
-    activeStages[stage] = activity
-    syncActivities = activeStages.values.sortedForDisplay
-  }
+  /// Owned by the session, so this is a plain projection: the screen now repaints
+  /// for work the *scheduler* started on this server too, which it could not do
+  /// while the only reporter was this store.
+  public var syncActivities: [SyncActivity] { session?.syncActivities ?? [] }
 
   /// When the document reconcile sweep (R2/R3δ/membership) last **succeeded**.
   /// `nil` until the first successful reconcile this session.
@@ -210,9 +195,6 @@ public final class DocumentStore: Sendable {
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
     wireElementStore()
-    session?.progress = { [weak self] activity, stage in
-      self?.report(activity, for: stage)
-    }
   }
 
   deinit {
@@ -358,13 +340,9 @@ public final class DocumentStore: Sendable {
     // switching servers mid-fill no longer throws away the pages already paid
     // for.
     //
-    // The progress hook does move, though: the outgoing session must stop
-    // reporting into this store's `syncActivities`, or the Offline & Sync screen
-    // would show the previous server's stages.
-    self.session?.progress = nil
-    session.progress = { [weak self] activity, stage in
-      self?.report(activity, for: stage)
-    }
+    // Progress needs no unwiring either: each session publishes its own stages,
+    // so pointing the store at a new one *is* switching which server's progress
+    // the Offline & Sync screen shows.
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
     wireElementStore()

--- a/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/NeedsAuthRepository.swift
@@ -3,8 +3,8 @@
 //  AppShared
 //
 //  A `Repository` decorator that watches outgoing calls for
-//  `RequestError.unauthorized` (HTTP 401) and flips the wrapped connection's
-//  `needsAuth` flag on `ConnectionManager`. The original error is always
+//  `RequestError.unauthorized` (HTTP 401) and sets the wrapped connection's
+//  `needs_auth` column. The original error is always
 //  re-thrown so call sites still see the failure — the flag drives the
 //  user-visible recovery UI (banner + re-auth sheet); silent swallowing is
 //  not the goal.
@@ -20,6 +20,7 @@
 import DataModel
 import Foundation
 import Networking
+import Persistence
 import SwiftUI
 import os
 
@@ -27,16 +28,50 @@ import os
 public final class NeedsAuthRepository<Wrapped: Repository>: Repository {
   private let wrapped: Wrapped
   private let serverID: UUID
-  private let connectionManager: ConnectionManager
+  private let database: Database
+
+  /// Whether this instance has already recorded a rejection.
+  ///
+  /// `ConnectionManager.markNeedsAuth` used to dedupe against its in-memory
+  /// set; writing the column directly needs its own guard, or a sync doing
+  /// dozens of calls against a dead token would issue an `UPDATE` per 401. One
+  /// write per instance is the right scope: a repository instance *is* one
+  /// connection configuration, and a new credential rebuilds the stack (the
+  /// session compares `Connection`s), which re-arms this.
+  private var marked = false
 
   public init(
     wrapping: Wrapped,
     serverID: UUID,
-    connectionManager: ConnectionManager
+    database: Database
   ) {
     self.wrapped = wrapping
     self.serverID = serverID
-    self.connectionManager = connectionManager
+    self.database = database
+  }
+
+  /// Record that this server's credential was rejected.
+  ///
+  /// Writes the column rather than calling `ConnectionManager`: `needs_auth` is
+  /// source-of-truth state on the `server` row, and the manager's own
+  /// `markNeedsAuth` is a thin wrapper over this same write whose in-memory set
+  /// is rebuilt by the connection observer either way. Going straight to the
+  /// database is what keeps an app-level object out of the repository stack.
+  private func markNeedsAuth() {
+    guard !marked else { return }
+    marked = true
+    Self.recordNeedsAuth(serverID: serverID, database: database)
+  }
+
+  fileprivate static func recordNeedsAuth(serverID: UUID, database: Database) {
+    Logger.api.info(
+      "Marking connection \(serverID, privacy: .private(mask: .hash)) as needing re-authentication"
+    )
+    do {
+      try database.setNeedsAuth(true, forConnection: serverID)
+    } catch {
+      Logger.api.error("Needs-auth write failed: \(error)")
+    }
   }
 
   private func intercept<T>(_ op: () async throws -> T) async throws -> T {
@@ -44,7 +79,7 @@ public final class NeedsAuthRepository<Wrapped: Repository>: Repository {
       return try await op()
     } catch let error as RequestError {
       if case .unauthorized = error {
-        connectionManager.markNeedsAuth(for: serverID)
+        markNeedsAuth()
       }
       throw error
     }
@@ -55,18 +90,21 @@ public final class NeedsAuthRepository<Wrapped: Repository>: Repository {
       return try op()
     } catch let error as RequestError {
       if case .unauthorized = error {
-        connectionManager.markNeedsAuth(for: serverID)
+        markNeedsAuth()
       }
       throw error
     }
   }
 
+  /// The paged sources outlive this decorator's call stack, so they carry the
+  /// write rather than a reference back to it — and therefore without the
+  /// per-instance dedupe, which is fine: paging 401s once and stops.
   private var sourceCallback: @Sendable () -> Void {
-    let manager = connectionManager
+    let database = self.database
     let id = serverID
     return {
       Task { @MainActor in
-        manager.markNeedsAuth(for: id)
+        NeedsAuthRepository.recordNeedsAuth(serverID: id, database: database)
       }
     }
   }

--- a/AppShared/Sources/AppShared/Networking/NetworkMonitor.swift
+++ b/AppShared/Sources/AppShared/Networking/NetworkMonitor.swift
@@ -11,6 +11,7 @@
 //  positives — used here as the source of the "device offline" signal only.
 //
 
+import DataModel
 import Foundation
 import Network
 import os
@@ -32,8 +33,9 @@ public final class NetworkMonitor {
   // without disrupting the device's actual network.
   public var debugForceOffline: Bool = false
 
-  public private(set) var isExpensive: Bool = false
-  public private(set) var isConstrained: Bool = false
+  /// What the current path costs. One value, published as one value: the two
+  /// facts are only meaningful together, and every consumer wants both.
+  public private(set) var cost: LinkCost = .unrestricted
 
   @ObservationIgnored private let monitor = NWPathMonitor()
   @ObservationIgnored private let queue = DispatchQueue(label: "NetworkMonitor.queue")
@@ -41,8 +43,7 @@ public final class NetworkMonitor {
   public init() {
     monitor.pathUpdateHandler = { [weak self] path in
       let online = path.status == .satisfied
-      let expensive = path.isExpensive
-      let constrained = path.isConstrained
+      let cost = LinkCost(isExpensive: path.isExpensive, isConstrained: path.isConstrained)
       Task { @MainActor [weak self] in
         guard let self else { return }
         if self.interfaceOnline != online {
@@ -50,8 +51,7 @@ public final class NetworkMonitor {
             "NetworkMonitor: interfaceOnline \(self.interfaceOnline) -> \(online)")
           self.interfaceOnline = online
         }
-        if self.isExpensive != expensive { self.isExpensive = expensive }
-        if self.isConstrained != constrained { self.isConstrained = constrained }
+        if self.cost != cost { self.cost = cost }
       }
     }
     monitor.start(queue: queue)

--- a/AppShared/Sources/AppShared/Networking/RepositoryFactory.swift
+++ b/AppShared/Sources/AppShared/Networking/RepositoryFactory.swift
@@ -25,13 +25,12 @@ import Persistence
 public func makeCachingRepository(
   for stored: StoredConnection,
   database: Database,
-  manager: ConnectionManager,
   mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
 ) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
   let connection = try stored.connection
   let api = await ApiRepository(connection: connection, mode: mode)
   let needsAuth = NeedsAuthRepository(
-    wrapping: api, serverID: stored.id, connectionManager: manager)
+    wrapping: api, serverID: stored.id, database: database)
   // Caching outermost: reads come from the GRDB cache, while sync's network
   // calls still flow through the needs-auth 401 interception.
   return CachingRepository(wrapping: needsAuth, database: database, serverID: stored.id)

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -482,8 +482,11 @@ public final class ServerSession {
   /// sequence needs that distinction to decide whether the server is fully
   /// synced; the store's callers discard it.
   @discardableResult
-  public func fillLibrary(unmetered: Bool, force: Bool = false) async -> Bool {
-    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+  public func fillLibrary(force: Bool = false) async -> Bool {
+    // No network gate here: whether this link may carry a fill is the planner's
+    // call, expressed by including `.fill` in the phase set. What remains is the
+    // server's own mode, which is a property of the server, not the decision.
+    guard let backend = current, backend.offlineBrowsingMode == .entireLibrary
     else { return true }
 
     // Join an in-flight fill rather than starting a second pass over the same
@@ -519,8 +522,8 @@ public final class ServerSession {
   /// to walk are already on disk. Idempotent and resumable (driven off what's
   /// still missing), so it needs no `force`. Soft-fail.
   @discardableResult
-  public func fillDocumentDetails(unmetered: Bool) async -> Bool {
-    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+  public func fillDocumentDetails() async -> Bool {
+    guard let backend = current, backend.offlineBrowsingMode == .entireLibrary
     else { return true }
     if let detailFillTask {
       return await detailFillTask.value
@@ -556,14 +559,16 @@ public final class ServerSession {
   /// of it. Nothing throws out: a per-server failure (offline, a rethrown 401)
   /// is this server's problem alone and must never affect its siblings.
   ///
-  /// `runHeavyFill` is `SyncPlan`'s decision, not this type's.
-  public func sync(stored: StoredConnection, runHeavyFill: Bool) async {
+  /// Which phases to run is `SyncPlan`'s decision, not this type's — the
+  /// session receives a decision, never the inputs to one — and the order they
+  /// run in is `SyncPhases`'s, not either party's.
+  public func sync(stored: StoredConnection, phases: SyncPhases) async {
     if let syncTask {
       return await syncTask.value
     }
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
-      await runSync(stored: stored, runHeavyFill: runHeavyFill)
+      await runSync(stored: stored, phases: phases)
     }
     syncTask = task
     await task.value
@@ -593,27 +598,34 @@ public final class ServerSession {
     }
   }
 
-  private func runSync(stored: StoredConnection, runHeavyFill: Bool) async {
+  private func runSync(stored: StoredConnection, phases: SyncPhases) async {
     Logger.sync.info(
-      "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
+      "Syncing server \(stored.logLabel, privacy: .public) (phases: \(phases.ordered.count))")
     do {
       _ = try await prepareRepository(for: stored)
       state = .ready
 
-      // Cheap tier (always, regardless of metered-ness): element sync + the
-      // reconcile sweeps (the last two self-gate on *Entire library*).
-      try await syncElements()
-
-      // The scheduler applied its own, much longer throttle before asking, so
-      // the reconcile's 300 s sub-throttle — which exists to keep the *active*
-      // server's on-appear flurry off the wire — must not veto this pass.
-      let reconcile = await reconcileDocuments(force: true)
-
-      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
+      // Walk the phases in `SyncPhases`'s canonical order, so the executor
+      // cannot run one before something it depends on even if a future planner
+      // hands them over in a different shape.
+      var reconcile = ReconcileResult()
       var filled = true
-      if runHeavyFill, !reconcile.cancelled {
-        filled = await fillLibrary(unmetered: true, force: false)
-        filled = await fillDocumentDetails(unmetered: true) && filled
+      for phase in phases.ordered {
+        switch phase {
+        case .elements:
+          try await syncElements()
+        case .reconcile:
+          // The scheduler applied its own, much longer throttle before asking,
+          // so the reconcile's 300 s sub-throttle — which exists to keep the
+          // *active* server's on-appear flurry off the wire — must not veto it.
+          reconcile = await reconcileDocuments(force: true)
+        case .fill:
+          // A reconcile that was called off means the pass as a whole is
+          // unwanted; don't start paging the library behind it.
+          guard !reconcile.cancelled else { continue }
+          filled = await fillLibrary(force: false)
+          filled = await fillDocumentDetails() && filled
+        }
       }
 
       // Advance the stamp only on a *fully* successful pass — a pass that failed

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -105,11 +105,49 @@ public final class ServerSession {
   // callers hit the same session concurrently and coalesce — which in turn is
   // what let the engine's "skip the active server" guard go away, since there
   // is no longer a second owner to stay out of the way of.
-  @ObservationIgnored private var syncTask: Task<Void, Never>?
-  @ObservationIgnored private var elementSyncTask: Task<Void, Error>?
-  @ObservationIgnored private var reconcileTask: Task<ReconcileResult, Never>?
-  @ObservationIgnored private var libraryFillTask: Task<Bool, Never>?
-  @ObservationIgnored private var detailFillTask: Task<Bool, Never>?
+  //
+  // The slots stay unobserved — `deinit` cancels them, and an observed
+  // property can't be read from a nonisolated deinit — so `didSet` mirrors
+  // them into ``isSyncing`` instead. Doing it in `didSet` rather than at each
+  // mutation site is what keeps the flag from drifting: there is no assignment
+  // that can forget to update it.
+  @ObservationIgnored private var syncTask: Task<Void, Never>? {
+    didSet { refreshIsSyncing() }
+  }
+  @ObservationIgnored private var elementSyncTask: Task<Void, Error>? {
+    didSet { refreshIsSyncing() }
+  }
+  @ObservationIgnored private var reconcileTask: Task<ReconcileResult, Never>? {
+    didSet { refreshIsSyncing() }
+  }
+  @ObservationIgnored private var libraryFillTask: Task<Bool, Never>? {
+    didSet { refreshIsSyncing() }
+  }
+  @ObservationIgnored private var detailFillTask: Task<Bool, Never>? {
+    didSet { refreshIsSyncing() }
+  }
+
+  /// Whether any work is running for this server.
+  ///
+  /// Tracks the task slots rather than ``syncActivities``, because the activity
+  /// list is a *progress* channel and answers a different question. It is
+  /// legitimately empty between phases, and while a phase is in flight but has
+  /// not yet reported its first checkpoint — the element sync clears its stage
+  /// the moment it finishes, and the reconcile that follows is kicked detached,
+  /// so there is a window in every pass where work is plainly running and
+  /// nothing is being reported. Gating a control on "no stage is reporting"
+  /// made the Offline & Sync screen's Sync now button flick back to enabled
+  /// mid-pass.
+  public private(set) var isSyncing: Bool = false
+
+  private func refreshIsSyncing() {
+    let busy =
+      syncTask != nil || elementSyncTask != nil || reconcileTask != nil
+      || libraryFillTask != nil || detailFillTask != nil
+    if busy != isSyncing {
+      isSyncing = busy
+    }
+  }
 
   public private(set) var state: State = .idle
 

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -171,7 +171,7 @@ public final class ServerSession {
   /// Keeps the active server's on-appear triggers off the wire. Bypassed by
   /// pull-to-refresh and by the scheduler, which has already applied its own
   /// (much longer) throttle before asking.
-  @ObservationIgnored private let reconcileThrottle: TimeInterval = 300
+  private static let reconcileThrottle: TimeInterval = 300
 
   /// Every sync stage running right now *for this server*, in a fixed order;
   /// empty when idle. The Offline & Sync screen renders the active server's,
@@ -187,19 +187,18 @@ public final class ServerSession {
   /// Living on the session rather than the store is what makes an *inactive*
   /// server's progress observable at all: the engine's sweeps used to report
   /// nowhere, because the only reporter belonged to the active server's store.
-  public private(set) var syncActivities: [SyncActivity] = []
+  public var syncActivities: [SyncActivity] { activeStages.values.sortedForDisplay }
 
   // One entry per sweep currently running. Keyed by stage because each sweep
   // owns exactly one, and because a sweep reporting "done" says only *that* —
   // it can't say which stage it was, so the key has to come from the call site.
-  @ObservationIgnored
+  // Observed, so the derived list above tracks it without a stored mirror.
   private var activeStages: [SyncActivity.Stage: SyncActivity] = [:]
 
   /// Fold one sweep's progress into the published activity. `nil` retires the
   /// stage; the list keeps showing whatever else is still running.
   private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
     activeStages[stage] = activity
-    syncActivities = activeStages.values.sortedForDisplay
   }
 
   public init(
@@ -405,7 +404,7 @@ public final class ServerSession {
     }
     guard let backend = current else { return ReconcileResult() }
     if !force, let last = lastReconcileAttempt,
-      Date().timeIntervalSince(last) < reconcileThrottle
+      Date().timeIntervalSince(last) < Self.reconcileThrottle
     {
       return ReconcileResult()
     }

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -121,14 +121,33 @@ public final class ServerSession {
   /// (much longer) throttle before asking.
   @ObservationIgnored private let reconcileThrottle: TimeInterval = 300
 
-  /// Where a running phase reports progress, installed by the store that is
-  /// showing this server. An inactive server leaves it `nil` and reports
-  /// nothing — exactly what the engine's sweeps did when it ran them itself.
-  @ObservationIgnored
-  public var progress: (@MainActor (SyncActivity?, SyncActivity.Stage) -> Void)?
+  /// Every sync stage running right now *for this server*, in a fixed order;
+  /// empty when idle. The Offline & Sync screen renders the active server's,
+  /// through its store.
+  ///
+  /// A list rather than one "current" stage because they genuinely overlap: the
+  /// store's `sync()` starts the reconcile in its own task and returns, so a
+  /// reconcile is usually still running when the library fill begins. Publishing
+  /// one of them meant whichever finished first blanked the screen to "Idle"
+  /// while the other carried on — and, because progress is reported coarsely, it
+  /// stayed blank until the survivor reached its next checkpoint.
+  ///
+  /// Living on the session rather than the store is what makes an *inactive*
+  /// server's progress observable at all: the engine's sweeps used to report
+  /// nowhere, because the only reporter belonged to the active server's store.
+  public private(set) var syncActivities: [SyncActivity] = []
 
+  // One entry per sweep currently running. Keyed by stage because each sweep
+  // owns exactly one, and because a sweep reporting "done" says only *that* —
+  // it can't say which stage it was, so the key has to come from the call site.
+  @ObservationIgnored
+  private var activeStages: [SyncActivity.Stage: SyncActivity] = [:]
+
+  /// Fold one sweep's progress into the published activity. `nil` retires the
+  /// stage; the list keeps showing whatever else is still running.
   private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
-    progress?(activity, stage)
+    activeStages[stage] = activity
+    syncActivities = activeStages.values.sortedForDisplay
   }
 
   public init(

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -61,6 +61,14 @@ public final class ServerSession {
   /// `Connection` is kept alongside and compared on each use: a changed URL,
   /// token, identity or extra header rebuilds the stack. (`Connection` is
   /// `Equatable` over exactly the fields `makeCachingRepository` consumes.)
+  ///
+  /// This comparison is load-bearing for re-auth, and only works because
+  /// `StoredConnection.token` reads the Keychain *live* on every access: a
+  /// re-auth writes the new token to the Keychain without changing the
+  /// `StoredConnection` record at all, so a session that compared records rather
+  /// than `Connection`s would keep serving the rejected token forever. The same
+  /// holds for `ConnectionsView.updateExtraHeaders`, which edits headers in
+  /// place.
   @ObservationIgnored private var built:
     (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
 

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -245,6 +245,17 @@ public final class ServerSession {
       if built != nil {
         Logger.sync.info(
           "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
+        // Everything still running belongs to the *outgoing* repository: the
+        // phase tasks captured it by value when they started, so they would go
+        // on writing through a stack built from credentials the server has
+        // since rejected — and, worse, a follow-up `sync()` would *join* that
+        // stale element task and report success without ever exercising the new
+        // token. (`ConnectionsView.updateExtraHeaders` and re-auth both land
+        // here.) The store used to cancel this on every repository swap; that
+        // guard was doing two jobs and only the server-switch half became
+        // unnecessary when sessions took ownership — a rebuild is the same
+        // session, so this half still has to be done by hand.
+        retirePhases()
       }
       // No suspension between the loop exiting and this assignment, and the
       // session is main-actor, so the slot cannot be claimed twice.
@@ -264,11 +275,14 @@ public final class ServerSession {
     }
   }
 
-  /// Drop the retained stack. Used when the server row goes away — the row
-  /// delete FK-cascades the cache, so there is nothing else to clean up.
-  public func invalidate() {
-    syncTask?.cancel()
-    syncTask = nil
+  /// Cancel and clear every phase slot, leaving the composed ``sync`` slot
+  /// alone.
+  ///
+  /// Deliberately not the composed slot: `runSync` calls `prepareRepository`
+  /// *before* its own phases, so a rebuild discovered there would otherwise
+  /// cancel the very task doing the discovering. Retiring the phases is enough
+  /// — the composed pass then sees them fail out and ends on its own.
+  private func retirePhases() {
     elementSyncTask?.cancel()
     elementSyncTask = nil
     reconcileTask?.cancel()
@@ -277,6 +291,14 @@ public final class ServerSession {
     libraryFillTask = nil
     detailFillTask?.cancel()
     detailFillTask = nil
+  }
+
+  /// Drop the retained stack. Used when the server row goes away — the row
+  /// delete FK-cascades the cache, so there is nothing else to clean up.
+  public func invalidate() {
+    syncTask?.cancel()
+    syncTask = nil
+    retirePhases()
     built = nil
     state = .idle
   }
@@ -560,6 +582,14 @@ public final class ServerSession {
       lastSuccessfulSync = Date()
       Logger.sync.info("Server \(stored.logLabel, privacy: .public) synced")
     } catch {
+      // A pass retired by a rebuild (or by the caller going away) was called
+      // off, not failed: leaving `state` alone keeps a connection edit from
+      // showing the server as broken, and the next trigger picks it up.
+      guard !error.isCancellationError else {
+        Logger.sync.debug(
+          "Sync cancelled for \(stored.logLabel, privacy: .public)")
+        return
+      }
       state = .failed
       Logger.sync.info(
         "Sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)")

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -473,9 +473,9 @@ public final class ServerSession {
     return result
   }
 
-  /// Proactive *Entire library* fill, gated by the setting and an unmetered
-  /// link. Soft-fail (offline-tolerant). `force` ignores the freshness marker
-  /// (e.g. the user just enabled the setting).
+  /// Proactive *Entire library* fill, gated by the server's own mode. Soft-fail
+  /// (offline-tolerant). `force` ignores the freshness marker (e.g. the user
+  /// just enabled the setting).
   ///
   /// Returns whether the pass finished — `true` also when there was legitimately
   /// nothing to do, `false` only when it errored or was called off. The composed
@@ -518,7 +518,7 @@ public final class ServerSession {
   }
 
   /// Proactive *Entire library* per-document detail fill (notes + file
-  /// metadata). Run after ``fillLibrary(unmetered:force:)`` so the document rows
+  /// metadata). Run after ``fillLibrary(force:)`` so the document rows
   /// to walk are already on disk. Idempotent and resumable (driven off what's
   /// still missing), so it needs no `force`. Soft-fail.
   @discardableResult

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -51,7 +51,9 @@ public final class ServerSession {
   private enum Source {
     /// Production: assembled from the server's stored connection through
     /// ``makeCachingRepository``, and rebuilt whenever that connection changes.
-    case stored(database: Database, manager: ConnectionManager, mode: ApiRepository.Mode)
+    /// Carries no `ConnectionManager`: the only thing a session used it for was
+    /// flagging needs-auth, which is a column on the `server` row.
+    case stored(database: Database, mode: ApiRepository.Mode)
     /// Previews and tests: handed in ready-made, and never rebuilt. This is what
     /// keeps "every store is driven by a session" true without dragging a
     /// `ConnectionManager` and a real connection record into a fixture — the
@@ -203,11 +205,10 @@ public final class ServerSession {
   public init(
     serverID: UUID,
     database: Database,
-    manager: ConnectionManager,
     mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
   ) {
     self.serverID = serverID
-    source = .stored(database: database, manager: manager, mode: mode)
+    source = .stored(database: database, mode: mode)
   }
 
   /// A session around a repository that already exists, for previews and tests.
@@ -259,7 +260,7 @@ public final class ServerSession {
     switch source {
     case .fixed(let repository):
       return repository
-    case .stored(let database, let manager, let mode):
+    case .stored(let database, let mode):
       // At most one build in flight per session. A caller that arrives while
       // one is running waits for it and then re-evaluates, rather than starting
       // a second: it usually finds `built` already matching — the same
@@ -298,8 +299,7 @@ public final class ServerSession {
       // No suspension between the loop exiting and this assignment, and the
       // session is main-actor, so the slot cannot be claimed twice.
       let task = Task { @MainActor () throws -> any Repository & CachingBackend in
-        try await makeCachingRepository(
-          for: stored, database: database, manager: manager, mode: mode)
+        try await makeCachingRepository(for: stored, database: database, mode: mode)
       }
       building = (connection, task)
       defer {
@@ -580,11 +580,18 @@ public final class ServerSession {
   /// cheap, and the next trigger picks the server up once a token lands. The 401
   /// path stays a backstop for a token the server rejects.
   public func markNeedsAuth(_ stored: StoredConnection) {
-    guard case .stored(_, let manager, _) = source else { return }
+    guard case .stored(let database, _) = source else { return }
     Logger.sync.info(
       "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
     state = .needsAuth
-    manager.markNeedsAuth(for: serverID)
+    // Straight to the column, like the 401 path in `NeedsAuthRepository`: the
+    // `ConnectionManager` rebuilds its in-memory set from the observer, so it
+    // does not need telling — and the session stays free of it.
+    do {
+      try database.setNeedsAuth(true, forConnection: serverID)
+    } catch {
+      Logger.sync.error("Needs-auth write failed: \(error)")
+    }
   }
 
   private func runSync(stored: StoredConnection, runHeavyFill: Bool) async {

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -84,9 +84,20 @@ public final class ServerSession {
   @ObservationIgnored private var built:
     (connection: Connection, repository: any Repository & CachingBackend)?
 
-  /// In-flight sync, so concurrent callers coalesce onto one pass rather than
-  /// running a second one against the same server.
+  // In-flight work, one single-flight per phase.
+  //
+  // Per *phase* rather than one per session, because the two callers want
+  // different things: the store drives phases individually (pull-to-refresh
+  // wants the element sync back, not a full server sweep), while the scheduler
+  // runs the composed sequence. Sharing the per-phase tasks is what lets both
+  // callers hit the same session concurrently and coalesce — which in turn is
+  // what let the engine's "skip the active server" guard go away, since there
+  // is no longer a second owner to stay out of the way of.
   @ObservationIgnored private var syncTask: Task<Void, Never>?
+  @ObservationIgnored private var elementSyncTask: Task<Void, Error>?
+  @ObservationIgnored private var reconcileTask: Task<ReconcileResult, Never>?
+  @ObservationIgnored private var libraryFillTask: Task<Bool, Never>?
+  @ObservationIgnored private var detailFillTask: Task<Bool, Never>?
 
   public private(set) var state: State = .idle
 
@@ -94,6 +105,31 @@ public final class ServerSession {
   /// on a clean pass, so an interrupted or partially-failed one retries on the
   /// next trigger rather than being throttled away.
   public private(set) var lastSuccessfulSync: Date?
+
+  /// When the reconcile last *ran*. Advances on every attempt, deliberately —
+  /// it gates the sub-throttle below, and a server that fails every sweep must
+  /// not refetch its whole live id set on each of the seventeen on-appear
+  /// triggers. Distinct from ``lastReconcileSuccess`` for exactly that reason.
+  @ObservationIgnored private var lastReconcileAttempt: Date?
+
+  /// When the reconcile last refreshed *something*. The user-facing "last
+  /// refreshed" stamp the Offline & Sync screen renders, so it is observed.
+  public private(set) var lastReconcileSuccess: Date?
+
+  /// Keeps the active server's on-appear triggers off the wire. Bypassed by
+  /// pull-to-refresh and by the scheduler, which has already applied its own
+  /// (much longer) throttle before asking.
+  @ObservationIgnored private let reconcileThrottle: TimeInterval = 300
+
+  /// Where a running phase reports progress, installed by the store that is
+  /// showing this server. An inactive server leaves it `nil` and reports
+  /// nothing — exactly what the engine's sweeps did when it ran them itself.
+  @ObservationIgnored
+  public var progress: (@MainActor (SyncActivity?, SyncActivity.Stage) -> Void)?
+
+  private func report(_ activity: SyncActivity?, for stage: SyncActivity.Stage) {
+    progress?(activity, stage)
+  }
 
   public init(
     serverID: UUID,
@@ -116,6 +152,10 @@ public final class ServerSession {
 
   deinit {
     syncTask?.cancel()
+    elementSyncTask?.cancel()
+    reconcileTask?.cancel()
+    libraryFillTask?.cancel()
+    detailFillTask?.cancel()
   }
 
   // MARK: - Repository access
@@ -171,13 +211,228 @@ public final class ServerSession {
   public func invalidate() {
     syncTask?.cancel()
     syncTask = nil
+    elementSyncTask?.cancel()
+    elementSyncTask = nil
+    reconcileTask?.cancel()
+    reconcileTask = nil
+    libraryFillTask?.cancel()
+    libraryFillTask = nil
+    detailFillTask?.cancel()
+    detailFillTask = nil
     built = nil
     state = .idle
   }
 
-  // MARK: - Sync
+  // MARK: - Phases
 
-  /// Run (or join) this server's sync pass.
+  /// Run (or join) this server's element sync.
+  ///
+  /// Unthrottled by design: every on-appear trigger expects this to reach the
+  /// network, and the single-flight — not a timer — is what keeps the launch
+  /// flurry to one pass. Rethrows to *every* joined caller, so a user-initiated
+  /// pull-to-refresh that lands on an in-flight background sync still sees the
+  /// failure it needs to toast.
+  public func syncElements() async throws {
+    if let elementSyncTask {
+      Logger.sync.debug("Joining in-flight element sync")
+      return try await elementSyncTask.value
+    }
+    guard let backend = current else {
+      // No repository yet (e.g. a store still on `NullRepository` before login).
+      Logger.sync.info("Element sync skipped: session has no repository")
+      return
+    }
+    Logger.sync.debug("Starting element sync")
+    let task = Task { [weak self] in
+      try await NetworkTransfer.$category.withValue(.sync) {
+        try await backend.syncElements { self?.report($0, for: .elementSync) }
+      }
+    }
+    elementSyncTask = task
+    defer {
+      // Retract only our own task: a replacement may already own the slot by the
+      // time we resume, and clearing it blindly would break its coalescing.
+      if elementSyncTask == task {
+        elementSyncTask = nil
+      }
+    }
+    try await task.value
+  }
+
+  /// What one reconcile pass achieved.
+  ///
+  /// Two stamps ask two different questions of the same pass — the scheduler
+  /// wants "fully clean" before it advances a throttle that could hide a broken
+  /// server for fifteen minutes; the Offline & Sync screen wants "did anything
+  /// refresh", because one flaky sweep shouldn't erase the two that worked. One
+  /// pass, both answers.
+  public struct ReconcileResult: Sendable {
+    public var succeeded = 0
+    public var failed = false
+    public var cancelled = false
+
+    /// Neither failed nor called off. Only a clean pass advances the scheduler's
+    /// freshness stamp.
+    public var isClean: Bool { !failed && !cancelled }
+  }
+
+  /// Throttled remote-delete reconcile: drop cached documents that no longer
+  /// exist on the server, fold in the changed-metadata delta, then rebuild
+  /// saved-view membership. Soft-fail throughout. `force` bypasses the 300 s
+  /// sub-throttle.
+  @discardableResult
+  public func reconcileDocuments(force: Bool = false) async -> ReconcileResult {
+    if let reconcileTask {
+      return await reconcileTask.value
+    }
+    guard let backend = current else { return ReconcileResult() }
+    if !force, let last = lastReconcileAttempt,
+      Date().timeIntervalSince(last) < reconcileThrottle
+    {
+      return ReconcileResult()
+    }
+    lastReconcileAttempt = Date()
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return ReconcileResult() }
+      return await runReconcile(backend: backend)
+    }
+    reconcileTask = task
+    let result = await task.value
+    if reconcileTask == task {
+      reconcileTask = nil
+    }
+    return result
+  }
+
+  private func runReconcile(backend: any CachingBackend) async -> ReconcileResult {
+    report(SyncActivity(stage: .reconcile), for: .reconcile)
+    defer { report(nil, for: .reconcile) }
+
+    // Each sweep carries its own catch. The delete sweep is the most
+    // failure-prone of the three — it fetches the server's entire live id set —
+    // and under one shared `do` its failure took the freshness delta *and* the
+    // membership rebuild down with it, so a single flaky request cost the whole
+    // reconcile. Cancellation is the exception: it means the pass as a whole is
+    // unwanted, so it stops the remaining sweeps instead of being stepped over.
+    var result = ReconcileResult()
+    func sweep(_ label: String, _ body: () async throws -> Void) async {
+      guard !result.cancelled else { return }
+      do {
+        try await body()
+        result.succeeded += 1
+      } catch {
+        guard !error.isCancellationError else {
+          Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+          result.cancelled = true
+          return
+        }
+        Logger.sync.info(
+          "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+        result.failed = true
+      }
+    }
+
+    // Deletes first (correctness), then the changed-metadata delta (freshness),
+    // then the saved-view membership sweep (so newly-matched docs — now landed
+    // at detail by the delta — appear in every offline list). The last two are
+    // no-ops unless *Entire library* is enabled.
+    await NetworkTransfer.$category.withValue(.reconcile) {
+      await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+      await sweep("changes") {
+        try await backend.reconcileDocumentChanges { [weak self] in
+          // The delta finishing doesn't end the reconcile — the membership
+          // sweep runs after it — so fall back to the bare stage.
+          self?.report($0 ?? SyncActivity(stage: .reconcile), for: .reconcile)
+        }
+      }
+      await sweep("membership") { try await backend.reconcileSavedViewMembership() }
+    }
+
+    // A pass in which *something* refreshed counts. A cancelled pass stamps
+    // nothing — it didn't finish, it was called off.
+    if result.succeeded > 0, !result.cancelled {
+      lastReconcileSuccess = Date()
+    }
+    return result
+  }
+
+  /// Proactive *Entire library* fill, gated by the setting and an unmetered
+  /// link. Soft-fail (offline-tolerant). `force` ignores the freshness marker
+  /// (e.g. the user just enabled the setting).
+  ///
+  /// Returns whether the pass finished — `true` also when there was legitimately
+  /// nothing to do, `false` only when it errored or was called off. The composed
+  /// sequence needs that distinction to decide whether the server is fully
+  /// synced; the store's callers discard it.
+  @discardableResult
+  public func fillLibrary(unmetered: Bool, force: Bool = false) async -> Bool {
+    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+    else { return true }
+
+    // Join an in-flight fill rather than starting a second pass over the same
+    // queries. `force` is not lost by joining: a fill only runs at all when the
+    // coverage marker is stale or forced, so one is already doing the work.
+    if let libraryFillTask {
+      return await libraryFillTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      do {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillLibrary(force: force) { self?.report($0, for: .libraryFill) }
+        }
+        return true
+      } catch is CancellationError {
+        Logger.sync.info("Proactive library fill cancelled")
+        return false
+      } catch {
+        Logger.sync.info("Proactive library fill failed (suppressed): \(error)")
+        return false
+      }
+    }
+    libraryFillTask = task
+    let completed = await task.value
+    if libraryFillTask == task {
+      libraryFillTask = nil
+    }
+    return completed
+  }
+
+  /// Proactive *Entire library* per-document detail fill (notes + file
+  /// metadata). Run after ``fillLibrary(unmetered:force:)`` so the document rows
+  /// to walk are already on disk. Idempotent and resumable (driven off what's
+  /// still missing), so it needs no `force`. Soft-fail.
+  @discardableResult
+  public func fillDocumentDetails(unmetered: Bool) async -> Bool {
+    guard unmetered, let backend = current, backend.offlineBrowsingMode == .entireLibrary
+    else { return true }
+    if let detailFillTask {
+      return await detailFillTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      do {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillDocumentDetails { self?.report($0, for: .detailFill) }
+        }
+        return true
+      } catch is CancellationError {
+        Logger.sync.info("Proactive detail fill cancelled")
+        return false
+      } catch {
+        Logger.sync.info("Proactive detail fill failed (suppressed): \(error)")
+        return false
+      }
+    }
+    detailFillTask = task
+    let completed = await task.value
+    if detailFillTask == task {
+      detailFillTask = nil
+    }
+    return completed
+  }
+
+  // MARK: - Composed sequence
+
+  /// Run (or join) this server's full sync pass.
   ///
   /// The sequence is the one the active path has always run — element sync, the
   /// three reconcile sweeps, then the proactive fills — and is now the only copy
@@ -218,55 +473,28 @@ public final class ServerSession {
     Logger.sync.info(
       "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
     do {
-      let backend = try await prepareRepository(for: stored)
+      _ = try await prepareRepository(for: stored)
       state = .ready
 
       // Cheap tier (always, regardless of metered-ness): element sync + the
       // reconcile sweeps (the last two self-gate on *Entire library*).
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements()
-      }
+      try await syncElements()
 
-      // Each reconcile sweep carries its own catch: the deletion sweep is the
-      // most failure-prone of the three — it fetches the server's entire live id
-      // set — and under one shared `try` its failure took the freshness delta,
-      // the membership rebuild *and* the heavy fill down with it. Cancellation is
-      // the exception: it means the pass as a whole is unwanted, so it stops the
-      // remaining sweeps instead of being logged and stepped over.
-      var failed = false
-      var cancelled = false
-      func sweep(_ label: String, _ body: () async throws -> Void) async {
-        guard !cancelled else { return }
-        do {
-          try await body()
-        } catch {
-          guard !error.isCancellationError else {
-            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-            cancelled = true
-            return
-          }
-          Logger.sync.info(
-            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-          failed = true
-        }
-      }
-      await NetworkTransfer.$category.withValue(.reconcile) {
-        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-        await sweep("changes") { try await backend.reconcileDocumentChanges() }
-        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-      }
+      // The scheduler applied its own, much longer throttle before asking, so
+      // the reconcile's 300 s sub-throttle — which exists to keep the *active*
+      // server's on-appear flurry off the wire — must not veto this pass.
+      let reconcile = await reconcileDocuments(force: true)
 
       // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
-      if runHeavyFill, !cancelled {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillLibrary(force: false)
-          try await backend.fillDocumentDetails()
-        }
+      var filled = true
+      if runHeavyFill, !reconcile.cancelled {
+        filled = await fillLibrary(unmetered: true, force: false)
+        filled = await fillDocumentDetails(unmetered: true) && filled
       }
 
       // Advance the stamp only on a *fully* successful pass — a pass that failed
       // or was called off partway retries on the next trigger.
-      guard !failed, !cancelled else {
+      guard reconcile.isClean, filled else {
         Logger.sync.info(
           "Server \(stored.logLabel, privacy: .public) partially synced; stamp not advanced")
         return

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -1,0 +1,235 @@
+//
+//  ServerSession.swift
+//  AppShared
+//
+//  One configured server's networking life: its `CachingRepository`, its
+//  in-flight sync, and the freshness stamp the scheduler throttles on.
+//
+//  This type exists to make the invariant **"at most one `CachingRepository`
+//  per server executes at any time"** structural. Previously that was upheld by
+//  convention: `DocumentStore` drove the active server, `SyncEngine` swept the
+//  rest and skipped `activeConnectionId` to stay out of its way. Two independent
+//  owners, coordinating through a key that mutates underneath them — which is
+//  exactly how a server that went active mid-sweep could end up driven twice.
+//  With one session per server, the coordination scope (`CachingRepository`'s
+//  per-instance `activeFills`) and the ownership scope finally coincide.
+//
+//  The session is an imperative shell only. Every *decision* — which servers to
+//  sync, in what order, whether the throttle has elapsed, whether a heavy fill
+//  is allowed on this link — stays in the pure, unit-tested `DataModel.SyncPlan`,
+//  because `AppShared` has no test target and anything moved in here stops being
+//  covered.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+@Observable
+public final class ServerSession {
+  /// Where this server stands. `needsAuth` is a *state*, not a branch in the
+  /// scheduler: a config-synced-but-uncredentialed server is a normal session
+  /// that simply has nothing it can do yet, and picks up the moment a token
+  /// lands.
+  public enum State: Equatable, Sendable {
+    /// No repository built yet (nothing has asked this server to do anything).
+    case idle
+    /// Repository built; the server is usable.
+    case ready
+    /// No usable credential. No network call is attempted.
+    case needsAuth
+    /// The last attempt failed (offline, rejected token, …). Retried on the
+    /// next trigger; the stamp is not advanced, so the throttle won't hide it.
+    case failed
+  }
+
+  public let serverID: UUID
+
+  @ObservationIgnored private let database: Database
+  @ObservationIgnored private let manager: ConnectionManager
+  @ObservationIgnored private let mode: ApiRepository.Mode
+
+  /// The retained stack, together with the `Connection` it was assembled from.
+  ///
+  /// Retaining it is the point — a long-lived repository is what lets
+  /// `activeFills` dedupe across sweeps instead of only within one. But the
+  /// per-sweep rebuild it replaces picked up connection edits for free, so the
+  /// `Connection` is kept alongside and compared on each use: a changed URL,
+  /// token, identity or extra header rebuilds the stack. (`Connection` is
+  /// `Equatable` over exactly the fields `makeCachingRepository` consumes.)
+  @ObservationIgnored private var built:
+    (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
+
+  /// In-flight sync, so concurrent callers coalesce onto one pass rather than
+  /// running a second one against the same server.
+  @ObservationIgnored private var syncTask: Task<Void, Never>?
+
+  public private(set) var state: State = .idle
+
+  /// Last *fully* successful pass. The scheduler's throttle input; advanced only
+  /// on a clean pass, so an interrupted or partially-failed one retries on the
+  /// next trigger rather than being throttled away.
+  public private(set) var lastSuccessfulSync: Date?
+
+  public init(
+    serverID: UUID,
+    database: Database,
+    manager: ConnectionManager,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+  ) {
+    self.serverID = serverID
+    self.database = database
+    self.manager = manager
+    self.mode = mode
+  }
+
+  deinit {
+    syncTask?.cancel()
+  }
+
+  // MARK: - Repository access
+
+  /// The server's repository, or `nil` before anything has built it.
+  public var repository: (any Repository)? { built?.repository }
+
+  /// The same instance seen as the cache-backed surface the sync sequence and
+  /// the store's projections both drive.
+  public var backend: (any CachingBackend)? { built?.repository }
+
+  /// Build the stack, or hand back the retained one when it still matches
+  /// `stored`. Assembly goes through ``makeCachingRepository`` so every server's
+  /// layering is identical to the app shell's.
+  private func repository(
+    for stored: StoredConnection
+  ) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
+    let connection = try stored.connection
+    if let built, built.connection == connection {
+      return built.repository
+    }
+    if built != nil {
+      Logger.sync.info(
+        "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
+    }
+    let repository = try await makeCachingRepository(
+      for: stored, database: database, manager: manager, mode: mode)
+    built = (connection, repository)
+    return repository
+  }
+
+  /// Drop the retained stack. Used when the server row goes away — the row
+  /// delete FK-cascades the cache, so there is nothing else to clean up.
+  public func invalidate() {
+    syncTask?.cancel()
+    syncTask = nil
+    built = nil
+    state = .idle
+  }
+
+  // MARK: - Sync
+
+  /// Run (or join) this server's sync pass.
+  ///
+  /// The sequence is the one the active path has always run — element sync, the
+  /// three reconcile sweeps, then the proactive fills — and is now the only copy
+  /// of it. Nothing throws out: a per-server failure (offline, a rethrown 401)
+  /// is this server's problem alone and must never affect its siblings.
+  ///
+  /// `runHeavyFill` is `SyncPlan`'s decision, not this type's.
+  public func sync(stored: StoredConnection, runHeavyFill: Bool) async {
+    if let syncTask {
+      return await syncTask.value
+    }
+    let task = Task { @MainActor [weak self] in
+      guard let self else { return }
+      await runSync(stored: stored, runHeavyFill: runHeavyFill)
+    }
+    syncTask = task
+    await task.value
+    // Retract only our own task: a swap can retire this pass mid-flight and a
+    // replacement may already own `syncTask` by the time we resume, and clearing
+    // it blindly would break the replacement's coalescing.
+    if syncTask == task {
+      syncTask = nil
+    }
+  }
+
+  /// Degrade to per-server needs-auth without a network call: deterministic and
+  /// cheap, and the next trigger picks the server up once a token lands. The 401
+  /// path stays a backstop for a token the server rejects.
+  public func markNeedsAuth(_ stored: StoredConnection) {
+    Logger.sync.info(
+      "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
+    state = .needsAuth
+    manager.markNeedsAuth(for: serverID)
+  }
+
+  private func runSync(stored: StoredConnection, runHeavyFill: Bool) async {
+    Logger.sync.info(
+      "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
+    do {
+      let backend = try await repository(for: stored)
+      state = .ready
+
+      // Cheap tier (always, regardless of metered-ness): element sync + the
+      // reconcile sweeps (the last two self-gate on *Entire library*).
+      try await NetworkTransfer.$category.withValue(.sync) {
+        try await backend.syncElements()
+      }
+
+      // Each reconcile sweep carries its own catch: the deletion sweep is the
+      // most failure-prone of the three — it fetches the server's entire live id
+      // set — and under one shared `try` its failure took the freshness delta,
+      // the membership rebuild *and* the heavy fill down with it. Cancellation is
+      // the exception: it means the pass as a whole is unwanted, so it stops the
+      // remaining sweeps instead of being logged and stepped over.
+      var failed = false
+      var cancelled = false
+      func sweep(_ label: String, _ body: () async throws -> Void) async {
+        guard !cancelled else { return }
+        do {
+          try await body()
+        } catch {
+          guard !error.isCancellationError else {
+            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
+            cancelled = true
+            return
+          }
+          Logger.sync.info(
+            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
+          failed = true
+        }
+      }
+      await NetworkTransfer.$category.withValue(.reconcile) {
+        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
+        await sweep("changes") { try await backend.reconcileDocumentChanges() }
+        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
+      }
+
+      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
+      if runHeavyFill, !cancelled {
+        try await NetworkTransfer.$category.withValue(.fill) {
+          try await backend.fillLibrary(force: false)
+          try await backend.fillDocumentDetails()
+        }
+      }
+
+      // Advance the stamp only on a *fully* successful pass — a pass that failed
+      // or was called off partway retries on the next trigger.
+      guard !failed, !cancelled else {
+        Logger.sync.info(
+          "Server \(stored.logLabel, privacy: .public) partially synced; stamp not advanced")
+        return
+      }
+      lastSuccessfulSync = Date()
+      Logger.sync.info("Server \(stored.logLabel, privacy: .public) synced")
+    } catch {
+      state = .failed
+      Logger.sync.info(
+        "Sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)")
+    }
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -84,6 +84,18 @@ public final class ServerSession {
   @ObservationIgnored private var built:
     (connection: Connection, repository: any Repository & CachingBackend)?
 
+  /// The build currently in flight, if any.
+  ///
+  /// `prepareRepository` has an `await` between "is `built` still good?" and
+  /// committing the answer, so without this two callers could both miss the
+  /// check and each construct a repository — one of which would be handed to
+  /// its caller while the *other* sat in `built`. Two live repositories for one
+  /// server is precisely the state this type exists to make unrepresentable,
+  /// and deleting the engine's active-server guard is what made the race
+  /// reachable: a sweep and an `activate` can now land on the same session.
+  @ObservationIgnored private var building:
+    (connection: Connection, task: Task<any Repository & CachingBackend, Error>)?
+
   // In-flight work, one single-flight per phase.
   //
   // Per *phase* rather than one per session, because the two callers want
@@ -210,6 +222,22 @@ public final class ServerSession {
     case .fixed(let repository):
       return repository
     case .stored(let database, let manager, let mode):
+      // At most one build in flight per session. A caller that arrives while
+      // one is running waits for it and then re-evaluates, rather than starting
+      // a second: it usually finds `built` already matching — the same
+      // connection, so it gets the winner's repository for free — and otherwise
+      // builds the next one itself against config read *after* the wait, so a
+      // re-auth that landed mid-build isn't overwritten by a stale result.
+      //
+      // The failure of someone else's build is not this caller's to inherit;
+      // it just means the slot is free and this caller tries for itself.
+      while let building {
+        _ = try? await building.task.value
+        if self.building?.task == building.task {
+          self.building = nil
+        }
+      }
+
       let connection = try stored.connection
       if let built, built.connection == connection {
         return built.repository
@@ -218,8 +246,19 @@ public final class ServerSession {
         Logger.sync.info(
           "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
       }
-      let repository = try await makeCachingRepository(
-        for: stored, database: database, manager: manager, mode: mode)
+      // No suspension between the loop exiting and this assignment, and the
+      // session is main-actor, so the slot cannot be claimed twice.
+      let task = Task { @MainActor () throws -> any Repository & CachingBackend in
+        try await makeCachingRepository(
+          for: stored, database: database, manager: manager, mode: mode)
+      }
+      building = (connection, task)
+      defer {
+        if building?.task == task {
+          building = nil
+        }
+      }
+      let repository = try await task.value
       built = (connection, repository)
       return repository
     }

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -47,13 +47,25 @@ public final class ServerSession {
     case failed
   }
 
+  /// Where this session's repository comes from.
+  private enum Source {
+    /// Production: assembled from the server's stored connection through
+    /// ``makeCachingRepository``, and rebuilt whenever that connection changes.
+    case stored(database: Database, manager: ConnectionManager, mode: ApiRepository.Mode)
+    /// Previews and tests: handed in ready-made, and never rebuilt. This is what
+    /// keeps "every store is driven by a session" true without dragging a
+    /// `ConnectionManager` and a real connection record into a fixture — the
+    /// alternative being a `DocumentStore.init(repository:)` escape hatch that
+    /// would let production code bypass a server's owner too.
+    case fixed(any Repository & CachingBackend)
+  }
+
   public let serverID: UUID
 
-  @ObservationIgnored private let database: Database
-  @ObservationIgnored private let manager: ConnectionManager
-  @ObservationIgnored private let mode: ApiRepository.Mode
+  @ObservationIgnored private let source: Source
 
   /// The retained stack, together with the `Connection` it was assembled from.
+  /// Only ever populated for ``Source/stored``.
   ///
   /// Retaining it is the point — a long-lived repository is what lets
   /// `activeFills` dedupe across sweeps instead of only within one. But the
@@ -70,7 +82,7 @@ public final class ServerSession {
   /// holds for `ConnectionsView.updateExtraHeaders`, which edits headers in
   /// place.
   @ObservationIgnored private var built:
-    (connection: Connection, repository: CachingRepository<NeedsAuthRepository<ApiRepository>>)?
+    (connection: Connection, repository: any Repository & CachingBackend)?
 
   /// In-flight sync, so concurrent callers coalesce onto one pass rather than
   /// running a second one against the same server.
@@ -90,9 +102,16 @@ public final class ServerSession {
     mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
   ) {
     self.serverID = serverID
-    self.database = database
-    self.manager = manager
-    self.mode = mode
+    source = .stored(database: database, manager: manager, mode: mode)
+  }
+
+  /// A session around a repository that already exists, for previews and tests.
+  /// It consults no connection record and never rebuilds: the repository it is
+  /// handed is the one it keeps, so it is `.ready` from birth.
+  public init(serverID: UUID, repository: any Repository & CachingBackend) {
+    self.serverID = serverID
+    source = .fixed(repository)
+    state = .ready
   }
 
   deinit {
@@ -101,31 +120,50 @@ public final class ServerSession {
 
   // MARK: - Repository access
 
+  /// The live repository, or `nil` before anything has built it.
+  private var current: (any Repository & CachingBackend)? {
+    switch source {
+    case .fixed(let repository): repository
+    case .stored: built?.repository
+    }
+  }
+
   /// The server's repository, or `nil` before anything has built it.
-  public var repository: (any Repository)? { built?.repository }
+  public var repository: (any Repository)? { current }
 
   /// The same instance seen as the cache-backed surface the sync sequence and
   /// the store's projections both drive.
-  public var backend: (any CachingBackend)? { built?.repository }
+  public var backend: (any CachingBackend)? { current }
 
   /// Build the stack, or hand back the retained one when it still matches
   /// `stored`. Assembly goes through ``makeCachingRepository`` so every server's
   /// layering is identical to the app shell's.
-  private func repository(
+  ///
+  /// Public because activating a store on this server has to *await* the build:
+  /// the store publishes `repository` straight off the session, so a lazy build
+  /// would leave it on `NullRepository` — projection detached — for the first
+  /// render after every switch.
+  @discardableResult
+  public func prepareRepository(
     for stored: StoredConnection
-  ) async throws -> CachingRepository<NeedsAuthRepository<ApiRepository>> {
-    let connection = try stored.connection
-    if let built, built.connection == connection {
-      return built.repository
+  ) async throws -> any Repository & CachingBackend {
+    switch source {
+    case .fixed(let repository):
+      return repository
+    case .stored(let database, let manager, let mode):
+      let connection = try stored.connection
+      if let built, built.connection == connection {
+        return built.repository
+      }
+      if built != nil {
+        Logger.sync.info(
+          "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
+      }
+      let repository = try await makeCachingRepository(
+        for: stored, database: database, manager: manager, mode: mode)
+      built = (connection, repository)
+      return repository
     }
-    if built != nil {
-      Logger.sync.info(
-        "Server \(stored.logLabel, privacy: .public) connection changed; rebuilding stack")
-    }
-    let repository = try await makeCachingRepository(
-      for: stored, database: database, manager: manager, mode: mode)
-    built = (connection, repository)
-    return repository
   }
 
   /// Drop the retained stack. Used when the server row goes away — the row
@@ -169,6 +207,7 @@ public final class ServerSession {
   /// cheap, and the next trigger picks the server up once a token lands. The 401
   /// path stays a backstop for a token the server rejects.
   public func markNeedsAuth(_ stored: StoredConnection) {
+    guard case .stored(_, let manager, _) = source else { return }
     Logger.sync.info(
       "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
     state = .needsAuth
@@ -179,7 +218,7 @@ public final class ServerSession {
     Logger.sync.info(
       "Syncing server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
     do {
-      let backend = try await repository(for: stored)
+      let backend = try await prepareRepository(for: stored)
       state = .ready
 
       // Cheap tier (always, regardless of metered-ness): element sync + the

--- a/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
@@ -39,19 +39,16 @@ public final class ServerSessionRegistry {
   /// server's state, not just the active one's.
   public private(set) var sessions: [UUID: ServerSession] = [:]
 
-  /// Server IDs seen at the last observation tick, diffed to spot additions and
-  /// removals.
-  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
-  @ObservationIgnored private var observationTask: Task<Void, Never>?
-
-  /// Called after each observation tick with the current set and the set as it
-  /// was before, so a scheduler can decide what a newly-appeared server deserves.
+  /// The configured servers, as of the last observation tick.
   ///
-  /// The registry deliberately does not make that decision itself: whether a new
-  /// server is synced immediately, and whether the active one is excluded, is
-  /// `SyncPlan`'s call, not lifecycle.
-  @ObservationIgnored
-  public var onServersChanged: (@MainActor (_ current: Set<UUID>, _ previous: Set<UUID>) -> Void)?
+  /// Published rather than pushed: a scheduler that wants to react to a new
+  /// server observes this like any other state, instead of the registry holding
+  /// a callback into it. The registry still makes no *policy* decision — whether
+  /// a new server is synced immediately, and whether the active one is excluded,
+  /// is `SyncPlan`'s call, not lifecycle's.
+  public private(set) var serverIDs: Set<UUID> = []
+
+  @ObservationIgnored private var observationTask: Task<Void, Never>?
 
   public init(
     database: Database,
@@ -78,7 +75,7 @@ public final class ServerSessionRegistry {
     guard observationTask == nil else { return }
     // Seed with the current set so the first tick reports no spurious additions;
     // servers present at launch are handled by the caller's explicit sweep.
-    knownServerIDs = Set(manager.connections.keys)
+    serverIDs = Set(manager.connections.keys)
     observationTask = Task { @MainActor [weak self] in
       while !Task.isCancelled {
         let (stream, continuation) = AsyncStream<Void>.makeStream()
@@ -96,15 +93,15 @@ public final class ServerSessionRegistry {
 
   private func handleConnectionsChanged() {
     let current = Set(manager.connections.keys)
-    let previous = knownServerIDs
     // A vanished row has already FK-cascaded its whole cache, so there is no
     // cache work here — just stop and release the session.
-    for id in previous.subtracting(current) {
+    for id in serverIDs.subtracting(current) {
       sessions.removeValue(forKey: id)?.invalidate()
       Logger.sync.info("Server row removed; dropped its session")
     }
-    knownServerIDs = current
-    onServersChanged?(current, previous)
+    if serverIDs != current {
+      serverIDs = current
+    }
   }
 
   // MARK: - Access

--- a/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
@@ -118,8 +118,7 @@ public final class ServerSessionRegistry {
     if let existing = sessions[id] {
       return existing
     }
-    let session = ServerSession(
-      serverID: id, database: database, manager: manager, mode: mode)
+    let session = ServerSession(serverID: id, database: database, mode: mode)
     sessions[id] = session
     return session
   }

--- a/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSessionRegistry.swift
@@ -1,0 +1,132 @@
+//
+//  ServerSessionRegistry.swift
+//  AppShared
+//
+//  Owns exactly one ``ServerSession`` per configured server, for the lifetime of
+//  that server's row.
+//
+//  Session *lifetime* and sync *scheduling* are different jobs, and keeping them
+//  in one type is what let `SyncEngine` grow into an owner as well as a
+//  scheduler. The registry answers "which servers exist, and what is each one's
+//  session"; `SyncEngine` answers "which of them should sync now, in what
+//  order". Neither needs the other's state.
+//
+//  The registry is the **sole** observer of `manager.connections` for session
+//  lifecycle. It has to be: it maintains a second map keyed by the same UUIDs,
+//  and two independent observers of the same table would drift apart exactly the
+//  way the previous two repository owners did.
+//
+//  `ConnectionManager` deliberately stays *below* this type — `NeedsAuthRepository`
+//  already depends on it, so a registry-aware `ConnectionManager` would close a
+//  dependency cycle.
+//
+
+import Common
+import DataModel
+import Foundation
+import Networking
+import Persistence
+import os
+
+@MainActor
+@Observable
+public final class ServerSessionRegistry {
+  @ObservationIgnored private let database: Database
+  @ObservationIgnored private let manager: ConnectionManager
+  @ObservationIgnored private let mode: ApiRepository.Mode
+
+  /// One session per known server. Observable so a screen can show every
+  /// server's state, not just the active one's.
+  public private(set) var sessions: [UUID: ServerSession] = [:]
+
+  /// Server IDs seen at the last observation tick, diffed to spot additions and
+  /// removals.
+  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
+  @ObservationIgnored private var observationTask: Task<Void, Never>?
+
+  /// Called after each observation tick with the current set and the set as it
+  /// was before, so a scheduler can decide what a newly-appeared server deserves.
+  ///
+  /// The registry deliberately does not make that decision itself: whether a new
+  /// server is synced immediately, and whether the active one is excluded, is
+  /// `SyncPlan`'s call, not lifecycle.
+  @ObservationIgnored
+  public var onServersChanged: (@MainActor (_ current: Set<UUID>, _ previous: Set<UUID>) -> Void)?
+
+  public init(
+    database: Database,
+    manager: ConnectionManager,
+    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+  ) {
+    self.database = database
+    self.manager = manager
+    self.mode = mode
+  }
+
+  deinit {
+    observationTask?.cancel()
+  }
+
+  // MARK: - Lifecycle
+
+  /// Begin observing the `server` table (via `manager.connections`, its sole
+  /// projection), creating and dropping sessions as rows come and go.
+  ///
+  /// Wired to the *observation* rather than the "Add server" UI action, so a
+  /// Stage-12 UBKVS `server` upsert flows through the same path for free.
+  public func start() {
+    guard observationTask == nil else { return }
+    // Seed with the current set so the first tick reports no spurious additions;
+    // servers present at launch are handled by the caller's explicit sweep.
+    knownServerIDs = Set(manager.connections.keys)
+    observationTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+          _ = self?.manager.connections.keys
+        } onChange: {
+          continuation.yield()
+          continuation.finish()
+        }
+        self?.handleConnectionsChanged()
+        for await _ in stream { break }
+      }
+    }
+  }
+
+  private func handleConnectionsChanged() {
+    let current = Set(manager.connections.keys)
+    let previous = knownServerIDs
+    // A vanished row has already FK-cascaded its whole cache, so there is no
+    // cache work here — just stop and release the session.
+    for id in previous.subtracting(current) {
+      sessions.removeValue(forKey: id)?.invalidate()
+      Logger.sync.info("Server row removed; dropped its session")
+    }
+    knownServerIDs = current
+    onServersChanged?(current, previous)
+  }
+
+  // MARK: - Access
+
+  /// The server's session, created on first request.
+  ///
+  /// Creation is cheap: a session assembles no repository until something
+  /// actually asks it to sync, so holding one per configured server costs
+  /// nothing for servers that stay idle.
+  public func session(for id: UUID) -> ServerSession {
+    if let existing = sessions[id] {
+      return existing
+    }
+    let session = ServerSession(
+      serverID: id, database: database, manager: manager, mode: mode)
+    sessions[id] = session
+    return session
+  }
+
+  /// Every session's last fully-successful sync, for the scheduler's throttle.
+  /// Servers that have never completed a pass are absent rather than distant-past.
+  public func lastSuccessfulSyncs() -> [UUID: Date] {
+    sessions.compactMapValues(\.lastSuccessfulSync)
+  }
+}

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -50,6 +50,9 @@ public final class SyncEngine {
   @ObservationIgnored private let registry: ServerSessionRegistry
   /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
   @ObservationIgnored private var sweepTask: Task<Void, Never>?
+  @ObservationIgnored private var observationTask: Task<Void, Never>?
+  /// Servers this engine has already accounted for, diffed to spot additions.
+  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
 
   /// Background warmth cadence for inactive servers — deliberately looser than
   /// the active path's 300 s reconcile throttle; these servers aren't on screen.
@@ -65,19 +68,39 @@ public final class SyncEngine {
     self.pathCost = pathCost
   }
 
+  deinit {
+    observationTask?.cancel()
+  }
+
   // MARK: - Public API
 
   /// Start reacting to the server table: a newly-appeared, non-active server
   /// gets a throttle-exempt initial sync.
   ///
-  /// The observation itself belongs to ``ServerSessionRegistry`` — it owns
-  /// session lifetime, and one observer of that table is the whole point. The
-  /// engine only supplies the *policy* for what an addition deserves.
+  /// The registry owns session lifetime and remains the sole observer of the
+  /// `server` table; the engine observes the set the registry *publishes*, and
+  /// supplies only the policy for what an addition deserves. `knownServerIDs`
+  /// is the engine's own state — "which servers have I already given an initial
+  /// sync" — not a second copy of lifecycle.
   public func start() {
-    registry.onServersChanged = { [weak self] current, previous in
-      self?.handleServersChanged(current: current, previous: previous)
-    }
     registry.start()
+    guard observationTask == nil else { return }
+    // Seed from what is already configured: servers present at launch are
+    // covered by the caller's explicit sweep, not by the newly-added path.
+    knownServerIDs = registry.serverIDs
+    observationTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+          _ = self?.registry.serverIDs
+        } onChange: {
+          continuation.yield()
+          continuation.finish()
+        }
+        self?.handleServersChanged()
+        for await _ in stream { break }
+      }
+    }
   }
 
   /// Sweep every inactive server once, sequentially (active-first is implicit —
@@ -138,9 +161,11 @@ public final class SyncEngine {
   /// Policy for a server that just appeared. Session creation and teardown
   /// already happened in the registry; all that is left is deciding what the
   /// addition deserves, which is `SyncPlan`'s call.
-  private func handleServersChanged(current: Set<UUID>, previous: Set<UUID>) {
+  private func handleServersChanged() {
+    let current = registry.serverIDs
     let added = SyncPlan.newlyAdded(
-      current: current, known: previous, activeID: manager.activeConnectionId)
+      current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
+    knownServerIDs = current
     if !added.isEmpty {
       Logger.sync.info("Observed \(added.count) new server(s); kicking initial sync")
     }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -2,13 +2,16 @@
 //  SyncEngine.swift
 //  AppShared
 //
-//  Stage 10 (multi-server sync): keeps every *inactive* configured server's
-//  offline cache warm. The active server is deliberately NOT touched here — it
-//  is driven by `DocumentStore` (its own `CachingRepository` instance), so the
-//  engine skips `activeConnectionId` to avoid two instances racing the same
-//  `query_order` rows. "Active-first" therefore falls out for free: the store
-//  syncs the active server on the same lifecycle trigger, and the engine sweeps
-//  the rest.
+//  Stage 10 (multi-server sync): keeps every configured server's offline cache
+//  warm. The sweep still *selects* the inactive ones — the active server is
+//  driven by `DocumentStore` on the same lifecycle trigger, so "active-first"
+//  falls out for free — but that is now an ordering choice, not a safety
+//  requirement. It used to be both: the store and the engine each built their
+//  own `CachingRepository`, so sweeping the active server meant two instances
+//  racing the same `query_order` rows, and the engine had to re-check
+//  `activeConnectionId` on every iteration to narrow the window. Servers now
+//  own their repositories through `ServerSession`, so a sweep that reaches the
+//  active server coalesces onto the session the store is already using.
 //
 //  Scheduling stays on app-lifecycle triggers (launch / foreground /
 //  active-change); true `BGProcessingTask` execution is Stage 11's.
@@ -18,6 +21,10 @@
 //  server's repository and runs the sequence. The interesting decisions (active
 //  exclusion, throttle, uncredentialed degrade, heavy-fill gating, new-server
 //  diff) live in the pure, unit-tested `DataModel.SyncPlan`.
+//
+//  It keeps no per-server state of its own: freshness stamps and in-flight work
+//  live on the sessions, which is what lets a background sweep and the on-screen
+//  store agree about a server without either consulting the other.
 //
 
 import Common
@@ -117,10 +124,11 @@ public final class SyncEngine {
       "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
     )
     for action in actions {
-      // Re-read per iteration: the action list was computed before the first
-      // `await`, so a server the user switched to mid-sweep would otherwise be
-      // swept here while `DocumentStore` drives it on the same server.
-      guard action.serverID != manager.activeConnectionId else { continue }
+      // No "skip the server that went active mid-sweep" guard any more: sweeping
+      // it now means driving the *same* `ServerSession` the store drives, which
+      // coalesces onto that session's per-phase single-flights instead of racing
+      // a second `CachingRepository`. The guard only ever narrowed that window;
+      // one owner per server closes it.
       guard let stored = manager.connections[action.serverID] else { continue }
       await runAction(action, stored: stored)
     }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -11,13 +11,13 @@
 //  the rest.
 //
 //  Scheduling stays on app-lifecycle triggers (launch / foreground /
-//  active-change); true `BGProcessingTask` execution is Stage 11's. When that
-//  lands, `runSweep`'s server enumeration should move from `manager.connections`
-//  (main-actor) to an off-main `database.allConnections()` read.
+//  active-change); true `BGProcessingTask` execution is Stage 11's.
 //
-//  The interesting decisions (active exclusion, throttle, uncredentialed
-//  degrade, heavy-fill gating, new-server diff) live in the pure, unit-tested
-//  `DataModel.SyncPlan`; this type is the imperative shell that executes them.
+//  This type is now purely the *scheduler*: it decides which servers to sync and
+//  in what order, and hands each one to its ``ServerSession``, which owns that
+//  server's repository and runs the sequence. The interesting decisions (active
+//  exclusion, throttle, uncredentialed degrade, heavy-fill gating, new-server
+//  diff) live in the pure, unit-tested `DataModel.SyncPlan`.
 //
 
 import Common
@@ -40,12 +40,16 @@ public final class SyncEngine {
   @ObservationIgnored private let pathCost:
     @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
 
-  /// Last successful sweep per server; drives the throttle. The active server is
-  /// never keyed here (never swept by the engine).
-  @ObservationIgnored private var lastSweep: [UUID: Date] = [:]
-  /// Per-server in-flight sync, so an observation-driven initial sync and a
-  /// lifecycle sweep for the same server coalesce onto one task.
-  @ObservationIgnored private var inFlight: [UUID: Task<Void, Never>] = [:]
+  /// One session per server, retained across sweeps.
+  ///
+  /// This replaces the parallel `inFlight` / `lastSweep` dictionaries that used
+  /// to live here: both were per-server state keyed by UUID, which is precisely
+  /// what a session *is*. Retaining them also means a server's repository —
+  /// and therefore its `activeFills` dedupe — survives from one sweep to the
+  /// next instead of being rebuilt and forgotten each time.
+  ///
+  /// The active server is never keyed here: it is `DocumentStore`'s to drive.
+  @ObservationIgnored private var sessions: [UUID: ServerSession] = [:]
   /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
   @ObservationIgnored private var sweepTask: Task<Void, Never>?
   /// Server IDs seen at the last observation tick, to detect newly-added ones.
@@ -80,8 +84,8 @@ public final class SyncEngine {
   ///
   /// This is wired to the *observation*, not the "Add server" UI action, so a
   /// Stage-12 UBKVS `server` upsert flows into the initial-sync path for free.
-  /// Removed servers need no work — the `server` row delete FK-cascades the whole
-  /// cache; the engine just drops their throttle/in-flight bookkeeping.
+  /// Removed servers need no cache work — the `server` row delete FK-cascades
+  /// the whole cache; the engine just drops their session.
   public func start() {
     guard observationTask == nil else { return }
     // Seed with the current set so the observation only reacts to *new* servers;
@@ -136,7 +140,7 @@ public final class SyncEngine {
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
       activeID: manager.activeConnectionId,
-      lastSweep: userInitiated ? [:] : lastSweep,
+      lastSweep: userInitiated ? [:] : lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       isExpensive: isExpensive,
@@ -158,11 +162,9 @@ public final class SyncEngine {
 
   private func handleConnectionsChanged() {
     let current = Set(manager.connections.keys)
-    // Drop bookkeeping for servers whose rows vanished (cache already cascaded).
+    // Drop the session of any server whose row vanished (cache already cascaded).
     for id in knownServerIDs.subtracting(current) {
-      inFlight[id]?.cancel()
-      inFlight[id] = nil
-      lastSweep[id] = nil
+      sessions.removeValue(forKey: id)?.invalidate()
     }
     let added = SyncPlan.newlyAdded(
       current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
@@ -188,97 +190,31 @@ public final class SyncEngine {
   // MARK: - Per-server execution
 
   private func runAction(_ action: SyncServerAction, stored: StoredConnection) async {
+    let session = session(for: stored.id)
     if action.needsAuthOnly {
-      // Config-synced-but-uncredentialed: mark per-server needs-auth and make no
-      // network call. Deterministic and cheap; when the token later lands, the
-      // next sweep picks it up. The 401 path stays a backstop for a rejected token.
-      Logger.sync.info(
-        "Server \(stored.logLabel, privacy: .public) uncredentialed; marking needs-auth (no sync)")
-      manager.markNeedsAuth(for: stored.id)
+      session.markNeedsAuth(stored)
       return
     }
-    if let existing = inFlight[stored.id] {
-      return await existing.value
-    }
-    let task = Task { @MainActor [weak self] in
-      guard let self else { return }
-      await performServerSync(stored, runHeavyFill: action.runHeavyFill)
-    }
-    inFlight[stored.id] = task
-    await task.value
-    inFlight[stored.id] = nil
+    await session.sync(stored: stored, runHeavyFill: action.runHeavyFill)
   }
 
-  /// Mirrors the active path's sequence (`DocumentStore.sync` + `reconcileDocuments`
-  /// + `fillLibraryIfEnabled` + `fillDocumentDetailsIfEnabled`) against an
-  /// ephemeral per-server backend. The whole body is caught so a per-server
-  /// failure (offline, rethrown 401, …) never escapes to sibling servers.
-  private func performServerSync(_ stored: StoredConnection, runHeavyFill: Bool) async {
-    let id = stored.id
-    Logger.sync.info(
-      "Syncing inactive server \(stored.logLabel, privacy: .public) (heavyFill: \(runHeavyFill))")
-    do {
-      let backend = try await makeCachingRepository(
-        for: stored, database: database, manager: manager, mode: mode)
+  // MARK: - Sessions
 
-      // Cheap tier (always, regardless of metered-ness): element sync + the
-      // reconcile sweeps (the last two self-gate on *Entire library*).
-      try await NetworkTransfer.$category.withValue(.sync) {
-        try await backend.syncElements()
-      }
-      // Each reconcile sweep carries its own catch, as on the active path
-      // (`DocumentStore.reconcileDocuments`): the deletion sweep is the most
-      // failure-prone of the three — it fetches the server's entire live id set
-      // — and under one shared `try` its failure took the freshness delta, the
-      // membership rebuild *and* the heavy fill down with it. Cancellation is
-      // the exception: it means the pass as a whole is unwanted, so it stops
-      // the remaining sweeps instead of being logged and stepped over.
-      var failed = false
-      var cancelled = false
-      func sweep(_ label: String, _ body: () async throws -> Void) async {
-        guard !cancelled else { return }
-        do {
-          try await body()
-        } catch {
-          guard !error.isCancellationError else {
-            Logger.sync.debug("Reconcile cancelled during \(label, privacy: .public)")
-            cancelled = true
-            return
-          }
-          Logger.sync.info(
-            "Reconcile sweep \(label, privacy: .public) failed (suppressed): \(error)")
-          failed = true
-        }
-      }
-      await NetworkTransfer.$category.withValue(.reconcile) {
-        await sweep("deletions") { try await backend.reconcileDocumentDeletions() }
-        await sweep("changes") { try await backend.reconcileDocumentChanges() }
-        await sweep("membership") { try await backend.reconcileSavedViewMembership() }
-      }
-
-      // Heavy tier: only on an unmetered *Entire library* server (SyncPlan gate).
-      if runHeavyFill, !cancelled {
-        try await NetworkTransfer.$category.withValue(.fill) {
-          try await backend.fillLibrary(force: false)
-          try await backend.fillDocumentDetails()
-        }
-      }
-
-      // Advance the throttle only on a *fully* successful pass — a sweep that
-      // failed or was called off partway retries on the next trigger.
-      guard !failed, !cancelled else {
-        Logger.sync.info(
-          "Inactive server \(stored.logLabel, privacy: .public) partially synced; throttle not advanced"
-        )
-        return
-      }
-      lastSweep[id] = Date()
-      Logger.sync.info("Inactive server \(stored.logLabel, privacy: .public) synced")
-    } catch {
-      Logger.sync.info(
-        "Inactive-server sync failed for \(stored.logLabel, privacy: .public) (suppressed): \(error)"
-      )
+  /// The server's session, created on first use. Sessions are cheap — a
+  /// repository is only assembled when something actually syncs.
+  private func session(for id: UUID) -> ServerSession {
+    if let existing = sessions[id] {
+      return existing
     }
+    let session = ServerSession(
+      serverID: id, database: database, manager: manager, mode: mode)
+    sessions[id] = session
+    return session
+  }
+
+  /// The throttle input `SyncPlan` consumes, projected out of the sessions.
+  private func lastSuccessfulSyncs() -> [UUID: Date] {
+    sessions.compactMapValues(\.lastSuccessfulSync)
   }
 
   // MARK: - Helpers

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -30,9 +30,7 @@ import os
 @MainActor
 @Observable
 public final class SyncEngine {
-  @ObservationIgnored private let database: Database
   @ObservationIgnored private let manager: ConnectionManager
-  @ObservationIgnored private let mode: ApiRepository.Mode
   /// Live raw path cost read for the observation-driven initial-sync path (the
   /// lifecycle-triggered sweep receives it as a parameter instead). Raw, not a
   /// decision — each server combines it with its own `syncOverCellular` via
@@ -40,70 +38,39 @@ public final class SyncEngine {
   @ObservationIgnored private let pathCost:
     @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
 
-  /// One session per server, retained across sweeps.
-  ///
-  /// This replaces the parallel `inFlight` / `lastSweep` dictionaries that used
-  /// to live here: both were per-server state keyed by UUID, which is precisely
-  /// what a session *is*. Retaining them also means a server's repository —
-  /// and therefore its `activeFills` dedupe — survives from one sweep to the
-  /// next instead of being rebuilt and forgotten each time.
-  ///
-  /// The active server is never keyed here: it is `DocumentStore`'s to drive.
-  @ObservationIgnored private var sessions: [UUID: ServerSession] = [:]
+  /// Where the per-server sessions live. The engine borrows them; it does not
+  /// own them, and it no longer keeps any per-server state of its own.
+  @ObservationIgnored private let registry: ServerSessionRegistry
   /// Whole-sweep single-flight, coalescing concurrent lifecycle triggers.
   @ObservationIgnored private var sweepTask: Task<Void, Never>?
-  /// Server IDs seen at the last observation tick, to detect newly-added ones.
-  @ObservationIgnored private var knownServerIDs: Set<UUID> = []
-  @ObservationIgnored private var observationTask: Task<Void, Never>?
 
   /// Background warmth cadence for inactive servers — deliberately looser than
   /// the active path's 300 s reconcile throttle; these servers aren't on screen.
   @ObservationIgnored private let inactiveThrottle: TimeInterval = 900
 
   public init(
-    database: Database,
+    registry: ServerSessionRegistry,
     manager: ConnectionManager,
-    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool),
-    mode: ApiRepository.Mode = Bundle.main.appConfiguration.mode
+    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
   ) {
-    self.database = database
+    self.registry = registry
     self.manager = manager
     self.pathCost = pathCost
-    self.mode = mode
-  }
-
-  deinit {
-    observationTask?.cancel()
   }
 
   // MARK: - Public API
 
-  /// Begin observing the `server` table (via `manager.connections`, which is the
-  /// sole projection of it). A newly-appeared, non-active server triggers a
-  /// throttle-exempt initial sync.
+  /// Start reacting to the server table: a newly-appeared, non-active server
+  /// gets a throttle-exempt initial sync.
   ///
-  /// This is wired to the *observation*, not the "Add server" UI action, so a
-  /// Stage-12 UBKVS `server` upsert flows into the initial-sync path for free.
-  /// Removed servers need no cache work — the `server` row delete FK-cascades
-  /// the whole cache; the engine just drops their session.
+  /// The observation itself belongs to ``ServerSessionRegistry`` — it owns
+  /// session lifetime, and one observer of that table is the whole point. The
+  /// engine only supplies the *policy* for what an addition deserves.
   public func start() {
-    guard observationTask == nil else { return }
-    // Seed with the current set so the observation only reacts to *new* servers;
-    // the servers present at launch are handled by the explicit sweep below.
-    knownServerIDs = Set(manager.connections.keys)
-    observationTask = Task { @MainActor [weak self] in
-      while !Task.isCancelled {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
-        withObservationTracking {
-          _ = self?.manager.connections.keys
-        } onChange: {
-          continuation.yield()
-          continuation.finish()
-        }
-        self?.handleConnectionsChanged()
-        for await _ in stream { break }
-      }
+    registry.onServersChanged = { [weak self] current, previous in
+      self?.handleServersChanged(current: current, previous: previous)
     }
+    registry.start()
   }
 
   /// Sweep every inactive server once, sequentially (active-first is implicit —
@@ -140,7 +107,7 @@ public final class SyncEngine {
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
       activeID: manager.activeConnectionId,
-      lastSweep: userInitiated ? [:] : lastSuccessfulSyncs(),
+      lastSweep: userInitiated ? [:] : registry.lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       isExpensive: isExpensive,
@@ -160,15 +127,12 @@ public final class SyncEngine {
     Logger.sync.info("Inactive sweep complete")
   }
 
-  private func handleConnectionsChanged() {
-    let current = Set(manager.connections.keys)
-    // Drop the session of any server whose row vanished (cache already cascaded).
-    for id in knownServerIDs.subtracting(current) {
-      sessions.removeValue(forKey: id)?.invalidate()
-    }
+  /// Policy for a server that just appeared. Session creation and teardown
+  /// already happened in the registry; all that is left is deciding what the
+  /// addition deserves, which is `SyncPlan`'s call.
+  private func handleServersChanged(current: Set<UUID>, previous: Set<UUID>) {
     let added = SyncPlan.newlyAdded(
-      current: current, known: knownServerIDs, activeID: manager.activeConnectionId)
-    knownServerIDs = current
+      current: current, known: previous, activeID: manager.activeConnectionId)
     if !added.isEmpty {
       Logger.sync.info("Observed \(added.count) new server(s); kicking initial sync")
     }
@@ -190,31 +154,12 @@ public final class SyncEngine {
   // MARK: - Per-server execution
 
   private func runAction(_ action: SyncServerAction, stored: StoredConnection) async {
-    let session = session(for: stored.id)
+    let session = registry.session(for: stored.id)
     if action.needsAuthOnly {
       session.markNeedsAuth(stored)
       return
     }
     await session.sync(stored: stored, runHeavyFill: action.runHeavyFill)
-  }
-
-  // MARK: - Sessions
-
-  /// The server's session, created on first use. Sessions are cheap — a
-  /// repository is only assembled when something actually syncs.
-  private func session(for id: UUID) -> ServerSession {
-    if let existing = sessions[id] {
-      return existing
-    }
-    let session = ServerSession(
-      serverID: id, database: database, manager: manager, mode: mode)
-    sessions[id] = session
-    return session
-  }
-
-  /// The throttle input `SyncPlan` consumes, projected out of the sessions.
-  private func lastSuccessfulSyncs() -> [UUID: Date] {
-    sessions.compactMapValues(\.lastSuccessfulSync)
   }
 
   // MARK: - Helpers

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -38,12 +38,16 @@ import os
 @Observable
 public final class SyncEngine {
   @ObservationIgnored private let manager: ConnectionManager
-  /// Live raw path cost read for the observation-driven initial-sync path (the
-  /// lifecycle-triggered sweep receives it as a parameter instead). Raw, not a
-  /// decision — each server combines it with its own `syncOverCellular` via
-  /// `SyncCondition`.
-  @ObservationIgnored private let pathCost:
-    @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
+  /// The current link cost, read live at the moment a sweep runs.
+  ///
+  /// A supplier rather than a parameter on ``syncInactiveServers(userInitiated:)``:
+  /// the engine used to accept the cost from its caller *and* hold this closure
+  /// for the observation-driven path, which meant four call sites each reaching
+  /// into the same monitor to hand back what the engine could already read —
+  /// and two sources that could disagree. Injecting it also keeps the engine
+  /// off `NetworkMonitor` directly, so a headless caller can supply a cost that
+  /// was measured some other way.
+  @ObservationIgnored private let linkCost: @MainActor () -> LinkCost
 
   /// Where the per-server sessions live. The engine borrows them; it does not
   /// own them, and it no longer keeps any per-server state of its own.
@@ -61,11 +65,11 @@ public final class SyncEngine {
   public init(
     registry: ServerSessionRegistry,
     manager: ConnectionManager,
-    pathCost: @escaping @MainActor () -> (isExpensive: Bool, isConstrained: Bool)
+    linkCost: @escaping @MainActor () -> LinkCost
   ) {
     self.registry = registry
     self.manager = manager
-    self.pathCost = pathCost
+    self.linkCost = linkCost
   }
 
   deinit {
@@ -108,16 +112,13 @@ public final class SyncEngine {
   /// failure never affects the others. Coalesces concurrent callers.
   ///
   /// `userInitiated` bypasses the per-server throttle (explicit "sync now").
-  public func syncInactiveServers(
-    isExpensive: Bool, isConstrained: Bool, userInitiated: Bool = false
-  ) async {
+  public func syncInactiveServers(userInitiated: Bool = false) async {
     if let sweepTask {
       return await sweepTask.value
     }
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
-      await runSweep(
-        isExpensive: isExpensive, isConstrained: isConstrained, userInitiated: userInitiated)
+      await runSweep(cost: linkCost(), userInitiated: userInitiated)
     }
     sweepTask = task
     await task.value
@@ -126,7 +127,7 @@ public final class SyncEngine {
 
   // MARK: - Sweep
 
-  private func runSweep(isExpensive: Bool, isConstrained: Bool, userInitiated: Bool) async {
+  private func runSweep(cost: LinkCost, userInitiated: Bool) async {
     let snapshots = manager.connections.values.map { conn in
       SyncPlan.ServerSnapshot(
         id: conn.id,
@@ -140,11 +141,10 @@ public final class SyncEngine {
       lastSweep: userInitiated ? [:] : registry.lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
-      isExpensive: isExpensive,
-      isConstrained: isConstrained)
+      cost: cost)
 
     Logger.sync.info(
-      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (isExpensive: \(isExpensive), isConstrained: \(isConstrained), userInitiated: \(userInitiated))"
+      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (expensive: \(cost.isExpensive), constrained: \(cost.isConstrained), userInitiated: \(userInitiated))"
     )
     for action in actions {
       // No "skip the server that went active mid-sweep" guard any more: sweeping
@@ -172,15 +172,13 @@ public final class SyncEngine {
     for id in added {
       guard let stored = manager.connections[id] else { continue }
       // Throttle-exempt initial sync for a freshly-appeared server.
-      let cost = pathCost()
-      let condition = SyncCondition(
-        isExpensive: cost.isExpensive, isConstrained: cost.isConstrained,
-        syncOverCellular: stored.syncOverCellular)
       let action = SyncServerAction(
         serverID: stored.id,
         needsAuthOnly: !hasToken(stored),
-        phases: condition.allowsProactiveSync && stored.offlineBrowsingMode == .entireLibrary
-          ? .full : .cheap)
+        phases: SyncPlan.phases(
+          isEntireLibrary: stored.offlineBrowsingMode == .entireLibrary,
+          condition: SyncCondition(
+            cost: linkCost(), syncOverCellular: stored.syncOverCellular)))
       Task { @MainActor [weak self] in await self?.runAction(action, stored: stored) }
     }
   }

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -179,7 +179,8 @@ public final class SyncEngine {
       let action = SyncServerAction(
         serverID: stored.id,
         needsAuthOnly: !hasToken(stored),
-        runHeavyFill: condition.allowsProactiveSync && stored.offlineBrowsingMode == .entireLibrary)
+        phases: condition.allowsProactiveSync && stored.offlineBrowsingMode == .entireLibrary
+          ? .full : .cheap)
       Task { @MainActor [weak self] in await self?.runAction(action, stored: stored) }
     }
   }
@@ -192,7 +193,7 @@ public final class SyncEngine {
       session.markNeedsAuth(stored)
       return
     }
-    await session.sync(stored: stored, runHeavyFill: action.runHeavyFill)
+    await session.sync(stored: stored, phases: action.phases)
   }
 
   // MARK: - Helpers

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -111,14 +111,20 @@ public final class SyncEngine {
   /// active is excluded and driven by the store), each isolated so one server's
   /// failure never affects the others. Coalesces concurrent callers.
   ///
-  /// `userInitiated` bypasses the per-server throttle (explicit "sync now").
-  public func syncInactiveServers(userInitiated: Bool = false) async {
+  /// There is deliberately no throttle-bypassing "user initiated" sweep. The
+  /// only explicit sync control in the app is Offline & Sync's *Sync now*, and
+  /// that screen is per-server — it sits directly under that server's mode
+  /// picker and cellular toggle — so a button there reaching out to touch the
+  /// *other* servers would be the surprising reading. The flag that used to be
+  /// here was never passed by anyone, and a caller that had passed it would
+  /// have silently lost its intent by joining an in-flight automatic sweep.
+  public func syncInactiveServers() async {
     if let sweepTask {
       return await sweepTask.value
     }
     let task = Task { @MainActor [weak self] in
       guard let self else { return }
-      await runSweep(cost: linkCost(), userInitiated: userInitiated)
+      await runSweep(cost: linkCost())
     }
     sweepTask = task
     await task.value
@@ -127,7 +133,7 @@ public final class SyncEngine {
 
   // MARK: - Sweep
 
-  private func runSweep(cost: LinkCost, userInitiated: Bool) async {
+  private func runSweep(cost: LinkCost) async {
     let snapshots = manager.connections.values.map { conn in
       SyncPlan.ServerSnapshot(
         id: conn.id,
@@ -138,13 +144,13 @@ public final class SyncEngine {
     let actions = SyncPlan.inactiveActions(
       connections: snapshots,
       activeID: manager.activeConnectionId,
-      lastSweep: userInitiated ? [:] : registry.lastSuccessfulSyncs(),
+      lastSweep: registry.lastSuccessfulSyncs(),
       now: Date(),
       throttle: inactiveThrottle,
       cost: cost)
 
     Logger.sync.info(
-      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (expensive: \(cost.isExpensive), constrained: \(cost.isConstrained), userInitiated: \(userInitiated))"
+      "Inactive sweep: \(actions.count) of \(snapshots.count) server(s) (expensive: \(cost.isExpensive), constrained: \(cost.isConstrained))"
     )
     for action in actions {
       // No "skip the server that went active mid-sweep" guard any more: sweeping

--- a/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/ConnectionsView.swift
@@ -92,7 +92,6 @@ public struct ConnectionSelectionMenu: View {
 
 public struct ConnectionsView: View {
   private var connectionManager: ConnectionManager
-  private let database: Database
   @Binding public var showLoginSheet: Bool
 
   @ScaledMetric(relativeTo: .title) private var plusIconSize = 18.0
@@ -108,11 +107,8 @@ public struct ConnectionsView: View {
 
   @Environment(DocumentStore.self) private var store
 
-  public init(
-    connectionManager: ConnectionManager, database: Database, showLoginSheet: Binding<Bool>
-  ) {
+  public init(connectionManager: ConnectionManager, showLoginSheet: Binding<Bool>) {
     self.connectionManager = connectionManager
-    self.database = database
     _extraHeaders = State(initialValue: connectionManager.storedConnection?.extraHeaders ?? [])
     _showLoginSheet = showLoginSheet
   }
@@ -131,11 +127,11 @@ public struct ConnectionsView: View {
           // flipping the flag (and 401s are suppressed on the assumption the
           // connection banner covers them), and the caching wrapper because the
           // store detaches its ElementStore projection from any repository that
-          // fronts no database. `activate` owns that assembly, so this call site
-          // can no longer get it wrong.
+          // fronts no database. The server's session owns that assembly, so this
+          // call site can no longer get it wrong — and the header edit reaches the
+          // *same* repository the SyncEngine drives, rather than a second one.
           do {
-            try await store.activate(
-              connection: stored, database: database, manager: connectionManager)
+            try await store.activate(connection: stored)
           } catch {
             Logger.shared.error(
               "Could not rebuild repository after extra header change: \(error)")

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -41,13 +41,13 @@ public struct OfflineSyncView: View {
   /// question `SyncPlan` answers for every other server, asked here rather than
   /// re-derived, so this screen can't disagree with the sweep about its own
   /// server. Absent monitor (the SettingsView preview injects none) reads as an
-  /// unmetered link.
+  /// unrestricted link, so the preview renders the ordinary state rather than
+  /// the "waiting for Wi-Fi" one.
   private var plannedPhases: SyncPhases {
     SyncPlan.phases(
       isEntireLibrary: mode == .entireLibrary,
       condition: SyncCondition(
-        isExpensive: networkMonitor?.isExpensive ?? false,
-        isConstrained: networkMonitor?.isConstrained ?? false,
+        cost: networkMonitor?.cost ?? .unrestricted,
         syncOverCellular: connectionManager.activeSyncOverCellular))
   }
 

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -37,12 +37,18 @@ public struct OfflineSyncView: View {
   // on the connection record). The setting is per-server.
   private var mode: OfflineBrowsingMode { connectionManager.activeOfflineBrowsingMode }
 
-  private var unmetered: Bool {
-    guard let networkMonitor else { return true }
-    return SyncCondition(
-      isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
-      syncOverCellular: connectionManager.activeSyncOverCellular
-    ).allowsProactiveSync
+  /// What a proactive pass on the active server would run right now — the same
+  /// question `SyncPlan` answers for every other server, asked here rather than
+  /// re-derived, so this screen can't disagree with the sweep about its own
+  /// server. Absent monitor (the SettingsView preview injects none) reads as an
+  /// unmetered link.
+  private var plannedPhases: SyncPhases {
+    SyncPlan.phases(
+      isEntireLibrary: mode == .entireLibrary,
+      condition: SyncCondition(
+        isExpensive: networkMonitor?.isExpensive ?? false,
+        isConstrained: networkMonitor?.isConstrained ?? false,
+        syncOverCellular: connectionManager.activeSyncOverCellular))
   }
 
   /// Suggest the greedy mode only when it is actually cheap. A new server starts
@@ -60,7 +66,7 @@ public struct OfflineSyncView: View {
   /// difference between "nothing to do" and "not now", which the screen used to
   /// render identically as Idle.
   private var waitingForNetwork: Bool {
-    mode == .entireLibrary && !unmetered && !store.isSyncing
+    mode == .entireLibrary && !plannedPhases.contains(.fill) && !store.isSyncing
   }
 
   public var body: some View {
@@ -81,7 +87,7 @@ public struct OfflineSyncView: View {
               } else {
                 connectionManager.setOfflineBrowsingMode(newMode)
                 if newMode == .entireLibrary {
-                  Task { await store.fillLibraryIfEnabled(unmetered: unmetered, force: true) }
+                  Task { await store.fillIfEnabled(phases: plannedPhases, force: true) }
                 }
               }
             })
@@ -185,7 +191,7 @@ public struct OfflineSyncView: View {
         Button {
           Task {
             // Explicit user action: bypass the reconcile throttle and the
-            // unmetered gate, and force a re-fill ignoring the freshness marker.
+            // link gate, and force a re-fill ignoring the freshness marker.
             //
             // `userInitiated` exists precisely so this rethrows instead of
             // failing soft into `lastSyncError`; swallowing it here left a
@@ -197,11 +203,11 @@ public struct OfflineSyncView: View {
             } catch {
               errorController.push(error: error)
             }
-            await store.fillLibraryIfEnabled(unmetered: true, force: true)
-            // Both lifecycle paths pair the library fill with the detail fill;
-            // without this, notes and file metadata could only ever be filled by
-            // backgrounding and foregrounding the app.
-            await store.fillDocumentDetailsIfEnabled(unmetered: true)
+            // `.full` rather than the planned phases: this is the user asking
+            // for the work outright, so the link gate doesn't apply. Saying so
+            // in the phase set beats claiming the network is unmetered when it
+            // isn't.
+            await store.fillIfEnabled(phases: .full, force: true)
           }
         } label: {
           // Explicit `foregroundStyle`, not just `.disabled`: a `Label`'s icon

--- a/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
+++ b/AppShared/Sources/AppShared/Views/Settings/OfflineSyncView.swift
@@ -25,6 +25,12 @@ public struct OfflineSyncView: View {
   /// status. Only used to decide whether to suggest *Entire library*.
   @State private var libraryTotal: UInt?
 
+  /// Whether *this* button's action is still running. `store.isSyncing` covers
+  /// work the session has in flight, but there are brief moments between the
+  /// phases this action drives where no slot is occupied; without this the
+  /// button would blink back to enabled part-way through its own run.
+  @State private var syncNowRunning = false
+
   public init() {}
 
   // The active server's mode, read/written through ConnectionManager (persisted
@@ -42,6 +48,10 @@ public struct OfflineSyncView: View {
   /// Suggest the greedy mode only when it is actually cheap. A new server starts
   /// at *Recently browsed* whatever its size — downloading a whole library is
   /// the user's call — so this is where the size heuristic earns its keep.
+  /// Work is running — this button's own action, or anything else driving the
+  /// active server's session (a lifecycle sweep, a background run).
+  private var syncNowBusy: Bool { syncNowRunning || store.isSyncing }
+
   private var recommendsEntireLibrary: Bool {
     mode == .recentlyBrowsed && OfflineLibrarySize.isSmall(documentCount: libraryTotal)
   }
@@ -50,7 +60,7 @@ public struct OfflineSyncView: View {
   /// difference between "nothing to do" and "not now", which the screen used to
   /// render identically as Idle.
   private var waitingForNetwork: Bool {
-    mode == .entireLibrary && !unmetered && store.syncActivities.isEmpty
+    mode == .entireLibrary && !unmetered && !store.isSyncing
   }
 
   public var body: some View {
@@ -180,6 +190,8 @@ public struct OfflineSyncView: View {
             // `userInitiated` exists precisely so this rethrows instead of
             // failing soft into `lastSyncError`; swallowing it here left a
             // "Sync now" that looked identical whether it worked or not.
+            syncNowRunning = true
+            defer { syncNowRunning = false }
             do {
               try await store.sync(userInitiated: true)
             } catch {
@@ -192,11 +204,16 @@ public struct OfflineSyncView: View {
             await store.fillDocumentDetailsIfEnabled(unmetered: true)
           }
         } label: {
+          // Explicit `foregroundStyle`, not just `.disabled`: a `Label`'s icon
+          // in a `Form` row button doesn't pick up the row's disabled dimming
+          // the way its text does, so a disabled row otherwise reads as a
+          // grayed-out title next to a still-accent-coloured icon.
           Label(String(localized: .settings(.offlineSyncNow)), systemImage: "arrow.clockwise")
+            .foregroundStyle(syncNowBusy ? Color.secondary : Color.accentColor)
         }
-        // Any sweep, not just the library fill: the detail fill left this
-        // enabled, so a second pass could be stacked on a running one.
-        .disabled(!store.syncActivities.isEmpty)
+        // Any work on this server, not just the library fill: the detail fill
+        // left this enabled, so a second pass could be stacked on a running one.
+        .disabled(syncNowBusy)
       } header: {
         Text(.settings(.offlineSyncStatusHeader))
       }

--- a/AppShared/Sources/AppShared/Views/Tags/TagView.swift
+++ b/AppShared/Sources/AppShared/Views/Tags/TagView.swift
@@ -212,5 +212,5 @@ private func tag(_ id: UInt, _ name: String, _ color: Color) -> Tag {
 #Preview("Placeholder") {
   TagsView()
     .redacted(reason: .placeholder)
-    .environment(DocumentStore(repository: NullRepository()))
+    .environment(DocumentStore.preview())
 }

--- a/DataModel/Sources/DataModel/LinkCost.swift
+++ b/DataModel/Sources/DataModel/LinkCost.swift
@@ -1,0 +1,43 @@
+//
+//  LinkCost.swift
+//  DataModel
+//
+
+/// What the current network path costs, as one value.
+///
+/// A type rather than a pair of `Bool`s because the two facts are only ever
+/// meaningful together, and travelled together anyway: from the path monitor,
+/// through the scheduler, into ``SyncCondition``. Passed loose they were
+/// re-packed at every hop, and each hop was free to drop one, reorder them, or
+/// invent a default — which is how a "cost" ends up being a policy in disguise.
+///
+/// This is a *fact about the link*, and nothing more. What to do about it is
+/// ``SyncCondition``'s to say, because that also needs the server's own opt-in,
+/// which is not a property of the network.
+public struct LinkCost: Equatable, Sendable {
+  /// The path is metered — cellular, or a personal hotspot.
+  public var isExpensive: Bool
+  /// Low Data Mode is on for this network.
+  public var isConstrained: Bool
+
+  public init(isExpensive: Bool, isConstrained: Bool) {
+    self.isExpensive = isExpensive
+    self.isConstrained = isConstrained
+  }
+
+  /// Wi‑Fi or wired, no Low Data Mode: proactive work may run freely.
+  public static let unrestricted = LinkCost(isExpensive: false, isConstrained: false)
+
+  /// The stand-in for a link nobody could measure — no path monitor is running,
+  /// or none has reported yet.
+  ///
+  /// Deliberately the most restrictive value there is: guessing "cheap" spends
+  /// the user's data plan on a guess, where guessing "costly" only defers work
+  /// to the next trigger. It used to appear as a bare `(true, true)` tuple with
+  /// no name and no reason given.
+  ///
+  /// Behaviourally indistinguishable from a genuinely restricted link today.
+  /// Telling the two apart only becomes possible once something can actually
+  /// probe the path — until then there is nothing a caller could do differently.
+  public static let unknown = LinkCost(isExpensive: true, isConstrained: true)
+}

--- a/DataModel/Sources/DataModel/SyncActivity.swift
+++ b/DataModel/Sources/DataModel/SyncActivity.swift
@@ -15,7 +15,7 @@ import Foundation
 /// equally be stuck.
 ///
 /// Several of these run at once, so the store publishes *all* of them rather
-/// than picking one — see `AppShared.DocumentStore.syncActivities`.
+/// than picking one — see `AppShared.ServerSession.syncActivities`.
 ///
 /// In `DataModel` rather than `AppShared` for the same reason as
 /// ``OfflineLibrarySize``: the ordering rule is easy to regress silently and

--- a/DataModel/Sources/DataModel/SyncCondition.swift
+++ b/DataModel/Sources/DataModel/SyncCondition.swift
@@ -13,16 +13,15 @@
 /// Interactive work the user asked for (opening a document, pull-to-refresh,
 /// search, "Sync now") is never gated on this.
 public struct SyncCondition: Equatable, Sendable {
-  /// The network path is metered (cellular, or a personal hotspot).
-  public var isExpensive: Bool
-  /// Low Data Mode is on for the current network.
-  public var isConstrained: Bool
-  /// This server's own opt-in to proactive syncing on a metered link.
+  /// What the path costs — a fact about the network, measured elsewhere.
+  public var cost: LinkCost
+  /// This server's own opt-in to proactive syncing on a metered link — a
+  /// setting, and the reason this type exists separately from ``LinkCost``:
+  /// two servers on the same link can legitimately answer differently.
   public var syncOverCellular: Bool
 
-  public init(isExpensive: Bool, isConstrained: Bool, syncOverCellular: Bool) {
-    self.isExpensive = isExpensive
-    self.isConstrained = isConstrained
+  public init(cost: LinkCost, syncOverCellular: Bool) {
+    self.cost = cost
     self.syncOverCellular = syncOverCellular
   }
 
@@ -30,6 +29,6 @@ public struct SyncCondition: Equatable, Sendable {
   /// the whole system, not a guess about the link, so the per-server opt-in
   /// does not override it. The opt-in is what `isExpensive` alone is for.
   public var allowsProactiveSync: Bool {
-    isConstrained ? false : (syncOverCellular || !isExpensive)
+    cost.isConstrained ? false : (syncOverCellular || !cost.isExpensive)
   }
 }

--- a/DataModel/Sources/DataModel/SyncPhase.swift
+++ b/DataModel/Sources/DataModel/SyncPhase.swift
@@ -1,0 +1,62 @@
+//
+//  SyncPhase.swift
+//  DataModel
+//
+
+/// One unit of sync work for a single server.
+///
+/// Cases are declared in **dependency order**, and ``SyncPhases/ordered``
+/// relies on that: the reconcile needs the saved views the element sync brings
+/// down, and the fill pages rows the reconcile has already settled. A new phase
+/// must be inserted where it belongs in the sequence rather than appended.
+public enum SyncPhase: Int, Sendable, Equatable, CaseIterable, Comparable {
+  /// Tags, correspondents, saved views… — the element collections.
+  case elements
+  /// Remote deletes, the changed-metadata delta, saved-view membership.
+  case reconcile
+  /// The proactive *Entire library* fill: every query's pages, then the
+  /// per-document details.
+  case fill
+
+  public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// The phases a sync pass should run.
+///
+/// A set rather than a sequence, deliberately: *which* work to do is a decision
+/// (``SyncPlan`` makes it, from the server's mode and the link), but the order
+/// to do it in is not a caller's choice at all. ``ordered`` is the single
+/// canonical sequence, so no caller can run a phase before one it depends on —
+/// which used to be upheld only by every call site happening to agree.
+public struct SyncPhases: Sendable, Equatable, ExpressibleByArrayLiteral {
+  private var storage: Set<SyncPhase>
+
+  public init(_ phases: some Sequence<SyncPhase>) {
+    storage = Set(phases)
+  }
+
+  public init(arrayLiteral elements: SyncPhase...) {
+    storage = Set(elements)
+  }
+
+  /// Elements plus the reconcile sweeps: what every sync does, regardless of
+  /// the server's offline mode or how expensive the link is.
+  public static let cheap: Self = [.elements, .reconcile]
+
+  /// The cheap phases plus the proactive fill.
+  public static let full: Self = [.elements, .reconcile, .fill]
+
+  /// No network work at all — an uncredentialed server.
+  ///
+  /// Not spelled `none`: that shadows `Optional.none`, and every use site here
+  /// is a context where an optional is also plausible, so the compiler cannot
+  /// tell which one a bare `.none` means.
+  public static let nothing: Self = []
+
+  public var isEmpty: Bool { storage.isEmpty }
+
+  public func contains(_ phase: SyncPhase) -> Bool { storage.contains(phase) }
+
+  /// The phases in dependency order.
+  public var ordered: [SyncPhase] { storage.sorted() }
+}

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -94,14 +94,30 @@ public enum SyncPlan {
         if let last = lastSweep[server.id], now.timeIntervalSince(last) < throttle {
           return nil  // still fresh — skip the network sweep
         }
-        let condition = SyncCondition(
-          isExpensive: isExpensive, isConstrained: isConstrained,
-          syncOverCellular: server.syncOverCellular)
         return SyncServerAction(
           serverID: server.id,
           needsAuthOnly: false,
-          phases: condition.allowsProactiveSync && server.isEntireLibrary ? .full : .cheap)
+          phases: phases(
+            isEntireLibrary: server.isEntireLibrary,
+            condition: SyncCondition(
+              isExpensive: isExpensive, isConstrained: isConstrained,
+              syncOverCellular: server.syncOverCellular)))
       }
+  }
+
+  /// The phases one credentialed server should run.
+  ///
+  /// Shared by both drivers: the sweep reaches it through ``inactiveActions``,
+  /// and the active server — which `DocumentStore` drives directly, outside any
+  /// sweep — calls it itself. One function means the server the user is looking
+  /// at cannot drift onto a different rule than its siblings, which is exactly
+  /// what a `Bool` computed afresh at each call site invited.
+  ///
+  /// The mode gate is here as well as in the executor (which re-reads the
+  /// server's mode from the database before filling) on purpose: this is the
+  /// copy that is unit-tested, and the executor's is a guard, not a decision.
+  public static func phases(isEntireLibrary: Bool, condition: SyncCondition) -> SyncPhases {
+    condition.allowsProactiveSync && isEntireLibrary ? .full : .cheap
   }
 
   /// Server IDs that appeared since the last observation tick and warrant an

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -80,8 +80,7 @@ public enum SyncPlan {
     lastSweep: [UUID: Date],
     now: Date,
     throttle: TimeInterval,
-    isExpensive: Bool,
-    isConstrained: Bool
+    cost: LinkCost
   ) -> [SyncServerAction] {
     connections
       .filter { $0.id != activeID }
@@ -100,8 +99,7 @@ public enum SyncPlan {
           phases: phases(
             isEntireLibrary: server.isEntireLibrary,
             condition: SyncCondition(
-              isExpensive: isExpensive, isConstrained: isConstrained,
-              syncOverCellular: server.syncOverCellular)))
+              cost: cost, syncOverCellular: server.syncOverCellular)))
       }
   }
 

--- a/DataModel/Sources/DataModel/SyncPlan.swift
+++ b/DataModel/Sources/DataModel/SyncPlan.swift
@@ -21,16 +21,20 @@ public struct SyncServerAction: Equatable, Sendable {
   /// network call — never fail the whole engine.
   public let needsAuthOnly: Bool
 
-  /// Run the heavy proactive fill (`fillLibrary` + `fillDocumentDetails`) in
-  /// addition to the always-run cheap tier (`syncElements` + reconcile). Only
-  /// true on an unmetered path for an *Entire library* server. Implies a token
-  /// is present (`needsAuthOnly == false`).
-  public let runHeavyFill: Bool
+  /// The work this server should do, already decided: the fill is present only
+  /// on an unmetered path for an *Entire library* server. Empty when
+  /// `needsAuthOnly` — there is nothing to run without a credential.
+  ///
+  /// A phase set rather than a "heavy fill?" flag so the executor receives a
+  /// *decision* rather than the inputs to one, and so a new kind of work
+  /// (document binaries, OCR content, thumbnails) is a new case here rather
+  /// than another boolean threaded through every layer.
+  public let phases: SyncPhases
 
-  public init(serverID: UUID, needsAuthOnly: Bool, runHeavyFill: Bool) {
+  public init(serverID: UUID, needsAuthOnly: Bool, phases: SyncPhases) {
     self.serverID = serverID
     self.needsAuthOnly = needsAuthOnly
-    self.runHeavyFill = runHeavyFill
+    self.phases = phases
   }
 }
 
@@ -65,7 +69,7 @@ public enum SyncPlan {
   ///   sweep).
   /// - Credentialed servers are dropped while their last successful sweep is
   ///   still within `throttle`; otherwise they yield a sync action whose
-  ///   `runHeavyFill` is gated on `isEntireLibrary &&` that server's own
+  ///   the `.fill` phase is gated on `isEntireLibrary &&` that server's own
   ///   ``SyncCondition/allowsProactiveSync`` — each server's own
   ///   `syncOverCellular` opt-in applies to *that* server only, not the whole
   ///   sweep.
@@ -85,7 +89,7 @@ public enum SyncPlan {
       .compactMap { server in
         guard server.hasToken else {
           // Uncredentialed: mark needs-auth every sweep (no network, no throttle).
-          return SyncServerAction(serverID: server.id, needsAuthOnly: true, runHeavyFill: false)
+          return SyncServerAction(serverID: server.id, needsAuthOnly: true, phases: .nothing)
         }
         if let last = lastSweep[server.id], now.timeIntervalSince(last) < throttle {
           return nil  // still fresh — skip the network sweep
@@ -96,7 +100,7 @@ public enum SyncPlan {
         return SyncServerAction(
           serverID: server.id,
           needsAuthOnly: false,
-          runHeavyFill: condition.allowsProactiveSync && server.isEntireLibrary)
+          phases: condition.allowsProactiveSync && server.isEntireLibrary ? .full : .cheap)
       }
   }
 

--- a/DataModel/Tests/DataModelTests/SyncConditionTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncConditionTests.swift
@@ -9,33 +9,50 @@ import Testing
 
 @Suite
 struct SyncConditionTests {
+  @Test("An unmeasurable link is treated as the most restrictive one there is")
+  func unknownDeniesProactiveSync() {
+    // The fallback used to be an unnamed `(true, true)` tuple at the one call
+    // site that had it. Pinned here so the conservative choice is a decision
+    // the tests defend, not an accident of how a closure was written.
+    #expect(!SyncCondition(cost: .unknown, syncOverCellular: true).allowsProactiveSync)
+    #expect(!SyncCondition(cost: .unknown, syncOverCellular: false).allowsProactiveSync)
+  }
+
   @Test("An unmetered link always allows proactive sync, opt-in or not")
   func unmeteredAlwaysAllowed() {
     #expect(
-      SyncCondition(isExpensive: false, isConstrained: false, syncOverCellular: false)
-        .allowsProactiveSync)
+      SyncCondition(
+        cost: .unrestricted, syncOverCellular: false
+      )
+      .allowsProactiveSync)
     #expect(
-      SyncCondition(isExpensive: false, isConstrained: false, syncOverCellular: true)
-        .allowsProactiveSync)
+      SyncCondition(
+        cost: .unrestricted, syncOverCellular: true
+      )
+      .allowsProactiveSync)
   }
 
   @Test("An expensive link requires the opt-in")
   func expensiveRequiresOptIn() {
     #expect(
-      !SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: false)
-        .allowsProactiveSync)
+      !SyncCondition(
+        cost: LinkCost(isExpensive: true, isConstrained: false), syncOverCellular: false
+      )
+      .allowsProactiveSync)
     #expect(
-      SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: true)
+      SyncCondition(cost: LinkCost(isExpensive: true, isConstrained: false), syncOverCellular: true)
         .allowsProactiveSync)
   }
 
   @Test("Low Data Mode always wins, regardless of the opt-in or link cost")
   func constrainedAlwaysWins() {
     #expect(
-      !SyncCondition(isExpensive: false, isConstrained: true, syncOverCellular: true)
-        .allowsProactiveSync)
+      !SyncCondition(
+        cost: LinkCost(isExpensive: false, isConstrained: true), syncOverCellular: true
+      )
+      .allowsProactiveSync)
     #expect(
-      !SyncCondition(isExpensive: true, isConstrained: true, syncOverCellular: true)
+      !SyncCondition(cost: LinkCost(isExpensive: true, isConstrained: true), syncOverCellular: true)
         .allowsProactiveSync)
   }
 }

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -32,7 +32,7 @@ struct SyncPlanTests {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.a), snapshot(Self.b)],
       activeID: Self.a, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: false, isConstrained: false)
+      cost: .unrestricted)
     #expect(actions.map(\.serverID) == [Self.b])
   }
 
@@ -41,7 +41,7 @@ struct SyncPlanTests {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.c), snapshot(Self.a), snapshot(Self.b)],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: false, isConstrained: false)
+      cost: .unrestricted)
     #expect(actions.map(\.serverID) == [Self.a, Self.b, Self.c])
   }
 
@@ -51,7 +51,7 @@ struct SyncPlanTests {
       connections: [snapshot(Self.a), snapshot(Self.b)],
       activeID: nil,
       lastSweep: [Self.a: now.addingTimeInterval(-(throttle - 1))],
-      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
+      now: now, throttle: throttle, cost: .unrestricted)
     #expect(actions.map(\.serverID) == [Self.b])
   }
 
@@ -61,7 +61,7 @@ struct SyncPlanTests {
       connections: [snapshot(Self.a)],
       activeID: nil,
       lastSweep: [Self.a: now.addingTimeInterval(-(throttle + 1))],
-      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
+      now: now, throttle: throttle, cost: .unrestricted)
     #expect(actions.map(\.serverID) == [Self.a])
   }
 
@@ -72,7 +72,7 @@ struct SyncPlanTests {
       activeID: nil,
       // Even "recently swept" it must re-emit so a freshly-arrived token is caught.
       lastSweep: [Self.a: now],
-      now: now, throttle: throttle, isExpensive: false, isConstrained: false)
+      now: now, throttle: throttle, cost: .unrestricted)
     #expect(
       actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, phases: .nothing)])
   }
@@ -83,7 +83,7 @@ struct SyncPlanTests {
       SyncPlan.inactiveActions(
         connections: [snapshot(Self.a, isEntireLibrary: entire)],
         activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-        isExpensive: isExpensive, isConstrained: false
+        cost: LinkCost(isExpensive: isExpensive, isConstrained: false)
       ).first!.phases.contains(.fill)
     }
     #expect(heavy(isExpensive: false, entire: true))
@@ -102,7 +102,7 @@ struct SyncPlanTests {
         snapshot(Self.b, isEntireLibrary: true, syncOverCellular: false),
       ],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: true, isConstrained: false)
+      cost: LinkCost(isExpensive: true, isConstrained: false))
     #expect(actions.first(where: { $0.serverID == Self.a })?.phases.contains(.fill) == true)
     #expect(actions.first(where: { $0.serverID == Self.b })?.phases.contains(.fill) == false)
   }
@@ -112,7 +112,7 @@ struct SyncPlanTests {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.a, isEntireLibrary: true, syncOverCellular: true)],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: true, isConstrained: true)
+      cost: LinkCost(isExpensive: true, isConstrained: true))
     #expect(actions.first?.phases.contains(.fill) == false)
   }
 
@@ -121,7 +121,7 @@ struct SyncPlanTests {
     let actions = SyncPlan.inactiveActions(
       connections: [snapshot(Self.a, isEntireLibrary: true)],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: true, isConstrained: false)
+      cost: LinkCost(isExpensive: true, isConstrained: false))
     #expect(actions.count == 1)
     #expect(actions.first?.needsAuthOnly == false)
     #expect(actions.first?.phases.contains(.fill) == false)
@@ -149,9 +149,11 @@ struct SyncPlanTests {
   @Test("Both gates must pass for the fill to be planned")
   func fillNeedsModeAndLink() {
     let unmetered = SyncCondition(
-      isExpensive: false, isConstrained: false, syncOverCellular: false)
+      cost: .unrestricted,
+      syncOverCellular: false)
     let metered = SyncCondition(
-      isExpensive: true, isConstrained: false, syncOverCellular: false)
+      cost: LinkCost(isExpensive: true, isConstrained: false),
+      syncOverCellular: false)
 
     #expect(SyncPlan.phases(isEntireLibrary: true, condition: unmetered) == .full)
     #expect(SyncPlan.phases(isEntireLibrary: true, condition: metered) == .cheap)
@@ -161,13 +163,17 @@ struct SyncPlanTests {
 
   @Test("A server's own cellular opt-in reinstates the fill on a metered link")
   func cellularOptInPlansTheFill() {
-    let opted = SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: true)
+    let opted = SyncCondition(
+      cost: LinkCost(isExpensive: true, isConstrained: false),
+      syncOverCellular: true)
     #expect(SyncPlan.phases(isEntireLibrary: true, condition: opted) == .full)
   }
 
   @Test("The cheap phases are never dropped, however hostile the link")
   func cheapPhasesAlwaysRun() {
-    let worst = SyncCondition(isExpensive: true, isConstrained: true, syncOverCellular: true)
+    let worst = SyncCondition(
+      cost: LinkCost(isExpensive: true, isConstrained: true), syncOverCellular: true
+    )
     let phases = SyncPlan.phases(isEntireLibrary: true, condition: worst)
     #expect(phases.contains(.elements))
     #expect(phases.contains(.reconcile))
@@ -183,14 +189,15 @@ struct SyncPlanTests {
         snapshot(Self.c, isEntireLibrary: false),
       ],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
-      isExpensive: true, isConstrained: false)
+      cost: LinkCost(isExpensive: true, isConstrained: false))
 
     for action in actions {
       let server = [Self.a: false, Self.b: true, Self.c: false][action.serverID]!
       let expected = SyncPlan.phases(
         isEntireLibrary: action.serverID != Self.c,
         condition: SyncCondition(
-          isExpensive: true, isConstrained: false, syncOverCellular: server))
+          cost: LinkCost(isExpensive: true, isConstrained: false),
+          syncOverCellular: server))
       #expect(action.phases == expected)
     }
   }

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -74,7 +74,7 @@ struct SyncPlanTests {
       lastSweep: [Self.a: now],
       now: now, throttle: throttle, isExpensive: false, isConstrained: false)
     #expect(
-      actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, runHeavyFill: false)])
+      actions == [SyncServerAction(serverID: Self.a, needsAuthOnly: true, phases: .nothing)])
   }
 
   @Test("Heavy fill requires both an allowed link and entireLibrary")
@@ -84,7 +84,7 @@ struct SyncPlanTests {
         connections: [snapshot(Self.a, isEntireLibrary: entire)],
         activeID: nil, lastSweep: [:], now: now, throttle: throttle,
         isExpensive: isExpensive, isConstrained: false
-      ).first!.runHeavyFill
+      ).first!.phases.contains(.fill)
     }
     #expect(heavy(isExpensive: false, entire: true))
     #expect(!heavy(isExpensive: false, entire: false))
@@ -103,8 +103,8 @@ struct SyncPlanTests {
       ],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
       isExpensive: true, isConstrained: false)
-    #expect(actions.first(where: { $0.serverID == Self.a })?.runHeavyFill == true)
-    #expect(actions.first(where: { $0.serverID == Self.b })?.runHeavyFill == false)
+    #expect(actions.first(where: { $0.serverID == Self.a })?.phases.contains(.fill) == true)
+    #expect(actions.first(where: { $0.serverID == Self.b })?.phases.contains(.fill) == false)
   }
 
   @Test("Low Data Mode blocks the heavy fill even for a server opted into cellular")
@@ -113,7 +113,7 @@ struct SyncPlanTests {
       connections: [snapshot(Self.a, isEntireLibrary: true, syncOverCellular: true)],
       activeID: nil, lastSweep: [:], now: now, throttle: throttle,
       isExpensive: true, isConstrained: true)
-    #expect(actions.first?.runHeavyFill == false)
+    #expect(actions.first?.phases.contains(.fill) == false)
   }
 
   @Test("Metered entireLibrary still runs the cheap tier (action present, heavy off)")
@@ -124,7 +124,7 @@ struct SyncPlanTests {
       isExpensive: true, isConstrained: false)
     #expect(actions.count == 1)
     #expect(actions.first?.needsAuthOnly == false)
-    #expect(actions.first?.runHeavyFill == false)
+    #expect(actions.first?.phases.contains(.fill) == false)
   }
 
   @Test("newlyAdded returns only genuinely new, non-active ids")
@@ -138,5 +138,23 @@ struct SyncPlanTests {
   func newlyAddedExcludesActive() {
     let added = SyncPlan.newlyAdded(current: [Self.a], known: [], activeID: Self.a)
     #expect(added.isEmpty)
+  }
+}
+
+@Suite("Sync phases")
+struct SyncPhasesTests {
+  @Test("ordered is dependency order regardless of how the set was built")
+  func orderedIsCanonical() {
+    #expect(SyncPhases([.fill, .elements, .reconcile]).ordered == [.elements, .reconcile, .fill])
+    #expect(SyncPhases([.fill, .elements]).ordered == [.elements, .fill])
+  }
+
+  @Test("cheap omits the fill, full includes it")
+  func presets() {
+    #expect(!SyncPhases.cheap.contains(.fill))
+    #expect(SyncPhases.cheap.contains(.elements))
+    #expect(SyncPhases.cheap.contains(.reconcile))
+    #expect(SyncPhases.full.contains(.fill))
+    #expect(SyncPhases.nothing.isEmpty)
   }
 }

--- a/DataModel/Tests/DataModelTests/SyncPlanTests.swift
+++ b/DataModel/Tests/DataModelTests/SyncPlanTests.swift
@@ -139,6 +139,61 @@ struct SyncPlanTests {
     let added = SyncPlan.newlyAdded(current: [Self.a], known: [], activeID: Self.a)
     #expect(added.isEmpty)
   }
+
+  // MARK: - The shared phase rule
+
+  // `phases` is what both drivers ask: the sweep through `inactiveActions`, the
+  // active server directly from the store's callers. These pin the rule itself,
+  // so a change to it can't quietly apply to only one of them.
+
+  @Test("Both gates must pass for the fill to be planned")
+  func fillNeedsModeAndLink() {
+    let unmetered = SyncCondition(
+      isExpensive: false, isConstrained: false, syncOverCellular: false)
+    let metered = SyncCondition(
+      isExpensive: true, isConstrained: false, syncOverCellular: false)
+
+    #expect(SyncPlan.phases(isEntireLibrary: true, condition: unmetered) == .full)
+    #expect(SyncPlan.phases(isEntireLibrary: true, condition: metered) == .cheap)
+    #expect(SyncPlan.phases(isEntireLibrary: false, condition: unmetered) == .cheap)
+    #expect(SyncPlan.phases(isEntireLibrary: false, condition: metered) == .cheap)
+  }
+
+  @Test("A server's own cellular opt-in reinstates the fill on a metered link")
+  func cellularOptInPlansTheFill() {
+    let opted = SyncCondition(isExpensive: true, isConstrained: false, syncOverCellular: true)
+    #expect(SyncPlan.phases(isEntireLibrary: true, condition: opted) == .full)
+  }
+
+  @Test("The cheap phases are never dropped, however hostile the link")
+  func cheapPhasesAlwaysRun() {
+    let worst = SyncCondition(isExpensive: true, isConstrained: true, syncOverCellular: true)
+    let phases = SyncPlan.phases(isEntireLibrary: true, condition: worst)
+    #expect(phases.contains(.elements))
+    #expect(phases.contains(.reconcile))
+    #expect(!phases.contains(.fill))
+  }
+
+  @Test("The sweep plans each server by the same rule the active server uses")
+  func sweepAgreesWithTheSharedRule() {
+    let actions = SyncPlan.inactiveActions(
+      connections: [
+        snapshot(Self.a, isEntireLibrary: true),
+        snapshot(Self.b, isEntireLibrary: true, syncOverCellular: true),
+        snapshot(Self.c, isEntireLibrary: false),
+      ],
+      activeID: nil, lastSweep: [:], now: now, throttle: throttle,
+      isExpensive: true, isConstrained: false)
+
+    for action in actions {
+      let server = [Self.a: false, Self.b: true, Self.c: false][action.serverID]!
+      let expected = SyncPlan.phases(
+        isEntireLibrary: action.serverID != Self.c,
+        condition: SyncCondition(
+          isExpensive: true, isConstrained: false, syncOverCellular: server))
+      #expect(action.phases == expected)
+    }
+  }
 }
 
 @Suite("Sync phases")

--- a/ShareExtension/ShareView.swift
+++ b/ShareExtension/ShareView.swift
@@ -14,16 +14,8 @@ import os
 struct ShareView: View {
   @ObservedObject var attachmentManager: AttachmentManager
 
-  // The extension process's own Database (app-group SQLite, WAL). The same DB
-  // backs the `ConnectionManager` and — wrapped in a `CachingRepository` in
-  // `refreshConnection` — the element cache, so the store's `ElementStore`
-  // projection observes the extension's own writes. Cross-process live
-  // notification isn't delivered (the extension syncs at launch), but the
-  // extension's in-process writes drive its own observation normally.
-  private let database: Database
-
   @State private var connectionManager: ConnectionManager
-  @State private var store = DocumentStore(repository: NullRepository())
+  @State private var store: DocumentStore
   @State private var storeReady = false
 
   @StateObject private var errorController = ErrorController()
@@ -35,9 +27,22 @@ struct ShareView: View {
   init(attachmentManager: AttachmentManager, callback: @escaping () -> Void) {
     self.attachmentManager = attachmentManager
     self.callback = callback
+    // The extension process's own Database (app-group SQLite, WAL). The same DB
+    // backs the `ConnectionManager` and — through the session's
+    // `CachingRepository` — the element cache, so the store's `ElementStore`
+    // projection observes the extension's own writes. Cross-process live
+    // notification isn't delivered (the extension syncs at launch), but the
+    // extension's in-process writes drive its own observation normally.
     let database = Self.bootstrapDatabase()
-    self.database = database
-    _connectionManager = State(initialValue: ConnectionManager(database: database))
+    let connectionManager = ConnectionManager(database: database)
+    _connectionManager = State(initialValue: connectionManager)
+    // The extension keeps the same one-session-per-server rule as the app, in a
+    // process that has no `SyncEngine` to share those sessions with. The registry
+    // is retained by the store; it is never `start()`ed, because an extension has
+    // no reason to react to connection edits made elsewhere.
+    _store = State(
+      initialValue: DocumentStore(
+        registry: ServerSessionRegistry(database: database, manager: connectionManager)))
   }
 
   // Open the app-group SQLite file. If the bootstrap fails (corrupt file,
@@ -94,11 +99,10 @@ struct ShareView: View {
         store.events.emit(.repositoryWillChange)
         // Caching outermost, over the extension's own DB, so the store's
         // ElementStore projection observes the writes its sync performs. The
-        // store owns that assembly (see `DocumentStore.activate`), so the
-        // extension can't drift from the app's layering.
+        // server's session owns that assembly (see `DocumentStore.activate`), so
+        // the extension can't drift from the app's layering.
         do {
-          try await store.activate(
-            connection: stored, database: database, manager: connectionManager)
+          try await store.activate(connection: stored)
         } catch {
           Logger.api.error("Could not build repository for active connection: \(error)")
           return

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -23,3 +23,5 @@
 - Background sync and an open document list downloading at the same time no longer leave gaps in a cached list
 - A document you no longer have permission to view is no longer served from the offline cache as though the server were unreachable
 - A failed cleanup of documents deleted on the server no longer stops the rest of the offline refresh
+- Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
+- Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -25,3 +25,4 @@
 - A failed cleanup of documents deleted on the server no longer stops the rest of the offline refresh
 - Switching to another server no longer throws away the offline download already running for the one you left; it keeps going in the background instead of starting over next time you switch back
 - Data used by the background library download is now counted under its own category in the Offline & Sync transfer statistics, instead of being lumped into "Other"
+- Switching a server to "Entire library" now starts downloading document notes and file metadata straight away, instead of waiting until the next time you reopen the app

--- a/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
+++ b/swift-paperless/Views/Document/Detail/DocumentMetadataView.swift
@@ -141,8 +141,8 @@ struct DocumentMetadataView: View {
 // - MARK: Preview
 
 #Preview {
-  @Previewable @State var store = DocumentStore(
-    repository: PreviewRepository(downloadDelay: 3.0))
+  @Previewable @State var store = DocumentStore.preview(
+    PreviewRepository(downloadDelay: 3.0))
   @Previewable @StateObject var errorController = ErrorController()
 
   @Previewable @State var document: Document?

--- a/swift-paperless/Views/Settings/SettingsView.swift
+++ b/swift-paperless/Views/Settings/SettingsView.swift
@@ -21,17 +21,9 @@ struct SettingsView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(NetworkMonitor.self) private var networkMonitor: NetworkMonitor?
 
-  /// Threaded down to ``ConnectionsView`` so it can rebuild the full caching
-  /// repository stack when the active connection's extra headers change.
-  private let database: Database
-
   @State private var feedbackMailRequest: FeedbackMailRequest?
   @State private var showLoginSheet: Bool = false
   @State var identityManager = IdentityManager()
-
-  init(database: Database) {
-    self.database = database
-  }
 
   private func checked(_ fn: @escaping () async throws -> Void) async {
     do {
@@ -237,7 +229,6 @@ struct SettingsView: View {
       Form {
         ConnectionsView(
           connectionManager: connectionManager,
-          database: database,
           showLoginSheet: $showLoginSheet)
 
         Section(String(localized: .settings(.preferences))) {
@@ -300,14 +291,13 @@ struct SettingsView: View {
 #Preview("SettingsView") {
   @Previewable @State var store = DocumentStore.preview()
   @Previewable @StateObject var errorController = ErrorController()
-  @Previewable @State var database = try! Database.inMemory()
   @Previewable @State var connectionManager = ConnectionManager(
     database: try! Database.inMemory())
 
   VStack {
   }
   .sheet(isPresented: .constant(true)) {
-    SettingsView(database: database)
+    SettingsView()
       .environment(store)
       .environment(connectionManager)
   }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -24,6 +24,11 @@ struct MainView: View {
 
   @State private var manager: ConnectionManager
 
+  // Owns one ServerSession per configured server, for the lifetime of its row.
+  // Held here rather than inside the engine because it is the process's single
+  // source of per-server repositories, not a scheduling detail.
+  @State private var sessionRegistry: ServerSessionRegistry
+
   // Keeps every *inactive* server's offline cache warm (Stage 10). The active
   // server stays on the DocumentStore path; the engine skips it.
   @State private var syncEngine: SyncEngine
@@ -61,9 +66,11 @@ struct MainView: View {
     // Raw path cost, read live so the engine's observation-driven initial
     // sync gates on the current link — same source `isUnmetered` below reads,
     // combined per-server via `SyncCondition` rather than folded here.
+    let sessionRegistry = ServerSessionRegistry(database: database, manager: manager)
+    _sessionRegistry = State(wrappedValue: sessionRegistry)
     _syncEngine = State(
       wrappedValue: SyncEngine(
-        database: database,
+        registry: sessionRegistry,
         manager: manager,
         pathCost: { [weak networkMonitor] in
           guard let networkMonitor else { return (isExpensive: true, isConstrained: true) }

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -63,19 +63,17 @@ struct MainView: View {
     _manager = State(wrappedValue: manager)
     let errorController = ErrorController()
     let networkMonitor = NetworkMonitor()
-    // Raw path cost, read live so the engine's observation-driven initial
-    // sync gates on the current link — same source `isUnmetered` below reads,
-    // combined per-server via `SyncCondition` rather than folded here.
     let sessionRegistry = ServerSessionRegistry(database: database, manager: manager)
     _sessionRegistry = State(wrappedValue: sessionRegistry)
     _syncEngine = State(
       wrappedValue: SyncEngine(
         registry: sessionRegistry,
         manager: manager,
-        pathCost: { [weak networkMonitor] in
-          guard let networkMonitor else { return (isExpensive: true, isConstrained: true) }
-          return (networkMonitor.isExpensive, networkMonitor.isConstrained)
-        }))
+        // Read live, per sweep, so the engine gates on the link as it is when
+        // the work starts rather than when the app launched. Each server
+        // combines it with its own opt-in via `SyncCondition`; the engine never
+        // folds it into a single answer for all of them.
+        linkCost: { [weak networkMonitor] in networkMonitor?.cost ?? .unknown }))
     errorController.suppressBannerCoveredErrors(networkMonitor: networkMonitor)
     _errorController = StateObject(wrappedValue: errorController)
     _networkMonitor = State(initialValue: networkMonitor)
@@ -174,14 +172,13 @@ struct MainView: View {
   /// server's own cellular opt-in (Low Data Mode always wins — see
   /// `SyncCondition`).
   ///
-  /// The sweep resolves its servers' conditions itself — hand it raw path cost
-  /// (`networkMonitor.isExpensive`/`.isConstrained`), not this.
+  /// The sweep resolves its servers' conditions itself, from its own live cost
+  /// read — it needs nothing from here.
   private var activePhases: SyncPhases {
     SyncPlan.phases(
       isEntireLibrary: manager.activeOfflineBrowsingMode == .entireLibrary,
       condition: SyncCondition(
-        isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
-        syncOverCellular: manager.activeSyncOverCellular))
+        cost: networkMonitor.cost, syncOverCellular: manager.activeSyncOverCellular))
   }
 
   /// Fire-and-forget the proactive *Entire library* fill (no-op when disabled,
@@ -397,8 +394,7 @@ struct MainView: View {
       // inactive server's cache (the active server was just synced above).
       syncEngine.start()
       Task {
-        await syncEngine.syncInactiveServers(
-          isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
+        await syncEngine.syncInactiveServers()
       }
     }
 
@@ -408,8 +404,7 @@ struct MainView: View {
         Task {
           await refreshConnection(animated: animated)
           // The just-deactivated server is now inactive: sweep it (and the rest).
-          await syncEngine.syncInactiveServers(
-            isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
+          await syncEngine.syncInactiveServers()
         }
       case .logout:
         showLoginScreen = true
@@ -444,8 +439,7 @@ struct MainView: View {
           }
           // Warm the inactive servers alongside the active refresh.
           Task {
-            await syncEngine.syncInactiveServers(
-              isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained)
+            await syncEngine.syncInactiveServers()
           }
         }
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -167,16 +167,21 @@ struct MainView: View {
     }
   }
 
-  /// The gate for the *active* server's heavy proactive fill (cheap reconcile
-  /// sweeps run regardless). Wi‑Fi‑ish by default, unless the active server has
-  /// been opted in to cellular; Low Data Mode always wins. See `SyncCondition`.
-  /// The inactive-server sweep resolves this per-server itself — pass it raw
-  /// path cost (`networkMonitor.isExpensive`/`.isConstrained`), not this.
-  private var isUnmetered: Bool {
-    SyncCondition(
-      isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
-      syncOverCellular: manager.activeSyncOverCellular
-    ).allowsProactiveSync
+  /// What a proactive pass on the *active* server should run right now — asked
+  /// of `SyncPlan`, the same way the inactive-server sweep asks it, so the
+  /// server on screen is planned by the same rule as the ones that aren't.
+  /// The cheap phases are always in; `.fill` depends on the link and this
+  /// server's own cellular opt-in (Low Data Mode always wins — see
+  /// `SyncCondition`).
+  ///
+  /// The sweep resolves its servers' conditions itself — hand it raw path cost
+  /// (`networkMonitor.isExpensive`/`.isConstrained`), not this.
+  private var activePhases: SyncPhases {
+    SyncPlan.phases(
+      isEntireLibrary: manager.activeOfflineBrowsingMode == .entireLibrary,
+      condition: SyncCondition(
+        isExpensive: networkMonitor.isExpensive, isConstrained: networkMonitor.isConstrained,
+        syncOverCellular: manager.activeSyncOverCellular))
   }
 
   /// Fire-and-forget the proactive *Entire library* fill (no-op when disabled,
@@ -184,8 +189,7 @@ struct MainView: View {
   /// scenePhase path chains it after `sync()` directly.
   private func kickLibraryFill(_ store: DocumentStore, force: Bool = false) {
     Task {
-      await store.fillLibraryIfEnabled(unmetered: isUnmetered, force: force)
-      await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+      await store.fillIfEnabled(phases: activePhases, force: force)
     }
   }
 
@@ -435,8 +439,7 @@ struct MainView: View {
           if let store {
             Task {
               try? await store.sync()
-              await store.fillLibraryIfEnabled(unmetered: isUnmetered)
-              await store.fillDocumentDetailsIfEnabled(unmetered: isUnmetered)
+              await store.fillIfEnabled(phases: activePhases)
             }
           }
           // Warm the inactive servers alongside the active refresh.

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -212,13 +212,13 @@ struct MainView: View {
         return
       }
 
-      // The store assembles the active server's stack itself (identical to the
-      // per-server stacks the SyncEngine builds for inactive servers), so both the
-      // reuse and the first-launch path go through one entry point. A fresh store
-      // starts on `NullRepository` and is only published once `activate` succeeds —
-      // otherwise a failed login would leave a detached store installed.
+      // The store activates onto the *same* session the SyncEngine sweeps this
+      // server with, so the active and inactive paths share one repository rather
+      // than racing two. A fresh store starts serverless (`NullRepository`) and is
+      // only published once `activate` succeeds — otherwise a failed login would
+      // leave a detached store installed.
       let isNewStore = store == nil
-      let target = store ?? DocumentStore(repository: NullRepository())
+      let target = store ?? DocumentStore(registry: sessionRegistry)
 
       if !isNewStore {
         await sleep(.seconds(0.1))
@@ -227,7 +227,7 @@ struct MainView: View {
       }
 
       do {
-        try await target.activate(connection: stored, database: database, manager: manager)
+        try await target.activate(connection: stored)
       } catch {
         Logger.api.error("Could not build repository for active connection: \(error)")
         storeReady = false
@@ -367,7 +367,7 @@ struct MainView: View {
 
     .sheet(isPresented: $showSettings) {
       if let store {
-        SettingsView(database: database)
+        SettingsView()
           .environment(manager)
           .environment(store)
           .environment(networkMonitor)


### PR DESCRIPTION
This pull request refactors the `DocumentStore` to delegate server ownership and sync responsibilities to a `ServerSession`, improving separation of concerns and preventing multiple owners from driving the same server. The store now activates and syncs through a session, rather than directly managing repositories and sync tasks. This enables more robust handling of server switching, progress reporting, and background tasks.

Key changes include:

**Session Ownership and Activation:**

* `DocumentStore` now holds a reference to a `ServerSession` (or a registry to obtain one) instead of directly owning a repository, and exposes the repository via a computed property that reads from the session. The store is constructed either with a session (for previews/tests) or a registry (for production). [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L148-R167) [[2]](diffhunk://#diff-cfd0bb6a054df08870aa9bda104e7cc9b2204aba2ebb6204ba5340e821a6c725L51-R54)
* The `activate(connection:)` method now obtains and prepares a session from the registry, and swaps the session via a new `install(session:reload:)` method, rather than swapping repositories directly.

**Sync and Progress Reporting:**

* Sync activities (`syncActivities`, `isSyncing`, `lastReconcileAt`) are now projections from the session, not state managed by the store. This ensures the UI reflects background or scheduler-initiated syncs, not just those initiated by the store.
* The element sync and reconcile logic now runs through the session (`session.syncElements()`, `session.reconcileDocuments(force:)`), and the previous coalescing/cancellation logic in the store is removed. [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L480-R518) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L523-L554)

**Repository and Backend Access:**

* All code paths that previously downcast the store's repository to a `CachingBackend` now access the backend via the session (`session?.backend`). [[1]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L214-R220) [[2]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L815-R801) [[3]](diffhunk://#diff-2f7b34a418ea1f6972b552ed9fe8da0466ab897fa87ef7940f2fc850a7d84f70L834-R813)

**Lifecycle and Memory Management:**

* The store no longer cancels in-flight sync or fill tasks when switching servers; these tasks are now owned by the outgoing session and allowed to complete. This prevents wasted work and improves consistency when switching servers mid-operation.

**Preview and Test Support:**

* The preview initializer for `DocumentStore` is updated to use a session, matching the production code path and ensuring consistent ownership semantics.

These changes collectively improve the reliability and maintainability of server activation, sync, and progress reporting in the app.

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

<details>
<summary>10 merged PRs</summary>

- ~~#591 refactor/wire-domain-split~~ (merged)
- ~~#592 feat/document-versions~~ (merged)
- ~~#595 feat/persistence-foundation~~ (merged)
- ~~#596 refactor/observable-document-store~~ (merged)
- ~~#653 fix/api-version-reprobe~~ (merged)
- ~~#597 feat/element-cache-records~~ (merged)
- ~~#598 feat/element-cache-source-of-truth~~ (merged)
- ~~#600 feat/document-cache-source-of-truth~~ (merged)
- ~~#617 feat/offline-entire-library~~ (merged)
- ~~#620 fix/pdf-preview-cache-latency~~ (merged)

</details>

- #618 feat/multi-server-sync
- #685 refactor/server-session-ownership  👈
- #627 feat/background-sync
<!-- /jjp:stack-nav -->
