### PR TITLE
fix: stop CachingRepository blocking the main thread on SQLite

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -52,8 +52,13 @@ extension DocumentStore {
     // ownership path production does, and there is no `init(repository:)` for
     // production code to reach for.
     let store = DocumentStore(session: ServerSession(serverID: serverID, repository: caching))
-    store.projection?.refreshUISettings()
-    Task { try? await store.sync() }
+    // Both awaits, so both go in the task: a preview builds its store in a
+    // property initializer and cannot await. The projection repaints as soon as
+    // the read lands, which for an in-memory seed is immediate.
+    Task {
+      await store.projection?.refreshUISettings()
+      try? await store.sync()
+    }
     return store
   }
 

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -451,8 +451,8 @@ public final class DocumentStore: Sendable {
     await fetchTasks()
   }
 
-  /// Refresh `ui_settings` (permissions/settings) from the network, then
-  /// synchronously pull the singleton into the projection — the one path
+  /// Refresh `ui_settings` (permissions/settings) from the network, then pull
+  /// the singleton into the projection before returning — the one path
   /// (`DocumentListViewModel.load`) that reads `permissions` immediately
   /// afterwards can't wait for the observation's runloop hop. Automatic (not
   /// user-initiated): a sync failure fails soft and we proceed with the cached
@@ -461,7 +461,7 @@ public final class DocumentStore: Sendable {
     try await sync()
     // Re-read after the await: a switch during the sync means the projection to
     // refresh is the new server's, and it reads its own database and serverID.
-    projection?.refreshUISettings()
+    await projection?.refreshUISettings()
   }
 
   /// Network → DB via the caching backend; the live element observation repaints
@@ -878,9 +878,14 @@ extension DocumentStore {
   /// PDF/thumbnail blobs, and the in-memory and on-disk image caches — while
   /// keeping the configured server connections. The live observations repaint
   /// empty immediately; the next sync / list open refills from the network.
-  public func wipeLocalCache() throws {
+  ///
+  /// `async` because `clearCache` is a cache-table write and no longer offers a
+  /// blocking form (see the rule in `Database+Connections`) — a `DELETE` across
+  /// every cache table is exactly the kind of transaction that must not sit on
+  /// the main thread.
+  public func wipeLocalCache() async throws {
     if let backend = session?.backend {
-      try backend.database.clearCache()
+      try await backend.database.clearCache()
     }
     // Downloaded originals/archives/thumbnails (app-group blob store). Rooted at
     // the app group, so a fresh handle addresses the same files the repository

--- a/AppShared/Sources/AppShared/Document/ServerProjection.swift
+++ b/AppShared/Sources/AppShared/Document/ServerProjection.swift
@@ -129,13 +129,13 @@ public final class ServerProjection {
     observationTasks.cancelAll()
   }
 
-  /// Synchronously pull the `ui_settings` singleton from the DB into the
-  /// projection, for the one caller (`DocumentStore.fetchUISettings`) that reads
-  /// `permissions` immediately after a refresh and cannot wait for the
-  /// observation's runloop hop. The observation will re-emit the same values
-  /// harmlessly.
-  func refreshUISettings() {
-    guard let uiSettings = try? database.uiSettings(serverID: serverID) else { return }
+  /// Pull the `ui_settings` singleton from the DB into the projection, for the
+  /// one caller (`DocumentStore.fetchUISettings`) that reads `permissions`
+  /// immediately after a refresh and cannot wait for the observation's runloop
+  /// hop. The observation will re-emit the same values harmlessly. Awaits rather
+  /// than blocks: `ui_settings` is a cache table (see `Database+Connections`).
+  func refreshUISettings() async {
+    guard let uiSettings = try? await database.uiSettings(serverID: serverID) else { return }
     apply(uiSettings)
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -128,9 +128,12 @@ public protocol CachingBackend: AnyObject, Sendable {
   var database: Database { get }
   var serverID: UUID { get }
 
-  /// This server's offline browsing mode (per-server; read live from
-  /// ``OfflineBrowsingModeStore``). The reconcile sweeps and the proactive fill
-  /// branch on it.
+  /// This server's offline browsing mode (per-server; read live from the
+  /// `server` row). The reconcile sweeps and the proactive fill branch on it.
+  ///
+  /// Stays synchronous: `server` is the one table whose accessors may block
+  /// (see the rule in `Database+Connections`), and this is a single-row read of
+  /// a handful of rows.
   var offlineBrowsingMode: OfflineBrowsingMode { get }
 }
 
@@ -325,7 +328,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         do {
           let batch = try await source.fetch(limit: pageSize)
           let total = await source.totalCount
-          try database.writeQueryPage(
+          try await database.writeQueryPage(
             queryKey: key, serverID: serverID, documents: batch,
             startPosition: 0, totalCount: total, replaceAll: true)
           position = batch.count
@@ -354,7 +357,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           // may already have landed — writing here would graft our stale
           // positions onto its rows.
           try Task.checkCancellation()
-          try database.writeQueryPage(
+          try await database.writeQueryPage(
             queryKey: key, serverID: serverID, documents: batch,
             startPosition: position, totalCount: await source.totalCount,
             replaceAll: false)
@@ -365,7 +368,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // membership, and only here is that recorded. Page 1's `replaceAll`
         // cleared the stamp, so anything that stopped us short leaves the key
         // marked incomplete for the next pass to redo.
-        try database.markQueryFillComplete(queryKey: key, serverID: serverID)
+        try await database.markQueryFillComplete(queryKey: key, serverID: serverID)
       }
     }
 
@@ -418,8 +421,10 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   private func isFilling(_ key: QueryKey) -> Bool { activeFills[key] != nil }
 
   public func fillLibrary(force: Bool, progress: SyncProgressReporter?) async throws {
-    guard force || !LibraryCoverage.isFresh(try? database.libraryCoverageAt(serverID: serverID))
-    else { return }
+    // Read the marker before the guard rather than inside it: `||`'s right-hand
+    // side is an `@autoclosure`, which cannot be `async`.
+    let coverage = try? await database.libraryCoverageAt(serverID: serverID)
+    guard force || !LibraryCoverage.isFresh(coverage) else { return }
 
     // Claim the stage before the saved-view read, so the setup isn't a gap the
     // screen renders as "Idle".
@@ -430,7 +435,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // just before this in the foreground trigger). Build the *same* FilterState
     // the UI observes so the filled QueryKeys match its subscriptions. A `nil`
     // name denotes the default list (used to label a failure for the UI).
-    let savedViews = try database.elements(SavedViewRecord.self, serverID: serverID)
+    let savedViews = try await database.elements(SavedViewRecord.self, serverID: serverID)
     let views: [(name: String?, filter: FilterState)] =
       [(nil, .default)] + savedViews.map { ($0.name, FilterState(savedView: $0)) }
 
@@ -473,7 +478,9 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // would stamp the coverage marker and suppress the retry for a day,
         // leaving the list hard-stopped at whatever page it reached — with the
         // count pill still claiming the server's full total.
-        guard (try? database.queryFillCompletedAt(queryKey: key, serverID: serverID)) ?? nil != nil
+        guard
+          (try? await database.queryFillCompletedAt(queryKey: key, serverID: serverID))
+            ?? nil != nil
         else {
           // A backstop, not the main path: the fill throws on every way of
           // stopping short, so reaching here means the stamp and the outcome
@@ -484,7 +491,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           )
           continue
         }
-        try? database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
+        try? await database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
         succeeded += 1
       } catch is CancellationError {
         throw CancellationError()
@@ -494,7 +501,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // Offline & Sync screen can warn, and carry on.
         Logger.sync.warning(
           "Library fill: '\(name ?? "default", privacy: .public)' failed (\(error)); skipping")
-        try? database.recordQuerySyncError(
+        try? await database.recordQuerySyncError(
           serverID: serverID, queryKey: key.rawValue, savedViewName: name,
           message: Self.syncFailureMessage(error))
       }
@@ -511,7 +518,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         "Library fill: all \(views.count, privacy: .public) views failed; leaving coverage unset")
       return
     }
-    try? database.setLibraryCoverageAt(Date(), serverID: serverID)
+    try? await database.setLibraryCoverageAt(Date(), serverID: serverID)
   }
 
   // Documents whose detail fetch failed this session. Without this, a document
@@ -530,7 +537,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Free step: every zero-note document gets an empty notes row from the list
     // payload's count — no request — so it renders "no notes" offline and drops
     // out of the fetch set below.
-    let seeded = (try? database.seedEmptyNotesForZeroCountDocuments(serverID: serverID)) ?? 0
+    let seeded = (try? await database.seedEmptyNotesForZeroCountDocuments(serverID: serverID)) ?? 0
 
     // Then fetch only what's genuinely missing, capped per pass. `try?` per doc
     // so one failure (or going offline mid-pass) doesn't abort the rest; the
@@ -543,16 +550,16 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // fill asks for every noted document's `/notes/` and takes a 403 each time —
     // one doomed request per document, on every foreground, forever. `nil` (no
     // cached matrix yet) stays optimistic, matching `syncElements`.
-    let permissions = try? database.uiSettings(serverID: serverID)?.permissions
+    let permissions = try? await database.uiSettings(serverID: serverID)?.permissions
     let canViewNotes = permissions?.test(.view, for: .note) ?? true
 
     try await NetworkTransfer.$category.withValue(.fill) {
       let missingMetadata =
-        (try? database.documentIDsMissingFileMetadata(
+        (try? await database.documentIDsMissingFileMetadata(
           serverID: serverID, excluding: detailFillFailures)) ?? []
-      let needsNotes =
+      let needsNotes: [UInt] =
         canViewNotes
-        ? (try? database.documentIDsNeedingNotesFetch(
+        ? (try? await database.documentIDsNeedingNotesFetch(
           serverID: serverID, excluding: detailFillFailures)) ?? []
         : []
 
@@ -617,7 +624,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   ) async throws {
     do {
       let domains = try await fetch()
-      try database.replaceElements(domains, of: type, serverID: serverID)
+      try await database.replaceElements(domains, of: type, serverID: serverID)
     } catch let error where Self.isSkippable(error) {
       Logger.sync.info(
         "Skipping \(R.databaseTableName, privacy: .public) sync: \(error)")
@@ -632,19 +639,19 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   private func syncUISettings() async -> UserPermissions? {
     do {
       let settings = try await wrapped.uiSettings()
-      try database.setUISettings(settings, serverID: serverID)
+      try await database.setUISettings(settings, serverID: serverID)
       return settings.permissions
     } catch {
       Logger.sync.info(
         "uiSettings sync failed (\(error)); gating sync on cached permissions")
-      return try? database.uiSettings(serverID: serverID)?.permissions
+      return try? await database.uiSettings(serverID: serverID)?.permissions
     }
   }
 
   private func syncServerConfiguration() async throws {
     do {
       let config = try await wrapped.serverConfiguration()
-      try database.setServerConfiguration(config, serverID: serverID)
+      try await database.setServerConfiguration(config, serverID: serverID)
     } catch let error where Self.isSkippable(error) {
       Logger.sync.info("Skipping serverConfiguration sync: \(error)")
     }
@@ -683,53 +690,53 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   // MARK: - Element reads (cache)
 
   public func tags() async throws -> [Tag] {
-    try database.elements(TagRecord.self, serverID: serverID)
+    try await database.elements(TagRecord.self, serverID: serverID)
   }
 
   public func correspondents() async throws -> [Correspondent] {
-    try database.elements(CorrespondentRecord.self, serverID: serverID)
+    try await database.elements(CorrespondentRecord.self, serverID: serverID)
   }
 
   public func documentTypes() async throws -> [DocumentType] {
-    try database.elements(DocumentTypeRecord.self, serverID: serverID)
+    try await database.elements(DocumentTypeRecord.self, serverID: serverID)
   }
 
   public func storagePaths() async throws -> [StoragePath] {
-    try database.elements(StoragePathRecord.self, serverID: serverID)
+    try await database.elements(StoragePathRecord.self, serverID: serverID)
   }
 
   public func savedViews() async throws -> [SavedView] {
-    try database.elements(SavedViewRecord.self, serverID: serverID)
+    try await database.elements(SavedViewRecord.self, serverID: serverID)
   }
 
   public func users() async throws -> [User] {
-    try database.elements(UserRecord.self, serverID: serverID)
+    try await database.elements(UserRecord.self, serverID: serverID)
   }
 
   public func groups() async throws -> [UserGroup] {
-    try database.elements(UserGroupRecord.self, serverID: serverID)
+    try await database.elements(UserGroupRecord.self, serverID: serverID)
   }
 
   public func customFields() async throws -> [CustomField] {
-    try database.elements(CustomFieldRecord.self, serverID: serverID)
+    try await database.elements(CustomFieldRecord.self, serverID: serverID)
   }
 
   public func currentUser() async throws -> User {
-    guard let user = try database.uiSettings(serverID: serverID)?.user else {
+    guard let user = try await database.uiSettings(serverID: serverID)?.user else {
       throw CachingRepositoryError.cacheMiss
     }
     return user
   }
 
   public func uiSettings() async throws -> UISettings {
-    guard let settings = try database.uiSettings(serverID: serverID) else {
+    guard let settings = try await database.uiSettings(serverID: serverID) else {
       throw CachingRepositoryError.cacheMiss
     }
     return settings
   }
 
   public func serverConfiguration() async throws -> ServerConfiguration {
-    guard let config = try database.serverConfiguration(serverID: serverID) else {
+    guard let config = try await database.serverConfiguration(serverID: serverID) else {
       throw CachingRepositoryError.cacheMiss
     }
     return config
@@ -738,29 +745,31 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   // MARK: - Single-element getters (cache-first + network fallback + write-through)
 
   public func tag(id: UInt) async throws -> Tag? {
-    if let cached = try database.element(TagRecord.self, serverID: serverID, id: id) {
+    if let cached = try await database.element(TagRecord.self, serverID: serverID, id: id) {
       return cached
     }
     guard let fetched = try await wrapped.tag(id: id) else { return nil }
-    try database.upsertElement(fetched, of: TagRecord.self, serverID: serverID)
+    try await database.upsertElement(fetched, of: TagRecord.self, serverID: serverID)
     return fetched
   }
 
   public func correspondent(id: UInt) async throws -> Correspondent? {
-    if let cached = try database.element(CorrespondentRecord.self, serverID: serverID, id: id) {
+    if let cached = try await database.element(CorrespondentRecord.self, serverID: serverID, id: id)
+    {
       return cached
     }
     guard let fetched = try await wrapped.correspondent(id: id) else { return nil }
-    try database.upsertElement(fetched, of: CorrespondentRecord.self, serverID: serverID)
+    try await database.upsertElement(fetched, of: CorrespondentRecord.self, serverID: serverID)
     return fetched
   }
 
   public func documentType(id: UInt) async throws -> DocumentType? {
-    if let cached = try database.element(DocumentTypeRecord.self, serverID: serverID, id: id) {
+    if let cached = try await database.element(DocumentTypeRecord.self, serverID: serverID, id: id)
+    {
       return cached
     }
     guard let fetched = try await wrapped.documentType(id: id) else { return nil }
-    try database.upsertElement(fetched, of: DocumentTypeRecord.self, serverID: serverID)
+    try await database.upsertElement(fetched, of: DocumentTypeRecord.self, serverID: serverID)
     return fetched
   }
 
@@ -768,87 +777,89 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
   public func create(tag: ProtoTag) async throws -> Tag {
     let created = try await wrapped.create(tag: tag)
-    try database.upsertElement(created, of: TagRecord.self, serverID: serverID)
+    try await database.upsertElement(created, of: TagRecord.self, serverID: serverID)
     return created
   }
 
   public func update(tag: Tag) async throws -> Tag {
     let updated = try await wrapped.update(tag: tag)
-    try database.upsertElement(updated, of: TagRecord.self, serverID: serverID)
+    try await database.upsertElement(updated, of: TagRecord.self, serverID: serverID)
     return updated
   }
 
   public func delete(tag: Tag) async throws {
     try await wrapped.delete(tag: tag)
-    try database.deleteElement(TagRecord.self, serverID: serverID, id: tag.id)
+    try await database.deleteElement(TagRecord.self, serverID: serverID, id: tag.id)
   }
 
   public func create(correspondent: ProtoCorrespondent) async throws -> Correspondent {
     let created = try await wrapped.create(correspondent: correspondent)
-    try database.upsertElement(created, of: CorrespondentRecord.self, serverID: serverID)
+    try await database.upsertElement(created, of: CorrespondentRecord.self, serverID: serverID)
     return created
   }
 
   public func update(correspondent: Correspondent) async throws -> Correspondent {
     let updated = try await wrapped.update(correspondent: correspondent)
-    try database.upsertElement(updated, of: CorrespondentRecord.self, serverID: serverID)
+    try await database.upsertElement(updated, of: CorrespondentRecord.self, serverID: serverID)
     return updated
   }
 
   public func delete(correspondent: Correspondent) async throws {
     try await wrapped.delete(correspondent: correspondent)
-    try database.deleteElement(CorrespondentRecord.self, serverID: serverID, id: correspondent.id)
+    try await database.deleteElement(
+      CorrespondentRecord.self, serverID: serverID, id: correspondent.id)
   }
 
   public func create(documentType: ProtoDocumentType) async throws -> DocumentType {
     let created = try await wrapped.create(documentType: documentType)
-    try database.upsertElement(created, of: DocumentTypeRecord.self, serverID: serverID)
+    try await database.upsertElement(created, of: DocumentTypeRecord.self, serverID: serverID)
     return created
   }
 
   public func update(documentType: DocumentType) async throws -> DocumentType {
     let updated = try await wrapped.update(documentType: documentType)
-    try database.upsertElement(updated, of: DocumentTypeRecord.self, serverID: serverID)
+    try await database.upsertElement(updated, of: DocumentTypeRecord.self, serverID: serverID)
     return updated
   }
 
   public func delete(documentType: DocumentType) async throws {
     try await wrapped.delete(documentType: documentType)
-    try database.deleteElement(DocumentTypeRecord.self, serverID: serverID, id: documentType.id)
+    try await database.deleteElement(
+      DocumentTypeRecord.self, serverID: serverID, id: documentType.id)
   }
 
   public func create(storagePath: ProtoStoragePath) async throws -> StoragePath {
     let created = try await wrapped.create(storagePath: storagePath)
-    try database.upsertElement(created, of: StoragePathRecord.self, serverID: serverID)
+    try await database.upsertElement(created, of: StoragePathRecord.self, serverID: serverID)
     return created
   }
 
   public func update(storagePath: StoragePath) async throws -> StoragePath {
     let updated = try await wrapped.update(storagePath: storagePath)
-    try database.upsertElement(updated, of: StoragePathRecord.self, serverID: serverID)
+    try await database.upsertElement(updated, of: StoragePathRecord.self, serverID: serverID)
     return updated
   }
 
   public func delete(storagePath: StoragePath) async throws {
     try await wrapped.delete(storagePath: storagePath)
-    try database.deleteElement(StoragePathRecord.self, serverID: serverID, id: storagePath.id)
+    try await database.deleteElement(StoragePathRecord.self, serverID: serverID, id: storagePath.id)
   }
 
   public func create(savedView: ProtoSavedView) async throws -> SavedView {
     let created = try await wrapped.create(savedView: savedView)
-    try database.upsertElement(created, of: SavedViewRecord.self, serverID: serverID)
+    try await database.upsertElement(created, of: SavedViewRecord.self, serverID: serverID)
     return created
   }
 
   public func update(savedView: SavedView) async throws -> SavedView {
     let updated = try await wrapped.update(savedView: savedView)
-    try database.upsertElement(updated, of: SavedViewRecord.self, serverID: serverID)
+    try await database.upsertElement(updated, of: SavedViewRecord.self, serverID: serverID)
     return updated
   }
 
   public func delete(savedView: SavedView) async throws {
     try await wrapped.delete(savedView: savedView)
-    try database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
+    try await database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
   }
 
   // MARK: - Documents (pessimistic write-through + cache fallback)
@@ -860,8 +871,8 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // response carries permissions/custom fields — a `.full` write replaces the
     // row completely without dropping them. Ordering under the active sort isn't
     // recomputed offline — mark affected queries stale.
-    try database.upsertDocument(updated, serverID: serverID)
-    try database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
+    try await database.upsertDocument(updated, serverID: serverID)
+    try await database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
     return updated
   }
 
@@ -869,7 +880,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try await wrapped.delete(document: document)
     // Explicitly prunes every cached query_order referencing it too — no FK
     // cascade does this (dropped in migration V6).
-    try database.deleteDocuments(serverID: serverID, removedIDs: [document.id])
+    try await database.deleteDocuments(serverID: serverID, removedIDs: [document.id])
   }
 
   public func create(document: ProtoDocument, file: URL, filename: String) async throws {
@@ -884,7 +895,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // row would take its list membership with it, making an opened document
         // vanish. `reconcileDocumentDeletions` decides deletions against the
         // server's authoritative id set; here we serve the cached row.
-        if let cached = try database.document(serverID: serverID, id: id) {
+        if let cached = try await database.document(serverID: serverID, id: id) {
           Logger.shared.info(
             "document(id:) fetch returned nil (404?); serving cached instead of deleting")
           return cached
@@ -892,13 +903,13 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         return nil
       }
       // A full-detail fetch — upgrade the row to Tier-2.
-      try database.upsertDocument(fetched, serverID: serverID)
+      try await database.upsertDocument(fetched, serverID: serverID)
       return fetched
     } catch let error where Self.mayServeCache(after: error) {
       // Offline/transient: serve the last-known cached row (Tier-1 or Tier-2)
       // rather than failing the open. Mirrors the element offline-first policy.
       // A permission failure isn't caught here at all, so it propagates.
-      if let cached = try database.document(serverID: serverID, id: id) {
+      if let cached = try await database.document(serverID: serverID, id: id) {
         Logger.shared.info("document(id:) network failed (\(error)); serving cached")
         return cached
       }
@@ -909,10 +920,10 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   public func document(asn: UInt) async throws -> Document? {
     do {
       guard let fetched = try await wrapped.document(asn: asn) else { return nil }
-      try database.upsertDocument(fetched, serverID: serverID)
+      try await database.upsertDocument(fetched, serverID: serverID)
       return fetched
     } catch let error where Self.mayServeCache(after: error) {
-      if let cached = try database.document(serverID: serverID, asn: asn) {
+      if let cached = try await database.document(serverID: serverID, asn: asn) {
         Logger.shared.info("document(asn:) network failed (\(error)); serving cached")
         return cached
       }
@@ -933,7 +944,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   }
 
   public func reconcileDocumentDeletions() async throws {
-    let localIDs = try database.allDocumentIDs(serverID: serverID)
+    let localIDs = try await database.allDocumentIDs(serverID: serverID)
     // Nothing cached yet → nothing to reconcile (skip the id fetch entirely).
     guard !localIDs.isEmpty else { return }
 
@@ -944,7 +955,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
     Logger.sync.info(
       "Reconcile: dropping \(removed.count, privacy: .public) remotely-deleted documents")
-    try database.deleteDocuments(serverID: serverID, removedIDs: Array(removed))
+    try await database.deleteDocuments(serverID: serverID, removedIDs: Array(removed))
   }
 
   public func reconcileDocumentChanges(progress: SyncProgressReporter?) async throws {
@@ -957,10 +968,10 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // detail; the setting only governs which docs are kept (every row is written
     // at `.full`). Nothing cached ⇒ the proactive fill (or a list open) seeds
     // first.
-    let localIDs = try database.allDocumentIDs(serverID: serverID)
+    let localIDs = try await database.allDocumentIDs(serverID: serverID)
     guard !localIDs.isEmpty else { return }
 
-    guard let watermark = deltaWatermark() else {
+    guard let watermark = await deltaWatermark() else {
       // First run: establish the baseline from the newest doc; subsequent passes
       // delta against it. (Avoids re-paging the whole library on cold start.)
       var newestFirst = FilterState.empty
@@ -968,7 +979,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       newestFirst.sortOrder = .descending
       let baseline = try wrapped.documents(filter: newestFirst)
       if let newest = try await baseline.fetch(limit: 1).first?.modified {
-        setDeltaWatermark(newest)
+        await setDeltaWatermark(newest)
       }
       return
     }
@@ -1024,20 +1035,20 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       if !toUpsert.isEmpty {
         Logger.sync.info(
           "Reconcile: refreshing \(toUpsert.count, privacy: .public) changed documents")
-        try database.upsertDocuments(toUpsert, serverID: serverID)
+        try await database.upsertDocuments(toUpsert, serverID: serverID)
         // Note edits bump `modified`, so a changed doc's cached notes may be
         // stale. Drop them (cheap, local) — the upsert above just refreshed each
         // doc's `notesCount`, so the next `fillDocumentDetails` re-seeds an empty
         // row for free when the count is 0, or re-fetches when it's > 0. We can't
         // tell a note change from any other field change, so this may re-fetch a
         // few docs whose notes didn't actually change.
-        try? database.invalidateNotes(serverID: serverID, documentIDs: toUpsert.map(\.id))
+        try? await database.invalidateNotes(serverID: serverID, documentIDs: toUpsert.map(\.id))
         applied += toUpsert.count
       }
       // Commit the cursor per page rather than once at the end — this is what
       // makes an interrupted pass resume instead of restart.
       if cursor > watermark {
-        setDeltaWatermark(cursor)
+        await setDeltaWatermark(cursor)
       }
       if await source.isExhausted { break }
     }
@@ -1046,12 +1057,12 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   public func reconcileSavedViewMembership() async throws {
     guard offlineBrowsingMode == .entireLibrary else { return }
     // Nothing cached ⇒ the proactive fill seeds membership first.
-    guard try !database.allDocumentIDs(serverID: serverID).isEmpty else { return }
+    guard try await !database.allDocumentIDs(serverID: serverID).isEmpty else { return }
 
     // Rebuild the default list + each saved view's order from the cheap Tier-0 id
     // projection. Runs *after* the R3δ pass (which lands new docs at detail), so
     // newly-matched ids already have a `document` row for the FK.
-    let savedViews = try database.elements(SavedViewRecord.self, serverID: serverID)
+    let savedViews = try await database.elements(SavedViewRecord.self, serverID: serverID)
     let views: [(name: String?, filter: FilterState)] =
       [(nil, .default)] + savedViews.map { ($0.name, FilterState(savedView: $0)) }
     for (name, filter) in views {
@@ -1081,15 +1092,16 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
             "Membership sweep: '\(name ?? "default", privacy: .public)' began filling; skipping")
           continue
         }
-        try database.replaceQueryOrder(queryKey: key, serverID: serverID, orderedIDs: ids)
-        try? database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
+        try await database.replaceQueryOrder(
+          queryKey: key, serverID: serverID, orderedIDs: ids)
+        try? await database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
       } catch is CancellationError {
         throw CancellationError()
       } catch {
         Logger.sync.info(
           "Membership sweep: '\(name ?? "default", privacy: .public)' failed (\(error)); continuing"
         )
-        try? database.recordQuerySyncError(
+        try? await database.recordQuerySyncError(
           serverID: serverID, queryKey: key.rawValue, savedViewName: name,
           message: Self.syncFailureMessage(error))
       }
@@ -1099,13 +1111,13 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   // Per-server delta watermark (newest `modified` applied), in `server_sync_state`
   // keyed by serverID. Regenerable sync state — `clearCache` resets it, and
   // losing it just re-baselines on the next pass.
-  private func deltaWatermark() -> Date? {
-    try? database.deltaWatermark(serverID: serverID)
+  private func deltaWatermark() async -> Date? {
+    try? await database.deltaWatermark(serverID: serverID)
   }
 
-  private func setDeltaWatermark(_ date: Date) {
+  private func setDeltaWatermark(_ date: Date) async {
     do {
-      try database.setDeltaWatermark(date, serverID: serverID)
+      try await database.setDeltaWatermark(date, serverID: serverID)
     } catch {
       Logger.sync.error("setDeltaWatermark failed: \(error)")
     }
@@ -1120,20 +1132,21 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   /// cached row may be absent (nothing fetched it yet) and the read itself may
   /// fail. In practice the detail view fetches the document first, so the
   /// versions are usually known by the time this is called.
-  private func fileMetadataVersionID(documentId: UInt) -> UInt {
-    (try? database.document(serverID: serverID, id: documentId))?.currentVersionID ?? documentId
+  private func fileMetadataVersionID(documentId: UInt) async -> UInt {
+    (try? await database.document(serverID: serverID, id: documentId))?.currentVersionID
+      ?? documentId
   }
 
   public func metadata(documentId: UInt) async throws -> Metadata {
     // File-metadata is immutable per file version, so it caches under the
     // document's current version id.
-    let versionID = fileMetadataVersionID(documentId: documentId)
+    let versionID = await fileMetadataVersionID(documentId: documentId)
     do {
       let fetched = try await wrapped.metadata(documentId: documentId)
-      try database.setFileMetadata(fetched, serverID: serverID, versionID: versionID)
+      try await database.setFileMetadata(fetched, serverID: serverID, versionID: versionID)
       return fetched
     } catch let error where Self.mayServeCache(after: error) {
-      if let cached = try database.fileMetadata(serverID: serverID, versionID: versionID) {
+      if let cached = try await database.fileMetadata(serverID: serverID, versionID: versionID) {
         Logger.shared.info("metadata(documentId:) network failed (\(error)); serving cached")
         return cached
       }
@@ -1144,12 +1157,12 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   public func notes(documentId: UInt) async throws -> [Document.Note] {
     do {
       let fetched = try await wrapped.notes(documentId: documentId)
-      try database.setNotes(fetched, serverID: serverID, documentID: documentId)
+      try await database.setNotes(fetched, serverID: serverID, documentID: documentId)
       return fetched
     } catch let error where Self.mayServeCache(after: error) {
       // `nil` (never cached) is distinct from `[]` (cached, no notes): only the
       // former propagates the network error.
-      if let cached = try database.notes(serverID: serverID, documentID: documentId) {
+      if let cached = try await database.notes(serverID: serverID, documentID: documentId) {
         Logger.shared.info("notes(documentId:) network failed (\(error)); serving cached")
         return cached
       }
@@ -1163,13 +1176,13 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Pessimistic: the server returns the updated full list, which we write
     // through so the cached notes stay consistent without a re-fetch.
     let updated = try await wrapped.createNote(documentId: documentId, note: note)
-    try database.setNotes(updated, serverID: serverID, documentID: documentId)
+    try await database.setNotes(updated, serverID: serverID, documentID: documentId)
     return updated
   }
 
   public func deleteNote(id: UInt, documentId: UInt) async throws -> [Document.Note] {
     let updated = try await wrapped.deleteNote(id: id, documentId: documentId)
-    try database.setNotes(updated, serverID: serverID, documentID: documentId)
+    try await database.setNotes(updated, serverID: serverID, documentID: documentId)
     return updated
   }
 
@@ -1231,10 +1244,10 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Write the new settings through to the cached `ui_settings` singleton (the
     // server returns no body), merging onto the cached user/permissions, so the
     // live observation repaints `settings` (e.g. saved-view visibility).
-    if let current = try database.uiSettings(serverID: serverID) {
+    if let current = try await database.uiSettings(serverID: serverID) {
       let merged = UISettings(
         user: current.user, settings: settings, permissions: current.permissions)
-      try database.setUISettings(merged, serverID: serverID)
+      try await database.setUISettings(merged, serverID: serverID)
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -1087,7 +1087,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       newestFirst.sortOrder = .descending
       let baseline = try wrapped.documents(filter: newestFirst)
       if let newest = try await baseline.fetch(limit: 1).first?.modified {
-        await setDeltaWatermark(newest)
+        try await setDeltaWatermark(newest)
       }
       return
     }
@@ -1167,7 +1167,7 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       // transaction from the page's write, and harmlessly so: losing it only
       // re-applies the page next time, and the upsert is a straight replace.
       if cursor > watermark {
-        await setDeltaWatermark(cursor)
+        try await setDeltaWatermark(cursor)
       }
       if await source.isExhausted { break }
     }
@@ -1228,6 +1228,17 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           serverID: serverID, queryKey: key.rawValue, savedViewName: name,
           message: Self.syncFailureMessage(error))
       }
+      // Both branches above end on a `try?`, which swallows cancellation along
+      // with everything else. On any view but the last, the check at the top of
+      // the next iteration catches that; on the last view the loop simply ends
+      // and this method returns normally, so `ServerSession.runReconcile` counts
+      // a cancelled sweep as one that succeeded. Ask once more here, after the
+      // body, so the last view is not a special case.
+      //
+      // `ServerSession`'s `sweep` helper re-asks the same question before it
+      // records an outcome; that is the backstop for this whole family of
+      // one-`await`-too-late windows, not a reason to leave them open.
+      try Task.checkCancellation()
     }
   }
 
@@ -1285,9 +1296,19 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try? await database.deltaWatermark(serverID: serverID)
   }
 
-  private func setDeltaWatermark(_ date: Date) async {
+  /// Commit the cursor, swallowing an ordinary persistence failure (the pass
+  /// re-applies the page next time) but *not* a cancellation.
+  ///
+  /// This is the delta's last `await` on its final page: `isExhausted` doesn't
+  /// throw, and under *Recently browsed* the membership sweep behind it no-ops,
+  /// so a swallowed cancellation here would let `reconcileDocumentChanges`
+  /// return normally with the cursor uncommitted — and `ServerSession` would
+  /// stamp the pass as clean over a delta that never landed.
+  private func setDeltaWatermark(_ date: Date) async throws {
     do {
       try await database.setDeltaWatermark(date, serverID: serverID)
+    } catch is CancellationError {
+      throw CancellationError()
     } catch {
       Logger.sync.error("setDeltaWatermark failed: \(error)")
     }

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -159,6 +159,13 @@ extension CachingBackend {
 enum CachingRepositoryError: Error {
   /// A pure cache read found nothing for a non-optional resource. The store's
   /// hydrate path tolerates this (cold cache); `sync` then fills it.
+  ///
+  /// Reachable, despite a note in the offline-stack inventory (#656 item 11)
+  /// suggesting otherwise: `currentUser()`, `uiSettings()` and
+  /// `serverConfiguration()` all throw it whenever the `ui_settings` /
+  /// `server_configuration` singleton has not been synced yet — the ordinary
+  /// first-launch state — and `DocumentStore.fillDocumentQuery` reuses it for
+  /// "no caching backend at all". Kept.
   case cacheMiss
 }
 
@@ -172,11 +179,12 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
   public let database: Database
   public let serverID: UUID
 
-  /// The in-flight fill per `QueryKey` — page 1 included, not only the
-  /// background continuation. Every writer of a key's `query_order` consults
-  /// this: a new fill drains the current owner before touching the key, and the
-  /// membership sweep steps over a key that is mid-fill. Main-actor isolated
-  /// like the rest of this class, so claiming and clearing never interleave.
+  /// The in-flight writer of each `QueryKey`'s `query_order` — a fill (page 1
+  /// included, not only the background continuation) or the membership sweep's
+  /// rewrite. Every writer of a key consults this: a new fill drains the current
+  /// owner before touching the key, and the membership sweep steps over a key
+  /// that is mid-fill. Main-actor isolated like the rest of this class, and
+  /// claiming/clearing never suspends, so two writers cannot both hold a key.
   private var activeFills: [QueryKey: Task<Void, any Error>] = [:]
 
   public init(wrapping: Wrapped, database: Database, serverID: UUID) {
@@ -417,7 +425,8 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     if activeFills[key] == owner { activeFills[key] = nil }
   }
 
-  /// Whether a fill currently owns this key's `query_order`.
+  /// Whether a fill (or the membership sweep's own rewrite) currently owns this
+  /// key's `query_order`.
   private func isFilling(_ key: QueryKey) -> Bool { activeFills[key] != nil }
 
   public func fillLibrary(force: Bool, progress: SyncProgressReporter?) async throws {
@@ -1092,8 +1101,12 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
             "Membership sweep: '\(name ?? "default", privacy: .public)' began filling; skipping")
           continue
         }
-        try await database.replaceQueryOrder(
-          queryKey: key, serverID: serverID, orderedIDs: ids)
+        guard try await replaceQueryOrderOwningKey(key, orderedIDs: ids) else {
+          Logger.sync.info(
+            "Membership sweep: '\(name ?? "default", privacy: .public)' was taken over mid-write; skipping"
+          )
+          continue
+        }
         try? await database.clearQuerySyncError(serverID: serverID, queryKey: key.rawValue)
       } catch is CancellationError {
         throw CancellationError()
@@ -1105,6 +1118,40 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           serverID: serverID, queryKey: key.rawValue, savedViewName: name,
           message: Self.syncFailureMessage(error))
       }
+    }
+  }
+
+  /// Rewrite `key`'s membership while *owning* the key, and report whether the
+  /// rewrite stood.
+  ///
+  /// The two `isFilling` guards around the caller used to be enough on their
+  /// own, because the write was a blocking main-actor call: nothing could claim
+  /// the key between the last check and the committed rewrite. Now that the
+  /// write suspends, that window is real — a fill could start inside it and
+  /// interleave its page-1 `replaceAll` with this delete-all-and-reinsert,
+  /// producing exactly the garbled merge the guards exist to prevent. Claiming
+  /// the key for the duration closes it again: a fill starting meanwhile drains
+  /// this write (`drainFill`) instead of racing it, and the drained sweep leaves
+  /// the key to the fill, which writes the better ordering anyway.
+  ///
+  /// - Returns: `false` if a fill took the key over, so the caller skips the
+  ///   view rather than clearing its recorded sync error.
+  private func replaceQueryOrderOwningKey(
+    _ key: QueryKey, orderedIDs: [UInt]
+  ) async throws -> Bool {
+    let database = database
+    let serverID = serverID
+    let write = Task {
+      try await database.replaceQueryOrder(
+        queryKey: key, serverID: serverID, orderedIDs: orderedIDs)
+    }
+    activeFills[key] = write
+    defer { if activeFills[key] == write { activeFills[key] = nil } }
+    do {
+      try await write.value
+      return true
+    } catch is CancellationError {
+      return false
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -222,6 +222,11 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
       gate?.test(.view, for: resource) ?? true
     }
 
+    // Each collection reconciles in its own transaction, and they now run
+    // genuinely concurrently rather than serialized behind the main actor.
+    // That is the point, and it is safe: no invariant spans two collections,
+    // and each `replaceElements` is a whole-set replace for one server.
+    //
     // Counted as the group is built, so the total is final before the first
     // completion is awaited. Collections the user can't view are never added,
     // so the bar measures the work actually being done rather than a nominal
@@ -376,6 +381,11 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // membership, and only here is that recorded. Page 1's `replaceAll`
         // cleared the stamp, so anything that stopped us short leaves the key
         // marked incomplete for the next pass to redo.
+        //
+        // The pages and this stamp are separate transactions, which is safe
+        // because `activeFills` makes this fill the key's sole writer for the
+        // whole run: another fill drains us first, and the membership sweep
+        // steps over an owned key.
         try await database.markQueryFillComplete(queryKey: key, serverID: serverID)
       }
     }
@@ -959,7 +969,12 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     //
     // Both writes are shielded together: the stale-marking is what tells the
     // list its cached ordering no longer reflects the edit, so landing the row
-    // without it is its own kind of divergence.
+    // without it is its own kind of divergence. Two transactions rather than
+    // one, and deliberately so: anything that can land between them either
+    // rebuilds the affected key's order (a fill page, which clears the flag it
+    // has just earned the right to clear) or removes the document from it (a
+    // delete reconcile, after which there is nothing left to mark). Neither
+    // leaves a wrong state behind.
     try await commitCache("update(document:)") { [database, serverID] in
       try await database.upsertDocument(updated, serverID: serverID)
       try await database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
@@ -1124,29 +1139,33 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
       // *Entire library*: keep every changed/new doc. *Recently browsed*: only
       // refresh rows already cached. Either way the row is written at `.full`.
+      //
+      // `localIDs` is a snapshot taken before the paging began, so a document
+      // cached mid-pass is skipped here even though the cursor moves past it.
+      // Harmless: whatever cached it did so by fetching it from the network,
+      // which is strictly fresher than this delta page's copy of it.
       let toUpsert = entireLibrary ? changed : changed.filter { localIDs.contains($0.id) }
       if !toUpsert.isEmpty {
         Logger.sync.info(
           "Reconcile: refreshing \(toUpsert.count, privacy: .public) changed documents")
-        try await database.upsertDocuments(toUpsert, serverID: serverID)
         // Note edits bump `modified`, so a changed doc's cached notes may be
-        // stale. Drop them (cheap, local) — the upsert above just refreshed each
-        // doc's `notesCount`, so the next `fillDocumentDetails` re-seeds an empty
-        // row for free when the count is 0, or re-fetches when it's > 0. We can't
-        // tell a note change from any other field change, so this may re-fetch a
-        // few docs whose notes didn't actually change.
+        // stale. Dropping them is cheap and local — the upsert refreshes each
+        // doc's `notesCount`, so the next `fillDocumentDetails` re-seeds an
+        // empty row for free when the count is 0, or re-fetches when it's > 0.
+        // We can't tell a note change from any other field change, so this may
+        // re-fetch a few docs whose notes didn't actually change.
         //
-        // `try?` swallows cancellation along with everything else, so a pass
-        // stopped here leaves those documents' notes stale — the row survives
-        // next to a refreshed `notesCount`, and the detail fill sees a cached
-        // row and doesn't re-fetch. Accepted: the next reconcile that touches
-        // these documents invalidates them again, and note text going a pass
-        // stale is not worth holding an interrupted sweep open for.
-        try? await database.invalidateNotes(serverID: serverID, documentIDs: toUpsert.map(\.id))
+        // One transaction: a `createNote` / `deleteNote` write-through landing
+        // between an upsert and a separate invalidation would be deleted by it,
+        // and under *Recently browsed* nothing repairs that until the document
+        // is fetched online again.
+        try await database.upsertDocumentsInvalidatingNotes(toUpsert, serverID: serverID)
         applied += toUpsert.count
       }
       // Commit the cursor per page rather than once at the end — this is what
-      // makes an interrupted pass resume instead of restart.
+      // makes an interrupted pass resume instead of restart. A separate
+      // transaction from the page's write, and harmlessly so: losing it only
+      // re-applies the page next time, and the upsert is a straight replace.
       if cursor > watermark {
         await setDeltaWatermark(cursor)
       }
@@ -1238,12 +1257,25 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     }
     activeFills[key] = write
     defer { if activeFills[key] == write { activeFills[key] = nil } }
+    let stood: Bool
     do {
       try await write.value
-      return true
+      stood = true
     } catch is CancellationError {
-      return false
+      // A fill drained us. That cancellation is the *write task's*, not ours.
+      stood = false
     }
+    // Ours is a separate question, and it has to be asked outside the `catch`
+    // above so it propagates instead of reading as "a fill took the key over".
+    // The write runs on an unstructured `Task`, which inherits isolation but
+    // *not* cancellation — that is what lets it own the key, and it also means
+    // `write.value` returns happily on a sweep cancelled while the rewrite was
+    // in flight. Unasked, the caller would clear the view's recorded sync error
+    // and — on the last view — the loop would simply run out, so
+    // `ServerSession` would count a cancelled membership sweep as a completed
+    // one and advance its freshness stamps on the strength of it.
+    try Task.checkCancellation()
+    return stood
   }
 
   // Per-server delta watermark (newest `modified` applied), in `server_sync_state`
@@ -1386,13 +1418,16 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Write the new settings through to the cached `ui_settings` singleton (the
     // server returns no body), merging onto the cached user/permissions, so the
     // live observation repaints `settings` (e.g. saved-view visibility).
-    // Read-modify-write, shielded as a unit: cancelled between the read and the
-    // write, the server would be holding settings the cached singleton denies.
+    //
+    // `updateUISettings` does the read, the merge and the write in a single
+    // transaction: split across two accessors, an element sync writing a
+    // freshly-fetched row in between would be overwritten by a merge built on
+    // the pre-sync user and permission matrix. `commitCache` covers the other
+    // half — cancelled here, the server would be holding settings the cached
+    // singleton denies.
     try await commitCache("update(settings:)") { [database, serverID] in
-      if let current = try await database.uiSettings(serverID: serverID) {
-        let merged = UISettings(
-          user: current.user, settings: settings, permissions: current.permissions)
-        try await database.setUISettings(merged, serverID: serverID)
+      try await database.updateUISettings(serverID: serverID) { current in
+        UISettings(user: current.user, settings: settings, permissions: current.permissions)
       }
     }
   }

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -572,6 +572,14 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
           serverID: serverID, excluding: detailFillFailures)) ?? []
         : []
 
+      // Both discovery reads swallow their error, and a cancelled read is an
+      // error — so a pass cancelled here would come back with two empty lists,
+      // skip both loops (and the `checkCancellation` inside them), and return
+      // normally, which `ServerSession` records as a completed detail fill. Ask
+      // once, explicitly, before the emptiness can be mistaken for "nothing
+      // left to do".
+      try Task.checkCancellation()
+
       // The pass is uncapped: a first cold fill of a large library is meant to
       // run to completion, and the Offline & Sync screen reports it rather than
       // a per-pass budget hiding how much is left. Cancellation (backgrounding,
@@ -696,6 +704,46 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     !isSkippable(error)
   }
 
+  // MARK: - Write-through shield
+
+  /// Run a cache write that follows an *already committed* remote mutation, on
+  /// a task of its own so the caller's cancellation cannot abandon it.
+  ///
+  /// The mutation methods here are pessimistic: they forward to the server and
+  /// write through only once it has accepted the change. The blocking accessors
+  /// these replaced always ran to completion, and that is what the pattern
+  /// silently depended on. The `async` accessors are cancellation-aware — GRDB
+  /// throws `CancellationError` if the task is cancelled before the access
+  /// starts, and interrupts one already running — which is right for a sweep
+  /// and wrong here: a caller cancelled in the window between the two (a
+  /// dismissed sheet, a view that went away, a server switch) would leave the
+  /// server changed and the cache holding the old value, with nothing scheduled
+  /// to reconcile the two. A delete is the worst case — the row stays cached,
+  /// keeps appearing in lists and is served offline as though it still existed,
+  /// until the next `reconcileDocumentDeletions` happens to notice.
+  ///
+  /// An unstructured `Task` inherits actor isolation but *not* cancellation, so
+  /// the write runs to completion; awaiting its value keeps the method's
+  /// contract (it still returns only once the cache agrees with the server) and
+  /// still propagates a genuine write failure to the caller.
+  ///
+  /// Only for writes behind a committed remote mutation. Reads and sweep writes
+  /// stay cancellable: stopping those loses work, not consistency.
+  private func commitCache(
+    _ operation: String, _ body: @escaping @Sendable () async throws -> Void
+  ) async throws {
+    do {
+      try await Task { try await body() }.value
+    } catch {
+      // The caller sees this as a plain failure; only the log can say that the
+      // server already accepted the change and it is the cache that is behind.
+      Logger.shared.error(
+        "Cache write '\(operation, privacy: .public)' failed after the server accepted the change; the cache is stale until the next reconcile: \(error)"
+      )
+      throw error
+    }
+  }
+
   // MARK: - Element reads (cache)
 
   public func tags() async throws -> [Tag] {
@@ -786,89 +834,117 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
 
   public func create(tag: ProtoTag) async throws -> Tag {
     let created = try await wrapped.create(tag: tag)
-    try await database.upsertElement(created, of: TagRecord.self, serverID: serverID)
+    try await commitCache("create(tag:)") { [database, serverID] in
+      try await database.upsertElement(created, of: TagRecord.self, serverID: serverID)
+    }
     return created
   }
 
   public func update(tag: Tag) async throws -> Tag {
     let updated = try await wrapped.update(tag: tag)
-    try await database.upsertElement(updated, of: TagRecord.self, serverID: serverID)
+    try await commitCache("update(tag:)") { [database, serverID] in
+      try await database.upsertElement(updated, of: TagRecord.self, serverID: serverID)
+    }
     return updated
   }
 
   public func delete(tag: Tag) async throws {
     try await wrapped.delete(tag: tag)
-    try await database.deleteElement(TagRecord.self, serverID: serverID, id: tag.id)
+    try await commitCache("delete(tag:)") { [database, serverID, id = tag.id] in
+      try await database.deleteElement(TagRecord.self, serverID: serverID, id: id)
+    }
   }
 
   public func create(correspondent: ProtoCorrespondent) async throws -> Correspondent {
     let created = try await wrapped.create(correspondent: correspondent)
-    try await database.upsertElement(created, of: CorrespondentRecord.self, serverID: serverID)
+    try await commitCache("create(correspondent:)") { [database, serverID] in
+      try await database.upsertElement(created, of: CorrespondentRecord.self, serverID: serverID)
+    }
     return created
   }
 
   public func update(correspondent: Correspondent) async throws -> Correspondent {
     let updated = try await wrapped.update(correspondent: correspondent)
-    try await database.upsertElement(updated, of: CorrespondentRecord.self, serverID: serverID)
+    try await commitCache("update(correspondent:)") { [database, serverID] in
+      try await database.upsertElement(updated, of: CorrespondentRecord.self, serverID: serverID)
+    }
     return updated
   }
 
   public func delete(correspondent: Correspondent) async throws {
     try await wrapped.delete(correspondent: correspondent)
-    try await database.deleteElement(
-      CorrespondentRecord.self, serverID: serverID, id: correspondent.id)
+    try await commitCache("delete(correspondent:)") { [database, serverID, id = correspondent.id] in
+      try await database.deleteElement(CorrespondentRecord.self, serverID: serverID, id: id)
+    }
   }
 
   public func create(documentType: ProtoDocumentType) async throws -> DocumentType {
     let created = try await wrapped.create(documentType: documentType)
-    try await database.upsertElement(created, of: DocumentTypeRecord.self, serverID: serverID)
+    try await commitCache("create(documentType:)") { [database, serverID] in
+      try await database.upsertElement(created, of: DocumentTypeRecord.self, serverID: serverID)
+    }
     return created
   }
 
   public func update(documentType: DocumentType) async throws -> DocumentType {
     let updated = try await wrapped.update(documentType: documentType)
-    try await database.upsertElement(updated, of: DocumentTypeRecord.self, serverID: serverID)
+    try await commitCache("update(documentType:)") { [database, serverID] in
+      try await database.upsertElement(updated, of: DocumentTypeRecord.self, serverID: serverID)
+    }
     return updated
   }
 
   public func delete(documentType: DocumentType) async throws {
     try await wrapped.delete(documentType: documentType)
-    try await database.deleteElement(
-      DocumentTypeRecord.self, serverID: serverID, id: documentType.id)
+    try await commitCache("delete(documentType:)") { [database, serverID, id = documentType.id] in
+      try await database.deleteElement(DocumentTypeRecord.self, serverID: serverID, id: id)
+    }
   }
 
   public func create(storagePath: ProtoStoragePath) async throws -> StoragePath {
     let created = try await wrapped.create(storagePath: storagePath)
-    try await database.upsertElement(created, of: StoragePathRecord.self, serverID: serverID)
+    try await commitCache("create(storagePath:)") { [database, serverID] in
+      try await database.upsertElement(created, of: StoragePathRecord.self, serverID: serverID)
+    }
     return created
   }
 
   public func update(storagePath: StoragePath) async throws -> StoragePath {
     let updated = try await wrapped.update(storagePath: storagePath)
-    try await database.upsertElement(updated, of: StoragePathRecord.self, serverID: serverID)
+    try await commitCache("update(storagePath:)") { [database, serverID] in
+      try await database.upsertElement(updated, of: StoragePathRecord.self, serverID: serverID)
+    }
     return updated
   }
 
   public func delete(storagePath: StoragePath) async throws {
     try await wrapped.delete(storagePath: storagePath)
-    try await database.deleteElement(StoragePathRecord.self, serverID: serverID, id: storagePath.id)
+    try await commitCache("delete(storagePath:)") { [database, serverID, id = storagePath.id] in
+      try await database.deleteElement(StoragePathRecord.self, serverID: serverID, id: id)
+    }
   }
 
   public func create(savedView: ProtoSavedView) async throws -> SavedView {
     let created = try await wrapped.create(savedView: savedView)
-    try await database.upsertElement(created, of: SavedViewRecord.self, serverID: serverID)
+    try await commitCache("create(savedView:)") { [database, serverID] in
+      try await database.upsertElement(created, of: SavedViewRecord.self, serverID: serverID)
+    }
     return created
   }
 
   public func update(savedView: SavedView) async throws -> SavedView {
     let updated = try await wrapped.update(savedView: savedView)
-    try await database.upsertElement(updated, of: SavedViewRecord.self, serverID: serverID)
+    try await commitCache("update(savedView:)") { [database, serverID] in
+      try await database.upsertElement(updated, of: SavedViewRecord.self, serverID: serverID)
+    }
     return updated
   }
 
   public func delete(savedView: SavedView) async throws {
     try await wrapped.delete(savedView: savedView)
-    try await database.deleteElement(SavedViewRecord.self, serverID: serverID, id: savedView.id)
+    try await commitCache("delete(savedView:)") { [database, serverID, id = savedView.id] in
+      try await database.deleteElement(SavedViewRecord.self, serverID: serverID, id: id)
+    }
   }
 
   // MARK: - Documents (pessimistic write-through + cache fallback)
@@ -880,8 +956,14 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // response carries permissions/custom fields — a `.full` write replaces the
     // row completely without dropping them. Ordering under the active sort isn't
     // recomputed offline — mark affected queries stale.
-    try await database.upsertDocument(updated, serverID: serverID)
-    try await database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
+    //
+    // Both writes are shielded together: the stale-marking is what tells the
+    // list its cached ordering no longer reflects the edit, so landing the row
+    // without it is its own kind of divergence.
+    try await commitCache("update(document:)") { [database, serverID] in
+      try await database.upsertDocument(updated, serverID: serverID)
+      try await database.markQueriesOrderStale(containing: updated.id, serverID: serverID)
+    }
     return updated
   }
 
@@ -889,7 +971,9 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     try await wrapped.delete(document: document)
     // Explicitly prunes every cached query_order referencing it too — no FK
     // cascade does this (dropped in migration V6).
-    try await database.deleteDocuments(serverID: serverID, removedIDs: [document.id])
+    try await commitCache("delete(document:)") { [database, serverID, id = document.id] in
+      try await database.deleteDocuments(serverID: serverID, removedIDs: [id])
+    }
   }
 
   public func create(document: ProtoDocument, file: URL, filename: String) async throws {
@@ -1051,6 +1135,13 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
         // row for free when the count is 0, or re-fetches when it's > 0. We can't
         // tell a note change from any other field change, so this may re-fetch a
         // few docs whose notes didn't actually change.
+        //
+        // `try?` swallows cancellation along with everything else, so a pass
+        // stopped here leaves those documents' notes stale — the row survives
+        // next to a refreshed `notesCount`, and the detail fill sees a cached
+        // row and doesn't re-fetch. Accepted: the next reconcile that touches
+        // these documents invalidates them again, and note text going a pass
+        // stale is not worth holding an interrupted sweep open for.
         try? await database.invalidateNotes(serverID: serverID, documentIDs: toUpsert.map(\.id))
         applied += toUpsert.count
       }
@@ -1223,13 +1314,17 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Pessimistic: the server returns the updated full list, which we write
     // through so the cached notes stay consistent without a re-fetch.
     let updated = try await wrapped.createNote(documentId: documentId, note: note)
-    try await database.setNotes(updated, serverID: serverID, documentID: documentId)
+    try await commitCache("createNote(documentId:)") { [database, serverID] in
+      try await database.setNotes(updated, serverID: serverID, documentID: documentId)
+    }
     return updated
   }
 
   public func deleteNote(id: UInt, documentId: UInt) async throws -> [Document.Note] {
     let updated = try await wrapped.deleteNote(id: id, documentId: documentId)
-    try await database.setNotes(updated, serverID: serverID, documentID: documentId)
+    try await commitCache("deleteNote(id:documentId:)") { [database, serverID] in
+      try await database.setNotes(updated, serverID: serverID, documentID: documentId)
+    }
     return updated
   }
 
@@ -1291,10 +1386,14 @@ public final class CachingRepository<Wrapped: Repository>: Repository, CachingBa
     // Write the new settings through to the cached `ui_settings` singleton (the
     // server returns no body), merging onto the cached user/permissions, so the
     // live observation repaints `settings` (e.g. saved-view visibility).
-    if let current = try await database.uiSettings(serverID: serverID) {
-      let merged = UISettings(
-        user: current.user, settings: settings, permissions: current.permissions)
-      try await database.setUISettings(merged, serverID: serverID)
+    // Read-modify-write, shielded as a unit: cancelled between the read and the
+    // write, the server would be holding settings the cached singleton denies.
+    try await commitCache("update(settings:)") { [database, serverID] in
+      if let current = try await database.uiSettings(serverID: serverID) {
+        let merged = UISettings(
+          user: current.user, settings: settings, permissions: current.permissions)
+        try await database.setUISettings(merged, serverID: serverID)
+      }
     }
   }
 

--- a/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
+++ b/AppShared/Sources/AppShared/Networking/ConnectionManager.swift
@@ -611,7 +611,7 @@ public final class ConnectionManager {
     let database = database
     Task.detached(priority: .utility) {
       do {
-        let removed = try database.reclaimAfterDowngrade(
+        let removed = try await database.reclaimAfterDowngrade(
           serverID: serverID,
           defaultQueryKey: QueryKey(serverID: serverID, filter: .default),
           keepingFirst: OfflineLibrarySize.recentlyBrowsedDefaultListCap)

--- a/AppShared/Sources/AppShared/Networking/ServerSession.swift
+++ b/AppShared/Sources/AppShared/Networking/ServerSession.swift
@@ -436,6 +436,13 @@ public final class ServerSession {
       guard !result.cancelled else { return }
       do {
         try await body()
+        // The chokepoint for a whole family of bugs: a sweep whose *last*
+        // `await` swallowed cancellation — `try?` on a bookkeeping write, an
+        // unstructured task that doesn't inherit it — returns normally, and
+        // without this that would be indistinguishable from having finished.
+        // The sweeps close their own windows too; this is the backstop that
+        // catches the next one before it is found.
+        try Task.checkCancellation()
         result.succeeded += 1
       } catch {
         guard !error.isCancellationError else {
@@ -500,6 +507,9 @@ public final class ServerSession {
         try await NetworkTransfer.$category.withValue(.fill) {
           try await backend.fillLibrary(force: force) { self?.report($0, for: .libraryFill) }
         }
+        // `true` here is what tells `runSync` the pass completed; a cancellation
+        // swallowed on the fill's last `await` must not reach it as one.
+        try Task.checkCancellation()
         return true
       } catch is CancellationError {
         Logger.sync.info("Proactive library fill cancelled")
@@ -533,6 +543,8 @@ public final class ServerSession {
         try await NetworkTransfer.$category.withValue(.fill) {
           try await backend.fillDocumentDetails { self?.report($0, for: .detailFill) }
         }
+        // As in `fillLibrary`: `true` is a claim the pass finished.
+        try Task.checkCancellation()
         return true
       } catch is CancellationError {
         Logger.sync.info("Proactive detail fill cancelled")
@@ -635,6 +647,11 @@ public final class ServerSession {
           "Server \(stored.logLabel, privacy: .public) partially synced; stamp not advanced")
         return
       }
+      // Same question as `sweep` asks, for the phases that don't run through
+      // it: a cancelled pass must not advance the stamp that decides when this
+      // server is swept again. The `catch` below turns it back into a quiet
+      // return.
+      try Task.checkCancellation()
       lastSuccessfulSync = Date()
       Logger.sync.info("Server \(stored.logLabel, privacy: .public) synced")
     } catch {

--- a/Persistence/Sources/Persistence/Database+Connections.swift
+++ b/Persistence/Sources/Persistence/Database+Connections.swift
@@ -7,8 +7,23 @@ import os
 ///
 /// These are the only entry points `ConnectionManager` uses to read or
 /// mutate `server` rows; GRDB stays hidden from AppShared and the rest of
-/// the app. Element and document records have analogous APIs under the same
-/// principle ("GRDB is sealed inside Persistence").
+/// the app, under the same principle that governs the element and document
+/// caches ("GRDB is sealed inside Persistence").
+///
+/// **These are the only blocking accessors in the package**, and the rule is
+/// one line: *blocking database access is allowed for the `server` table and
+/// nothing else.* Every cache table (`Database+Elements`, `+Documents`,
+/// `+DocumentDetail`, `+QuerySyncError`, `+SyncState`, `+Maintenance`) is
+/// `async` only, because a main-actor caller that blocks there can stall the UI
+/// for the full 5 s `busy_timeout` while another process holds the writer lock.
+///
+/// `server` is exempt on its own merits, not by omission. It is a handful of
+/// rows; its writes are single-row updates driven from Login and Settings
+/// flows, not from a sync loop; and `ConnectionManager.init` has to hydrate it
+/// synchronously so SwiftUI's first frame sees the configured servers — an
+/// initializer cannot await. Making these `async` would push `async` through
+/// `ConnectionManager`'s whole synchronous API and into the views, buying
+/// nothing measurable.
 extension Database {
   /// Fetch every connection row currently in the table.
   public func allConnections() throws(DatabaseError) -> [ConnectionRecord] {

--- a/Persistence/Sources/Persistence/Database+DocumentDetail.swift
+++ b/Persistence/Sources/Persistence/Database+DocumentDetail.swift
@@ -10,34 +10,43 @@ import GRDB
 /// as `document(id:)`: the caching repository forwards to the server, replaces
 /// the cached row on success, and serves the cached row on failure. Notes are
 /// document-keyed and mutable; file-metadata is version-keyed and immutable.
+///
+/// Async only, like every cache table — see the rule in `Database+Connections`.
 extension Database {
   // MARK: - Notes (mutable, document-keyed)
 
   /// Replace a document's cached notes list (a row replace, not a per-note
   /// merge — the endpoint and mutations always return the full list).
-  public func setNotes(_ notes: [DocumentNote], serverID: UUID, documentID: UInt)
-    throws(DatabaseError)
-  {
-    try wrapping("setNotes") {
-      try writer.write { db in
-        try DocumentNoteRecord(serverId: serverID, documentId: documentID, notes: notes)
-          .upsert(db)
+  public func setNotes(_ notes: [DocumentNote], serverID: UUID, documentID: UInt) async throws {
+    try await wrappingAsync("setNotes") {
+      try await writer.write {
+        try Self.writeNotes(notes, serverID: serverID, documentID: documentID, $0)
       }
     }
+  }
+
+  private static func writeNotes(
+    _ notes: [DocumentNote], serverID: UUID, documentID: UInt, _ db: GRDB.Database
+  ) throws {
+    try DocumentNoteRecord(serverId: serverID, documentId: documentID, notes: notes).upsert(db)
   }
 
   /// A document's cached notes, or `nil` if never cached. `nil` (absent) is
   /// distinct from `[]` (cached, genuinely no notes) so the offline fallback can
   /// tell "nothing to serve" from "served an empty list".
-  public func notes(serverID: UUID, documentID: UInt) throws(DatabaseError) -> [DocumentNote]? {
-    try wrapping("notes") {
-      try writer.read { db in
-        try DocumentNoteRecord
-          .filter(Column("server_id") == serverID && Column("document_id") == documentID)
-          .fetchOne(db)?
-          .domain
-      }
+  public func notes(serverID: UUID, documentID: UInt) async throws -> [DocumentNote]? {
+    try await wrappingAsync("notes") {
+      try await writer.read { try Self.fetchNotes(serverID: serverID, documentID: documentID, $0) }
     }
+  }
+
+  private static func fetchNotes(
+    serverID: UUID, documentID: UInt, _ db: GRDB.Database
+  ) throws -> [DocumentNote]? {
+    try DocumentNoteRecord
+      .filter(Column("server_id") == serverID && Column("document_id") == documentID)
+      .fetchOne(db)?
+      .domain
   }
 
   // MARK: - File-metadata (immutable, version-keyed)
@@ -45,27 +54,38 @@ extension Database {
   /// Cache a file version's `/metadata/`. Immutable per version, so this only
   /// writes the first time a version is seen (re-writing an identical row is
   /// harmless).
-  public func setFileMetadata(_ metadata: Metadata, serverID: UUID, versionID: UInt)
-    throws(DatabaseError)
-  {
-    try wrapping("setFileMetadata") {
-      try writer.write { db in
-        try FileMetadataRecord(serverId: serverID, versionId: versionID, domain: metadata)
-          .upsert(db)
+  public func setFileMetadata(
+    _ metadata: Metadata, serverID: UUID, versionID: UInt
+  ) async throws {
+    try await wrappingAsync("setFileMetadata") {
+      try await writer.write {
+        try Self.writeFileMetadata(metadata, serverID: serverID, versionID: versionID, $0)
       }
     }
   }
 
+  private static func writeFileMetadata(
+    _ metadata: Metadata, serverID: UUID, versionID: UInt, _ db: GRDB.Database
+  ) throws {
+    try FileMetadataRecord(serverId: serverID, versionId: versionID, domain: metadata).upsert(db)
+  }
+
   /// A file version's cached metadata, or `nil` if never cached.
-  public func fileMetadata(serverID: UUID, versionID: UInt) throws(DatabaseError) -> Metadata? {
-    try wrapping("fileMetadata") {
-      try writer.read { db in
-        try FileMetadataRecord
-          .filter(Column("server_id") == serverID && Column("version_id") == versionID)
-          .fetchOne(db)?
-          .domain
+  public func fileMetadata(serverID: UUID, versionID: UInt) async throws -> Metadata? {
+    try await wrappingAsync("fileMetadata") {
+      try await writer.read {
+        try Self.fetchFileMetadata(serverID: serverID, versionID: versionID, $0)
       }
     }
+  }
+
+  private static func fetchFileMetadata(
+    serverID: UUID, versionID: UInt, _ db: GRDB.Database
+  ) throws -> Metadata? {
+    try FileMetadataRecord
+      .filter(Column("server_id") == serverID && Column("version_id") == versionID)
+      .fetchOne(db)?
+      .domain
   }
 
   // MARK: - Proactive detail fill
@@ -83,24 +103,26 @@ extension Database {
   /// proportional to the library — long enough, at a 5s `busy_timeout`, to stall
   /// the Share Extension behind it. `'[]'` is what empty notes encode to.
   @discardableResult
-  public func seedEmptyNotesForZeroCountDocuments(serverID: UUID) throws(DatabaseError) -> Int {
-    try wrapping("seedEmptyNotesForZeroCountDocuments") {
-      try writer.write { db in
-        try db.execute(
-          sql: """
-            INSERT INTO document_note (server_id, document_id, data)
-            SELECT d.server_id, d.id, '[]'
-            FROM document d
-            LEFT JOIN document_note n
-              ON n.server_id = d.server_id AND n.document_id = d.id
-            WHERE d.server_id = ?
-              AND n.document_id IS NULL
-              AND d.notes_count = 0
-            """,
-          arguments: [serverID])
-        return db.changesCount
-      }
+  public func seedEmptyNotesForZeroCountDocuments(serverID: UUID) async throws -> Int {
+    try await wrappingAsync("seedEmptyNotesForZeroCountDocuments") {
+      try await writer.write { try Self.seedEmptyNotes(serverID: serverID, $0) }
     }
+  }
+
+  private static func seedEmptyNotes(serverID: UUID, _ db: GRDB.Database) throws -> Int {
+    try db.execute(
+      sql: """
+        INSERT INTO document_note (server_id, document_id, data)
+        SELECT d.server_id, d.id, '[]'
+        FROM document d
+        LEFT JOIN document_note n
+          ON n.server_id = d.server_id AND n.document_id = d.id
+        WHERE d.server_id = ?
+          AND n.document_id IS NULL
+          AND d.notes_count = 0
+        """,
+      arguments: [serverID])
+    return db.changesCount
   }
 
   /// Cached document ids that have notes (`notesCount > 0`) but no cached notes
@@ -109,34 +131,40 @@ extension Database {
   ///
   /// SQL rather than `fetchAll` + a Swift filter: this runs on every foreground
   /// over the whole table, and decoding each row's JSON to read one integer is
-  /// main-actor work proportional to the library. `notes_count` is a real column
-  /// (`V9`), so the predicate is indexed rather than a `json_extract` scan over
-  /// a `TEXT` blob. Ordered by id so a caller can resume instead of re-walking
-  /// the same head.
+  /// work proportional to the library. `notes_count` is a real column (`V9`), so
+  /// the predicate is indexed rather than a `json_extract` scan over a `TEXT`
+  /// blob. Ordered by id so a caller can resume instead of re-walking the same
+  /// head.
   ///
   /// - Parameter excluding: ids to skip — the caller's per-session record of
   ///   failed fetches, so one bad document doesn't block the rest.
   public func documentIDsNeedingNotesFetch(
     serverID: UUID, excluding: Set<UInt> = []
-  ) throws(DatabaseError) -> [UInt] {
-    try wrapping("documentIDsNeedingNotesFetch") {
-      try writer.read { db in
-        try UInt.fetchAll(
-          db,
-          sql: """
-            SELECT d.id FROM document d
-            LEFT JOIN document_note n
-              ON n.server_id = d.server_id AND n.document_id = d.id
-            WHERE d.server_id = ?
-              AND n.document_id IS NULL
-              AND d.notes_count > 0
-            ORDER BY d.id
-            """,
-          arguments: [serverID]
-        )
-        .filter { !excluding.contains($0) }
+  ) async throws -> [UInt] {
+    try await wrappingAsync("documentIDsNeedingNotesFetch") {
+      try await writer.read {
+        try Self.idsNeedingNotes(serverID: serverID, excluding: excluding, $0)
       }
     }
+  }
+
+  private static func idsNeedingNotes(
+    serverID: UUID, excluding: Set<UInt>, _ db: GRDB.Database
+  ) throws -> [UInt] {
+    try UInt.fetchAll(
+      db,
+      sql: """
+        SELECT d.id FROM document d
+        LEFT JOIN document_note n
+          ON n.server_id = d.server_id AND n.document_id = d.id
+        WHERE d.server_id = ?
+          AND n.document_id IS NULL
+          AND d.notes_count > 0
+        ORDER BY d.id
+        """,
+      arguments: [serverID]
+    )
+    .filter { !excluding.contains($0) }
   }
 
   /// Cached document ids whose *current* file version has no cached
@@ -152,41 +180,58 @@ extension Database {
   /// `file_metadata`'s primary key rather than a `json_each` walk per row.
   public func documentIDsMissingFileMetadata(
     serverID: UUID, excluding: Set<UInt> = []
-  ) throws(DatabaseError) -> [UInt] {
-    try wrapping("documentIDsMissingFileMetadata") {
-      try writer.read { db in
-        try UInt.fetchAll(
-          db,
-          sql: """
-            SELECT d.id FROM document d
-            WHERE d.server_id = ?
-              AND NOT EXISTS (
-                SELECT 1 FROM file_metadata f
-                WHERE f.server_id = d.server_id
-                  AND f.version_id = d.current_version_id
-              )
-            ORDER BY d.id
-            """,
-          arguments: [serverID]
-        )
-        .filter { !excluding.contains($0) }
+  ) async throws -> [UInt] {
+    try await wrappingAsync("documentIDsMissingFileMetadata") {
+      try await writer.read {
+        try Self.idsMissingFileMetadata(serverID: serverID, excluding: excluding, $0)
       }
     }
   }
 
-  /// Drop cached notes rows for the given documents (no network). The R3δ delta
-  /// calls this for documents whose `modified` bumped (note edits bump it too),
-  /// so the next detail fill re-seeds or re-fetches their notes against the
-  /// fresh `notesCount`. Explicit bookkeeping, not an FK cascade.
-  public func invalidateNotes(serverID: UUID, documentIDs: [UInt]) throws(DatabaseError) {
-    try wrapping("invalidateNotes") {
-      guard !documentIDs.isEmpty else { return }
-      try writer.write { db in
-        _ =
-          try DocumentNoteRecord
-          .filter(Column("server_id") == serverID && documentIDs.contains(Column("document_id")))
-          .deleteAll(db)
+  private static func idsMissingFileMetadata(
+    serverID: UUID, excluding: Set<UInt>, _ db: GRDB.Database
+  ) throws -> [UInt] {
+    try UInt.fetchAll(
+      db,
+      sql: """
+        SELECT d.id FROM document d
+        WHERE d.server_id = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM file_metadata f
+            WHERE f.server_id = d.server_id
+              AND f.version_id = d.current_version_id
+          )
+        ORDER BY d.id
+        """,
+      arguments: [serverID]
+    )
+    .filter { !excluding.contains($0) }
+  }
+
+  /// Drop cached notes rows for the given documents (no network), so the next
+  /// detail fill re-seeds or re-fetches their notes against a fresh
+  /// `notesCount`. Explicit bookkeeping, not an FK cascade.
+  ///
+  /// Standalone form. The R3δ delta — the invalidation's reason for existing,
+  /// since a note edit bumps `modified` like any other change — needs it to
+  /// commit with the document upsert it follows, so it uses
+  /// ``upsertDocumentsInvalidatingNotes(_:serverID:)`` instead; this one has no
+  /// production caller today.
+  public func invalidateNotes(serverID: UUID, documentIDs: [UInt]) async throws {
+    guard !documentIDs.isEmpty else { return }
+    try await wrappingAsync("invalidateNotes") {
+      try await writer.write {
+        try Self.dropNotes(serverID: serverID, documentIDs: documentIDs, $0)
       }
     }
+  }
+
+  static func dropNotes(
+    serverID: UUID, documentIDs: [UInt], _ db: GRDB.Database
+  ) throws {
+    _ =
+      try DocumentNoteRecord
+      .filter(Column("server_id") == serverID && documentIDs.contains(Column("document_id")))
+      .deleteAll(db)
   }
 }

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -10,28 +10,35 @@ import GRDB
 /// `fillQuery`/`sync`). Writes are either a query fill (`writeQueryPage`, the
 /// network → DB replay materialization) or a single pessimistic-mutation
 /// write-through (`upsertDocument`, `deleteDocuments`).
+///
+/// Async only, like every cache table — see the rule in `Database+Connections`.
+/// The `static` bodies taking a `GRDB.Database` handle are what in-package
+/// seeding and the multi-step transactions (`reclaimAfterDowngrade`) compose
+/// from; nothing outside the package can reach the blocking form.
 extension Database {
   // MARK: - Writes
 
   /// Upsert a batch of documents. Every stored row is the complete object (the
   /// list carries `full_perms`), so this is a straight replace — there is no
   /// projection level to preserve.
-  public func upsertDocuments(_ domains: [Document], serverID: UUID) throws(DatabaseError) {
-    try wrapping("upsertDocuments") {
-      try writer.write { db in
-        for domain in domains {
-          try writeDocumentRow(db, domain, serverID: serverID)
-        }
-      }
+  public func upsertDocuments(_ domains: [Document], serverID: UUID) async throws {
+    try await wrappingAsync("upsertDocuments") {
+      try await writer.write { try Self.writeDocumentRows($0, domains, serverID: serverID) }
+    }
+  }
+
+  static func writeDocumentRows(
+    _ db: GRDB.Database, _ domains: [Document], serverID: UUID
+  ) throws {
+    for domain in domains {
+      try writeDocumentRow(db, domain, serverID: serverID)
     }
   }
 
   /// Single-row write-through (pessimistic mutation).
-  public func upsertDocument(_ domain: Document, serverID: UUID) throws(DatabaseError) {
-    try wrapping("upsertDocument") {
-      try writer.write { db in
-        try writeDocumentRow(db, domain, serverID: serverID)
-      }
+  public func upsertDocument(_ domain: Document, serverID: UUID) async throws {
+    try await wrappingAsync("upsertDocument") {
+      try await writer.write { try Self.writeDocumentRow($0, domain, serverID: serverID) }
     }
   }
 
@@ -45,27 +52,36 @@ extension Database {
   public func writeQueryPage(
     queryKey: QueryKey, serverID: UUID, documents: [Document],
     startPosition: Int, totalCount: UInt?, replaceAll: Bool
-  ) throws(DatabaseError) {
-    try wrapping("writeQueryPage") {
-      try writer.write { db in
-        if replaceAll {
-          try QueryOrderRow
-            .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
-            .deleteAll(db)
-        }
-        for (offset, domain) in documents.enumerated() {
-          try writeDocumentRow(db, domain, serverID: serverID)
-          try QueryOrderRow(
-            serverId: serverID, queryKey: queryKey.rawValue,
-            position: startPosition + offset, remoteId: domain.id
-          ).insert(db)
-        }
-        try setQueryMeta(
-          db, serverID: serverID, queryKey: queryKey,
-          totalCount: totalCount, orderStale: false,
-          stamp: replaceAll ? .cleared : .unchanged)
+  ) async throws {
+    try await wrappingAsync("writeQueryPage") {
+      try await writer.write {
+        try Self.writeQueryPage(
+          $0, queryKey: queryKey, serverID: serverID, documents: documents,
+          startPosition: startPosition, totalCount: totalCount, replaceAll: replaceAll)
       }
     }
+  }
+
+  private static func writeQueryPage(
+    _ db: GRDB.Database, queryKey: QueryKey, serverID: UUID, documents: [Document],
+    startPosition: Int, totalCount: UInt?, replaceAll: Bool
+  ) throws {
+    if replaceAll {
+      try QueryOrderRow
+        .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+        .deleteAll(db)
+    }
+    for (offset, domain) in documents.enumerated() {
+      try writeDocumentRow(db, domain, serverID: serverID)
+      try QueryOrderRow(
+        serverId: serverID, queryKey: queryKey.rawValue,
+        position: startPosition + offset, remoteId: domain.id
+      ).insert(db)
+    }
+    try setQueryMeta(
+      db, serverID: serverID, queryKey: queryKey,
+      totalCount: totalCount, orderStale: false,
+      stamp: replaceAll ? .cleared : .unchanged)
   }
 
   /// Rewrite a cached query's ordered membership from a Tier-0 id list (the
@@ -76,42 +92,53 @@ extension Database {
   /// `totalCount` records the server's full count for the scrollbar extent.
   public func replaceQueryOrder(
     queryKey: QueryKey, serverID: UUID, orderedIDs: [UInt]
-  ) throws(DatabaseError) {
-    try wrapping("replaceQueryOrder") {
-      try writer.write { db in
-        try QueryOrderRow
-          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
-          .deleteAll(db)
-        for (position, id) in orderedIDs.enumerated() {
-          try QueryOrderRow(
-            serverId: serverID, queryKey: queryKey.rawValue,
-            position: position, remoteId: id
-          ).insert(db)
-        }
-        try setQueryMeta(
-          db, serverID: serverID, queryKey: queryKey,
-          totalCount: UInt(orderedIDs.count), orderStale: false, stamp: .unchanged)
+  ) async throws {
+    try await wrappingAsync("replaceQueryOrder") {
+      try await writer.write {
+        try Self.replaceQueryOrder(
+          $0, queryKey: queryKey, serverID: serverID, orderedIDs: orderedIDs)
       }
     }
+  }
+
+  private static func replaceQueryOrder(
+    _ db: GRDB.Database, queryKey: QueryKey, serverID: UUID, orderedIDs: [UInt]
+  ) throws {
+    try QueryOrderRow
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+      .deleteAll(db)
+    for (position, id) in orderedIDs.enumerated() {
+      try QueryOrderRow(
+        serverId: serverID, queryKey: queryKey.rawValue,
+        position: position, remoteId: id
+      ).insert(db)
+    }
+    try setQueryMeta(
+      db, serverID: serverID, queryKey: queryKey,
+      totalCount: UInt(orderedIDs.count), orderStale: false, stamp: .unchanged)
   }
 
   /// Mark every cached query containing `remoteID` order-stale under its active
   /// sort. v1 over-marks (any query the doc is a member of); the ordering
   /// corrects on the next fill / delta.
-  public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID)
-    throws(DatabaseError)
-  {
-    try wrapping("markQueriesOrderStale") {
-      try writer.write { db in
-        let containing =
-          QueryOrderRow
-          .select(Column("query_key"), as: String.self)
-          .filter(Column("server_id") == serverID && Column("remote_id") == remoteID)
-        try QueryMetaRow
-          .filter(Column("server_id") == serverID && containing.contains(Column("query_key")))
-          .updateAll(db, Column("order_stale").set(to: true))
+  public func markQueriesOrderStale(containing remoteID: UInt, serverID: UUID) async throws {
+    try await wrappingAsync("markQueriesOrderStale") {
+      try await writer.write {
+        try Self.markOrderStale($0, containing: remoteID, serverID: serverID)
       }
     }
+  }
+
+  private static func markOrderStale(
+    _ db: GRDB.Database, containing remoteID: UInt, serverID: UUID
+  ) throws {
+    let containing =
+      QueryOrderRow
+      .select(Column("query_key"), as: String.self)
+      .filter(Column("server_id") == serverID && Column("remote_id") == remoteID)
+    try QueryMetaRow
+      .filter(Column("server_id") == serverID && containing.contains(Column("query_key")))
+      .updateAll(db, Column("order_stale").set(to: true))
   }
 
   /// Delete documents absent from the server's authoritative id set (the
@@ -119,21 +146,27 @@ extension Database {
   /// cached list. There is no FK from `query_order` to `document` (a row may be a
   /// skeleton), so the prune is explicit — a removed id must not linger as a
   /// permanent skeleton.
-  public func deleteDocuments(serverID: UUID, removedIDs: [UInt]) throws(DatabaseError) {
+  public func deleteDocuments(serverID: UUID, removedIDs: [UInt]) async throws {
     guard !removedIDs.isEmpty else { return }
-    try wrapping("deleteDocuments") {
-      try writer.write { db in
-        try Self.pruneDocumentDetail(db, serverID: serverID, documentIDs: removedIDs)
-        _ =
-          try DocumentRecord
-          .filter(Column("server_id") == serverID && removedIDs.contains(Column("id")))
-          .deleteAll(db)
-        _ =
-          try QueryOrderRow
-          .filter(Column("server_id") == serverID && removedIDs.contains(Column("remote_id")))
-          .deleteAll(db)
+    try await wrappingAsync("deleteDocuments") {
+      try await writer.write {
+        try Self.removeDocuments($0, serverID: serverID, removedIDs: removedIDs)
       }
     }
+  }
+
+  private static func removeDocuments(
+    _ db: GRDB.Database, serverID: UUID, removedIDs: [UInt]
+  ) throws {
+    try pruneDocumentDetail(db, serverID: serverID, documentIDs: removedIDs)
+    _ =
+      try DocumentRecord
+      .filter(Column("server_id") == serverID && removedIDs.contains(Column("id")))
+      .deleteAll(db)
+    _ =
+      try QueryOrderRow
+      .filter(Column("server_id") == serverID && removedIDs.contains(Column("remote_id")))
+      .deleteAll(db)
   }
 
   /// Deletes every `document` row for `serverID` no longer referenced by any
@@ -145,9 +178,9 @@ extension Database {
   /// membership — pinning (a second future exemption) doesn't exist yet.
   /// Returns the number of documents removed (for logging/tests).
   @discardableResult
-  public func pruneUnreferencedDocuments(serverID: UUID) throws(DatabaseError) -> Int {
-    try wrapping("pruneUnreferencedDocuments") {
-      try writer.write { db in try Self.pruneUnreferenced(db, serverID: serverID) }
+  public func pruneUnreferencedDocuments(serverID: UUID) async throws -> Int {
+    try await wrappingAsync("pruneUnreferencedDocuments") {
+      try await writer.write { try Self.pruneUnreferenced($0, serverID: serverID) }
     }
   }
 
@@ -179,11 +212,10 @@ extension Database {
   /// what `.recentlyBrowsed` already does for any other saved view. Returns
   /// the number of `query_order` rows removed.
   @discardableResult
-  public func dropQueryOrder(serverID: UUID, exceptQueryKey: QueryKey) throws(DatabaseError) -> Int
-  {
-    try wrapping("dropQueryOrder") {
-      try writer.write { db in
-        try Self.dropQueries(db, serverID: serverID, exceptQueryKey: exceptQueryKey)
+  public func dropQueryOrder(serverID: UUID, exceptQueryKey: QueryKey) async throws -> Int {
+    try await wrappingAsync("dropQueryOrder") {
+      try await writer.write {
+        try Self.dropQueries($0, serverID: serverID, exceptQueryKey: exceptQueryKey)
       }
     }
   }
@@ -220,10 +252,11 @@ extension Database {
   @discardableResult
   public func truncateQueryOrder(
     serverID: UUID, queryKey: QueryKey, keepingFirst limit: Int
-  ) throws(DatabaseError) -> Int {
-    try wrapping("truncateQueryOrder") {
-      try writer.write { db in
-        try Self.truncateQuery(db, serverID: serverID, queryKey: queryKey, keepingFirst: limit)
+  ) async throws -> Int {
+    try await wrappingAsync("truncateQueryOrder") {
+      try await writer.write {
+        try Self.truncateQuery(
+          $0, serverID: serverID, queryKey: queryKey, keepingFirst: limit)
       }
     }
   }
@@ -259,44 +292,58 @@ extension Database {
   @discardableResult
   public func reclaimAfterDowngrade(
     serverID: UUID, defaultQueryKey: QueryKey, keepingFirst limit: Int
-  ) throws(DatabaseError) -> Int {
-    try wrapping("reclaimAfterDowngrade") {
-      try writer.write { db in
-        try Self.dropQueries(db, serverID: serverID, exceptQueryKey: defaultQueryKey)
-        try Self.truncateQuery(
-          db, serverID: serverID, queryKey: defaultQueryKey, keepingFirst: limit)
-        let removed = try Self.pruneUnreferenced(db, serverID: serverID)
-        try Self.updateSyncState(db, serverID: serverID) { $0.libraryCoverageAt = nil }
-        return removed
+  ) async throws -> Int {
+    try await wrappingAsync("reclaimAfterDowngrade") {
+      try await writer.write {
+        try Self.reclaim(
+          $0, serverID: serverID, defaultQueryKey: defaultQueryKey, keepingFirst: limit)
       }
     }
+  }
+
+  private static func reclaim(
+    _ db: GRDB.Database, serverID: UUID, defaultQueryKey: QueryKey, keepingFirst limit: Int
+  ) throws -> Int {
+    try dropQueries(db, serverID: serverID, exceptQueryKey: defaultQueryKey)
+    try truncateQuery(db, serverID: serverID, queryKey: defaultQueryKey, keepingFirst: limit)
+    let removed = try pruneUnreferenced(db, serverID: serverID)
+    try updateSyncState(db, serverID: serverID) { $0.libraryCoverageAt = nil }
+    return removed
   }
 
   // MARK: - Reads (one-shot; observations live in Database+Observe)
 
   /// A single cached document by `(server, id)`, or `nil` if not cached.
-  public func document(serverID: UUID, id: UInt) throws(DatabaseError) -> Document? {
-    try wrapping("document(id:)") {
-      try writer.read { db in
-        try DocumentRecord
-          .filter(Column("server_id") == serverID && Column("id") == id)
-          .fetchOne(db)?
-          .domain
-      }
+  public func document(serverID: UUID, id: UInt) async throws -> Document? {
+    try await wrappingAsync("document(id:)") {
+      try await writer.read { try Self.fetchDocument($0, serverID: serverID, id: id) }
     }
+  }
+
+  private static func fetchDocument(
+    _ db: GRDB.Database, serverID: UUID, id: UInt
+  ) throws -> Document? {
+    try DocumentRecord
+      .filter(Column("server_id") == serverID && Column("id") == id)
+      .fetchOne(db)?
+      .domain
   }
 
   /// A single cached document by archive serial number (resolves the ASN
   /// scanner offline via the indexed `asn` column), or `nil` if not cached.
-  public func document(serverID: UUID, asn: UInt) throws(DatabaseError) -> Document? {
-    try wrapping("document(asn:)") {
-      try writer.read { db in
-        try DocumentRecord
-          .filter(Column("server_id") == serverID && Column("asn") == asn)
-          .fetchOne(db)?
-          .domain
-      }
+  public func document(serverID: UUID, asn: UInt) async throws -> Document? {
+    try await wrappingAsync("document(asn:)") {
+      try await writer.read { try Self.fetchDocument($0, serverID: serverID, asn: asn) }
     }
+  }
+
+  private static func fetchDocument(
+    _ db: GRDB.Database, serverID: UUID, asn: UInt
+  ) throws -> Document? {
+    try DocumentRecord
+      .filter(Column("server_id") == serverID && Column("asn") == asn)
+      .fetchOne(db)?
+      .domain
   }
 
   /// A window of a cached query's ordered answer: the `query_order ⟕ document`
@@ -306,35 +353,39 @@ extension Database {
   /// `observeDocumentPrefix`.
   public func queryDocuments(
     queryKey: QueryKey, serverID: UUID, limit: Int, offset: Int = 0
-  ) throws(DatabaseError) -> [DocumentEntry] {
-    try wrapping("queryDocuments") {
-      try writer.read { db in
+  ) async throws -> [DocumentEntry] {
+    try await wrappingAsync("queryDocuments") {
+      try await writer.read {
         try Self.fetchEntries(
-          db, serverID: serverID, queryKey: queryKey.rawValue, limit: limit, offset: offset)
+          $0, serverID: serverID, queryKey: queryKey.rawValue, limit: limit, offset: offset)
       }
     }
   }
 
   /// Every cached document id for a server — the local set the remote-delete
   /// reconcile diffs against the server's authoritative id set.
-  public func allDocumentIDs(serverID: UUID) throws(DatabaseError) -> Set<UInt> {
-    try wrapping("allDocumentIDs") {
-      try writer.read { db in
-        try DocumentRecord
-          .select(Column("id"), as: UInt.self)
-          .filter(Column("server_id") == serverID)
-          .fetchSet(db)
-      }
+  public func allDocumentIDs(serverID: UUID) async throws -> Set<UInt> {
+    try await wrappingAsync("allDocumentIDs") {
+      try await writer.read { try Self.fetchAllDocumentIDs($0, serverID: serverID) }
     }
+  }
+
+  private static func fetchAllDocumentIDs(
+    _ db: GRDB.Database, serverID: UUID
+  ) throws -> Set<UInt> {
+    try DocumentRecord
+      .select(Column("id"), as: UInt.self)
+      .filter(Column("server_id") == serverID)
+      .fetchSet(db)
   }
 
   /// Count of `document` rows cached for a server — a diagnostic surface (the
   /// Offline & Sync screen) so the proactive fill and the downgrade GC's
   /// effect are visible without a debugger.
-  public func documentCount(serverID: UUID) throws(DatabaseError) -> Int {
-    try wrapping("documentCount") {
-      try writer.read { db in
-        try DocumentRecord.filter(Column("server_id") == serverID).fetchCount(db)
+  public func documentCount(serverID: UUID) async throws -> Int {
+    try await wrappingAsync("documentCount") {
+      try await writer.read {
+        try DocumentRecord.filter(Column("server_id") == serverID).fetchCount($0)
       }
     }
   }
@@ -346,41 +397,49 @@ extension Database {
   /// The absence of the stamp is what tells the next pass the order is truncated
   /// and has to be redone; without it an interrupted fill was silently
   /// indistinguishable from a complete one.
-  public func markQueryFillComplete(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) {
-    try wrapping("markQueryFillComplete") {
-      try writer.write { db in
-        let meta =
-          try QueryMetaRow
-          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
-          .fetchOne(db)
-        try setQueryMeta(
-          db, serverID: serverID, queryKey: queryKey,
-          totalCount: meta?.totalCount, orderStale: meta?.orderStale ?? false,
-          stamp: .completed)
+  public func markQueryFillComplete(queryKey: QueryKey, serverID: UUID) async throws {
+    try await wrappingAsync("markQueryFillComplete") {
+      try await writer.write {
+        try Self.stampFillComplete($0, queryKey: queryKey, serverID: serverID)
       }
     }
+  }
+
+  private static func stampFillComplete(
+    _ db: GRDB.Database, queryKey: QueryKey, serverID: UUID
+  ) throws {
+    let meta =
+      try QueryMetaRow
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+      .fetchOne(db)
+    try setQueryMeta(
+      db, serverID: serverID, queryKey: queryKey,
+      totalCount: meta?.totalCount, orderStale: meta?.orderStale ?? false,
+      stamp: .completed)
   }
 
   /// When this query's order was last filled to completion, or `nil` if it never
   /// was (or was truncated since by a page-1 replace).
-  public func queryFillCompletedAt(queryKey: QueryKey, serverID: UUID) throws(DatabaseError)
-    -> Date?
-  {
-    try wrapping("queryFillCompletedAt") {
-      try writer.read { db in
-        try QueryMetaRow
-          .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
-          .fetchOne(db)?.filledAt
-      }
+  public func queryFillCompletedAt(queryKey: QueryKey, serverID: UUID) async throws -> Date? {
+    try await wrappingAsync("queryFillCompletedAt") {
+      try await writer.read { try Self.fetchFilledAt($0, queryKey: queryKey, serverID: serverID) }
     }
+  }
+
+  private static func fetchFilledAt(
+    _ db: GRDB.Database, queryKey: QueryKey, serverID: UUID
+  ) throws -> Date? {
+    try QueryMetaRow
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey.rawValue)
+      .fetchOne(db)?.filledAt
   }
 
   /// Server total, locally-present count (reflects deletion gaps), and
   /// order-stale flag for a cached query.
-  public func queryStatus(queryKey: QueryKey, serverID: UUID) throws(DatabaseError) -> QueryStatus {
-    try wrapping("queryStatus") {
-      try writer.read { db in
-        try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+  public func queryStatus(queryKey: QueryKey, serverID: UUID) async throws -> QueryStatus {
+    try await wrappingAsync("queryStatus") {
+      try await writer.read {
+        try Self.fetchQueryStatus($0, queryKey: queryKey, serverID: serverID)
       }
     }
   }
@@ -433,7 +492,7 @@ extension Database {
 
   /// Upsert one document row. Every write is the complete object (the list
   /// carries `full_perms`), so this is a straight replace — no merge, no level.
-  private func writeDocumentRow(
+  private static func writeDocumentRow(
     _ db: GRDB.Database, _ domain: Document, serverID: UUID
   ) throws {
     try DocumentRecord(serverId: serverID, domain: domain).upsert(db)
@@ -487,7 +546,7 @@ extension Database {
     case completed
   }
 
-  private func setQueryMeta(
+  private static func setQueryMeta(
     _ db: GRDB.Database, serverID: UUID, queryKey: QueryKey,
     totalCount: UInt?, orderStale: Bool, stamp: FillStamp
   ) throws {

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -35,6 +35,33 @@ extension Database {
     }
   }
 
+  /// Upsert a batch of documents **and** drop their cached notes, in one
+  /// transaction — the changed-metadata delta's write.
+  ///
+  /// A note edit bumps `modified`, so a document the delta refreshes may have
+  /// stale cached notes; the upsert also refreshes its `notesCount`, which is
+  /// what lets the next detail fill re-seed an empty row for free or re-fetch.
+  /// The delta cannot tell a note change from any other field change, so this
+  /// may drop notes that did not actually change.
+  ///
+  /// One transaction rather than an upsert followed by an invalidation,
+  /// because the two are no longer separated by nothing: the `async` accessors
+  /// suspend, and a `createNote` / `deleteNote` write-through landing between
+  /// them would be deleted by the invalidation that follows it. Under
+  /// *Recently browsed* nothing repairs that until the document is fetched
+  /// online again, so the user's just-written note would appear to vanish.
+  public func upsertDocumentsInvalidatingNotes(
+    _ domains: [Document], serverID: UUID
+  ) async throws {
+    guard !domains.isEmpty else { return }
+    try await wrappingAsync("upsertDocumentsInvalidatingNotes") {
+      try await writer.write { db in
+        try Self.writeDocumentRows(db, domains, serverID: serverID)
+        try Self.dropNotes(serverID: serverID, documentIDs: domains.map(\.id), db)
+      }
+    }
+  }
+
   /// Single-row write-through (pessimistic mutation).
   public func upsertDocument(_ domain: Document, serverID: UUID) async throws {
     try await wrappingAsync("upsertDocument") {

--- a/Persistence/Sources/Persistence/Database+Elements.swift
+++ b/Persistence/Sources/Persistence/Database+Elements.swift
@@ -145,6 +145,33 @@ extension Database {
     try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
   }
 
+  /// Read-modify-write the `ui_settings` singleton inside **one** transaction,
+  /// and report whether there was a row to transform.
+  ///
+  /// The alternative — read through one accessor, merge, write through another
+  /// — is two transactions with a suspension between them, so an element sync
+  /// writing a freshly-fetched row in the gap is overwritten by a merge built
+  /// on the row as it was *before* that sync, silently reverting the user and
+  /// permission matrix to a stale copy. On the main actor the two calls used to
+  /// be adjacent and this could not happen; they are not adjacent any more.
+  ///
+  /// `transform` runs inside the write transaction and must stay pure — it is
+  /// handed the current value and returns the one to store.
+  @discardableResult
+  public func updateUISettings(
+    serverID: UUID, _ transform: @escaping @Sendable (UISettings) -> UISettings
+  ) async throws -> Bool {
+    try await wrappingAsync("updateUISettings") {
+      try await writer.write { db in
+        guard let current = try UISettingsRecord.fetchOne(db, key: serverID)?.domain else {
+          return false
+        }
+        try Self.writeUISettings(transform(current), serverID: serverID, db)
+        return true
+      }
+    }
+  }
+
   public func serverConfiguration(serverID: UUID) async throws -> ServerConfiguration? {
     try await wrappingAsync("serverConfiguration") {
       try await writer.read { try ServerConfigurationRecord.fetchOne($0, key: serverID)?.domain }

--- a/Persistence/Sources/Persistence/Database+Elements.swift
+++ b/Persistence/Sources/Persistence/Database+Elements.swift
@@ -2,10 +2,18 @@ import DataModel
 import Foundation
 import GRDB
 
-/// Element-cache operations. Like `Database+Connections`, these are the only
-/// entry points AppShared uses to read or mutate element rows; GRDB stays
-/// sealed inside `Persistence`. Every access goes through ``Database/wrapping``
-/// so a GRDB failure reaches callers as a ``DatabaseError``.
+/// Element-cache operations. These are the only entry points AppShared uses to
+/// read or mutate element rows; GRDB stays sealed inside `Persistence`. Every
+/// access goes through ``Database/wrappingAsync`` so a GRDB failure reaches
+/// callers as a ``DatabaseError``.
+///
+/// **Async only, like every cache table.** Blocking database access is allowed
+/// for the `server` table and nothing else — see the rule and its rationale in
+/// `Database+Connections`. A cache-table query can wait the full 5 s
+/// `busy_timeout` behind another process's writer lock, so a main-actor caller
+/// must suspend on GRDB's own queues rather than park the main thread there.
+/// The query body lives in a `static` taking the `GRDB.Database` handle, which
+/// is also what in-package seeding reuses without needing a blocking accessor.
 ///
 /// Reads are pure cache reads (no network — that's the caching repository's
 /// `sync`). Writes are either a full per-server reconcile (`replaceElements`,
@@ -31,30 +39,38 @@ extension Database {
   /// All cached rows of one element kind for a server, ordered by name.
   public func elements<R: ElementRecord>(
     _ type: R.Type, serverID: UUID
-  ) throws(DatabaseError) -> [R.Domain] {
-    try wrapping("elements(\(R.databaseTableName))") {
-      try writer.read { db in
-        try R
-          .filter(Column("server_id") == serverID)
-          .order(Column("name"))
-          .fetchAll(db)
-          .map(\.domain)
-      }
+  ) async throws -> [R.Domain] {
+    try await wrappingAsync("elements(\(R.databaseTableName))") {
+      try await writer.read { try Self.fetchElements(R.self, serverID: serverID, $0) }
     }
+  }
+
+  static func fetchElements<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID, _ db: GRDB.Database
+  ) throws -> [R.Domain] {
+    try R
+      .filter(Column("server_id") == serverID)
+      .order(Column("name"))
+      .fetchAll(db)
+      .map(\.domain)
   }
 
   /// A single cached element by `(server, id)`, or `nil` if not cached.
   public func element<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
-  ) throws(DatabaseError) -> R.Domain? {
-    try wrapping("element(\(R.databaseTableName))") {
-      try writer.read { db in
-        try R
-          .filter(Column("server_id") == serverID && Column("id") == id)
-          .fetchOne(db)?
-          .domain
-      }
+  ) async throws -> R.Domain? {
+    try await wrappingAsync("element(\(R.databaseTableName))") {
+      try await writer.read { try Self.fetchElement(R.self, serverID: serverID, id: id, $0) }
     }
+  }
+
+  private static func fetchElement<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID, id: UInt, _ db: GRDB.Database
+  ) throws -> R.Domain? {
+    try R
+      .filter(Column("server_id") == serverID && Column("id") == id)
+      .fetchOne(db)?
+      .domain
   }
 
   /// Replace the entire cached set for a server in one transaction: delete the
@@ -67,75 +83,85 @@ extension Database {
   /// reconcile survives the duplicate.
   public func replaceElements<R: ElementRecord>(
     _ domains: [R.Domain], of type: R.Type, serverID: UUID
-  ) throws(DatabaseError) {
-    try wrapping("replaceElements(\(R.databaseTableName))") {
-      try writer.write { db in
-        try R.filter(Column("server_id") == serverID).deleteAll(db)
-        for domain in domains {
-          try R(serverId: serverID, domain: domain).upsert(db)
-        }
-      }
+  ) async throws {
+    try await wrappingAsync("replaceElements(\(R.databaseTableName))") {
+      try await writer.write { try Self.writeElements(domains, of: R.self, serverID: serverID, $0) }
+    }
+  }
+
+  static func writeElements<R: ElementRecord>(
+    _ domains: [R.Domain], of type: R.Type, serverID: UUID, _ db: GRDB.Database
+  ) throws {
+    try R.filter(Column("server_id") == serverID).deleteAll(db)
+    for domain in domains {
+      try R(serverId: serverID, domain: domain).upsert(db)
     }
   }
 
   /// Insert or replace a single cached row (pessimistic mutation write-through).
   public func upsertElement<R: ElementRecord>(
     _ domain: R.Domain, of type: R.Type, serverID: UUID
-  ) throws(DatabaseError) {
-    try wrapping("upsertElement(\(R.databaseTableName))") {
-      try writer.write { db in
-        try R(serverId: serverID, domain: domain).upsert(db)
-      }
+  ) async throws {
+    try await wrappingAsync("upsertElement(\(R.databaseTableName))") {
+      try await writer.write { try R(serverId: serverID, domain: domain).upsert($0) }
     }
   }
 
   /// Delete a single cached row by `(server, id)` (pessimistic delete).
   public func deleteElement<R: ElementRecord>(
     _ type: R.Type, serverID: UUID, id: UInt
-  ) throws(DatabaseError) {
-    try wrapping("deleteElement(\(R.databaseTableName))") {
-      try writer.write { db in
-        _ =
-          try R
-          .filter(Column("server_id") == serverID && Column("id") == id)
-          .deleteAll(db)
-      }
+  ) async throws {
+    try await wrappingAsync("deleteElement(\(R.databaseTableName))") {
+      try await writer.write { try Self.removeElement(R.self, serverID: serverID, id: id, $0) }
     }
+  }
+
+  private static func removeElement<R: ElementRecord>(
+    _ type: R.Type, serverID: UUID, id: UInt, _ db: GRDB.Database
+  ) throws {
+    _ =
+      try R
+      .filter(Column("server_id") == serverID && Column("id") == id)
+      .deleteAll(db)
   }
 
   // MARK: - Singletons
 
-  public func uiSettings(serverID: UUID) throws(DatabaseError) -> UISettings? {
-    try wrapping("uiSettings") {
-      try writer.read { db in
-        try UISettingsRecord.fetchOne(db, key: serverID)?.domain
-      }
+  public func uiSettings(serverID: UUID) async throws -> UISettings? {
+    try await wrappingAsync("uiSettings") {
+      try await writer.read { try UISettingsRecord.fetchOne($0, key: serverID)?.domain }
     }
   }
 
-  public func setUISettings(_ value: UISettings, serverID: UUID) throws(DatabaseError) {
-    try wrapping("setUISettings") {
-      try writer.write { db in
-        try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
-      }
+  public func setUISettings(_ value: UISettings, serverID: UUID) async throws {
+    try await wrappingAsync("setUISettings") {
+      try await writer.write { try Self.writeUISettings(value, serverID: serverID, $0) }
     }
   }
 
-  public func serverConfiguration(serverID: UUID) throws(DatabaseError) -> ServerConfiguration? {
-    try wrapping("serverConfiguration") {
-      try writer.read { db in
-        try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
-      }
+  static func writeUISettings(
+    _ value: UISettings, serverID: UUID, _ db: GRDB.Database
+  ) throws {
+    try UISettingsRecord(serverId: serverID, domain: value).upsert(db)
+  }
+
+  public func serverConfiguration(serverID: UUID) async throws -> ServerConfiguration? {
+    try await wrappingAsync("serverConfiguration") {
+      try await writer.read { try ServerConfigurationRecord.fetchOne($0, key: serverID)?.domain }
     }
   }
 
   public func setServerConfiguration(
     _ value: ServerConfiguration, serverID: UUID
-  ) throws(DatabaseError) {
-    try wrapping("setServerConfiguration") {
-      try writer.write { db in
-        try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)
-      }
+  ) async throws {
+    try await wrappingAsync("setServerConfiguration") {
+      try await writer.write { try Self.writeServerConfiguration(value, serverID: serverID, $0) }
     }
+  }
+
+  static func writeServerConfiguration(
+    _ value: ServerConfiguration, serverID: UUID, _ db: GRDB.Database
+  ) throws {
+    try ServerConfigurationRecord(serverId: serverID, domain: value).upsert(db)
   }
 }

--- a/Persistence/Sources/Persistence/Database+Maintenance.swift
+++ b/Persistence/Sources/Persistence/Database+Maintenance.swift
@@ -12,7 +12,9 @@ extension Database {
   ///
   /// All cache tables FK-cascade from `server`, so this is *not* the same as
   /// dropping connections; it clears the caches while the connections remain.
-  public func clearCache() throws(DatabaseError) {
+  ///
+  /// Async only, like every cache table — see the rule in `Database+Connections`.
+  public func clearCache() async throws {
     let tables =
       V3_CreateElementCache.multiRowTables
       + V3_CreateElementCache.singletonTables
@@ -20,8 +22,8 @@ extension Database {
       + V5_CreateDocumentDetailCache.tables
       + V6_DropProjectionAndQueryOrderFK.tables
       + V7_CreateQuerySyncError.tables
-    try wrapping("clearCache") {
-      try writer.write { db in
+    try await wrappingAsync("clearCache") {
+      try await writer.write { db in
         for table in tables {
           try db.execute(sql: "DELETE FROM \(table)")
         }

--- a/Persistence/Sources/Persistence/Database+QuerySyncError.swift
+++ b/Persistence/Sources/Persistence/Database+QuerySyncError.swift
@@ -24,31 +24,49 @@ public struct QuerySyncError: Sendable, Equatable, Identifiable {
 /// Per-query sync-failure tracking (`query_sync_error`). The proactive fill and
 /// membership sweep record a row when a view is rejected and delete it on the
 /// next success; the Offline & Sync screen observes the active server's set.
+///
+/// Async only, like every cache table — see the rule in `Database+Connections`.
 extension Database {
   /// Record (upsert) the latest sync failure for a query.
   public func recordQuerySyncError(
     serverID: UUID, queryKey: String, savedViewName: String?, message: String,
     at date: Date = Date()
-  ) throws(DatabaseError) {
-    try wrapping("recordQuerySyncError") {
-      try writer.write { db in
-        try QuerySyncErrorRecord(
-          serverId: serverID, queryKey: queryKey, savedViewName: savedViewName,
-          message: message, failedAt: date.timeIntervalSinceReferenceDate
-        ).upsert(db)
+  ) async throws {
+    try await wrappingAsync("recordQuerySyncError") {
+      try await writer.write {
+        try Self.writeQuerySyncError(
+          $0, serverID: serverID, queryKey: queryKey, savedViewName: savedViewName,
+          message: message, at: date)
       }
     }
   }
 
+  private static func writeQuerySyncError(
+    _ db: GRDB.Database, serverID: UUID, queryKey: String, savedViewName: String?,
+    message: String, at date: Date
+  ) throws {
+    try QuerySyncErrorRecord(
+      serverId: serverID, queryKey: queryKey, savedViewName: savedViewName,
+      message: message, failedAt: date.timeIntervalSinceReferenceDate
+    ).upsert(db)
+  }
+
   /// Clear a query's recorded failure (called when it next syncs successfully).
-  public func clearQuerySyncError(serverID: UUID, queryKey: String) throws(DatabaseError) {
-    try wrapping("clearQuerySyncError") {
-      _ = try writer.write { db in
-        try QuerySyncErrorRecord
-          .filter(Column("server_id") == serverID && Column("query_key") == queryKey)
-          .deleteAll(db)
+  public func clearQuerySyncError(serverID: UUID, queryKey: String) async throws {
+    try await wrappingAsync("clearQuerySyncError") {
+      try await writer.write {
+        try Self.removeQuerySyncError($0, serverID: serverID, queryKey: queryKey)
       }
     }
+  }
+
+  private static func removeQuerySyncError(
+    _ db: GRDB.Database, serverID: UUID, queryKey: String
+  ) throws {
+    _ =
+      try QuerySyncErrorRecord
+      .filter(Column("server_id") == serverID && Column("query_key") == queryKey)
+      .deleteAll(db)
   }
 
   /// Observe this server's recorded sync failures (newest first), emitting the

--- a/Persistence/Sources/Persistence/Database+Seeded.swift
+++ b/Persistence/Sources/Persistence/Database+Seeded.swift
@@ -1,5 +1,6 @@
 import DataModel
 import Foundation
+import GRDB
 
 extension Database {
   /// Build an in-memory database pre-populated with one server and the given
@@ -7,6 +8,13 @@ extension Database {
   /// repository with pre-filled dicts. Under the source-of-truth model every
   /// repository fronts a DB, so a preview's element data lives here and is
   /// surfaced through the same `observe…` live queries as production.
+  ///
+  /// Stays synchronous — a SwiftUI preview builds its store in a property
+  /// initializer and cannot await — without needing blocking cache accessors:
+  /// the cache tables are `async` only outside the package (see the rule in
+  /// `Database+Connections`), but seeding lives *inside* it, so it composes the
+  /// same `static` query bodies those accessors use into one `writer.write`.
+  /// One transaction rather than a dozen is the right shape for a seed anyway.
   ///
   /// Mirrors the inline `makeDatabase` helper in `ElementCacheTests`.
   public static func seeded(
@@ -24,30 +32,34 @@ extension Database {
     serverConfiguration: ServerConfiguration? = nil
   ) throws -> Database {
     let database = try Database.inMemory()
+    // `server` is the one table with a blocking accessor, and this row has to
+    // exist before the cache rows that FK-reference it.
     try database.upsertConnection(
       ConnectionRecord(
         id: serverID,
         url: URL(string: "https://paperless.example.com/api/")!,
         user: .init(id: 1, isSuperUser: true, username: "preview")))
 
-    try database.replaceElements(tags, of: TagRecord.self, serverID: serverID)
-    try database.replaceElements(correspondents, of: CorrespondentRecord.self, serverID: serverID)
-    try database.replaceElements(documentTypes, of: DocumentTypeRecord.self, serverID: serverID)
-    try database.replaceElements(storagePaths, of: StoragePathRecord.self, serverID: serverID)
-    try database.replaceElements(savedViews, of: SavedViewRecord.self, serverID: serverID)
-    try database.replaceElements(users, of: UserRecord.self, serverID: serverID)
-    try database.replaceElements(groups, of: UserGroupRecord.self, serverID: serverID)
-    try database.replaceElements(customFields, of: CustomFieldRecord.self, serverID: serverID)
+    try database.wrapping("seeded") {
+      try database.writer.write { db in
+        try writeElements(tags, of: TagRecord.self, serverID: serverID, db)
+        try writeElements(correspondents, of: CorrespondentRecord.self, serverID: serverID, db)
+        try writeElements(documentTypes, of: DocumentTypeRecord.self, serverID: serverID, db)
+        try writeElements(storagePaths, of: StoragePathRecord.self, serverID: serverID, db)
+        try writeElements(savedViews, of: SavedViewRecord.self, serverID: serverID, db)
+        try writeElements(users, of: UserRecord.self, serverID: serverID, db)
+        try writeElements(groups, of: UserGroupRecord.self, serverID: serverID, db)
+        try writeElements(customFields, of: CustomFieldRecord.self, serverID: serverID, db)
 
-    if !documents.isEmpty {
-      try database.upsertDocuments(documents, serverID: serverID)
-    }
+        try writeDocumentRows(db, documents, serverID: serverID)
 
-    if let uiSettings {
-      try database.setUISettings(uiSettings, serverID: serverID)
-    }
-    if let serverConfiguration {
-      try database.setServerConfiguration(serverConfiguration, serverID: serverID)
+        if let uiSettings {
+          try writeUISettings(uiSettings, serverID: serverID, db)
+        }
+        if let serverConfiguration {
+          try writeServerConfiguration(serverConfiguration, serverID: serverID, db)
+        }
+      }
     }
     return database
   }

--- a/Persistence/Sources/Persistence/Database+SyncState.swift
+++ b/Persistence/Sources/Persistence/Database+SyncState.swift
@@ -6,31 +6,41 @@ import GRDB
 /// `CachingRepository` and reset by `clearCache`. Dates cross the boundary as
 /// `Date?`; the on-disk shape (REAL `timeIntervalSinceReferenceDate`) stays
 /// inside `Persistence`.
+///
+/// Async only, like every cache table — see the rule in `Database+Connections`.
 extension Database {
   /// The newest document `modified` the changed-metadata delta has applied for
   /// this server, or `nil` if it has never baselined.
-  public func deltaWatermark(serverID: UUID) throws(DatabaseError) -> Date? {
-    try wrapping("deltaWatermark") {
-      try date(\.deltaWatermark, serverID: serverID)
+  public func deltaWatermark(serverID: UUID) async throws -> Date? {
+    try await wrappingAsync("deltaWatermark") {
+      try await writer.read { try Self.date(\.deltaWatermark, serverID: serverID, $0) }
     }
   }
 
-  public func setDeltaWatermark(_ date: Date?, serverID: UUID) throws(DatabaseError) {
-    try wrapping("setDeltaWatermark") {
-      try update(serverID: serverID) { $0.deltaWatermark = date?.timeIntervalSinceReferenceDate }
+  public func setDeltaWatermark(_ date: Date?, serverID: UUID) async throws {
+    try await wrappingAsync("setDeltaWatermark") {
+      try await writer.write {
+        try Self.updateSyncState($0, serverID: serverID) {
+          $0.deltaWatermark = date?.timeIntervalSinceReferenceDate
+        }
+      }
     }
   }
 
   /// When this server's library was last fully filled, or `nil` if never.
-  public func libraryCoverageAt(serverID: UUID) throws(DatabaseError) -> Date? {
-    try wrapping("libraryCoverageAt") {
-      try date(\.libraryCoverageAt, serverID: serverID)
+  public func libraryCoverageAt(serverID: UUID) async throws -> Date? {
+    try await wrappingAsync("libraryCoverageAt") {
+      try await writer.read { try Self.date(\.libraryCoverageAt, serverID: serverID, $0) }
     }
   }
 
-  public func setLibraryCoverageAt(_ date: Date?, serverID: UUID) throws(DatabaseError) {
-    try wrapping("setLibraryCoverageAt") {
-      try update(serverID: serverID) { $0.libraryCoverageAt = date?.timeIntervalSinceReferenceDate }
+  public func setLibraryCoverageAt(_ date: Date?, serverID: UUID) async throws {
+    try await wrappingAsync("setLibraryCoverageAt") {
+      try await writer.write {
+        try Self.updateSyncState($0, serverID: serverID) {
+          $0.libraryCoverageAt = date?.timeIntervalSinceReferenceDate
+        }
+      }
     }
   }
 
@@ -61,27 +71,17 @@ extension Database {
 
   // MARK: - Helpers
 
-  private func date(
-    _ keyPath: KeyPath<ServerSyncStateRecord, Double?>, serverID: UUID
+  private static func date(
+    _ keyPath: KeyPath<ServerSyncStateRecord, Double?>, serverID: UUID, _ db: GRDB.Database
   ) throws -> Date? {
-    try writer.read { db in
-      guard let stamp = try ServerSyncStateRecord.fetchOne(db, key: serverID)?[keyPath: keyPath]
-      else { return nil }
-      return Date(timeIntervalSinceReferenceDate: stamp)
-    }
+    guard let stamp = try ServerSyncStateRecord.fetchOne(db, key: serverID)?[keyPath: keyPath]
+    else { return nil }
+    return Date(timeIntervalSinceReferenceDate: stamp)
   }
 
-  /// Read-modify-write upsert preserving the row's other column.
-  private func update(
-    serverID: UUID, _ mutate: (inout ServerSyncStateRecord) -> Void
-  ) throws {
-    try writer.write { db in
-      try Self.updateSyncState(db, serverID: serverID, mutate)
-    }
-  }
-
-  /// Same read-modify-write, for callers that already hold a transaction and
-  /// need the change to commit atomically with the rest of their work.
+  /// Read-modify-write upsert preserving the row's other column. Takes the
+  /// caller's transaction so the change commits atomically with the rest of
+  /// its work.
   static func updateSyncState(
     _ db: GRDB.Database, serverID: UUID, _ mutate: (inout ServerSyncStateRecord) -> Void
   ) throws {

--- a/Persistence/Sources/Persistence/Database.swift
+++ b/Persistence/Sources/Persistence/Database.swift
@@ -225,11 +225,43 @@ extension Database {
   /// nothing on an accessor that stays untyped-`throws`, so the typed signature
   /// is the part to keep: drop it and raw `GRDB.DatabaseError`s escape the
   /// package again.
+  ///
+  /// Used by the `server`-table accessors, the only blocking ones left (see the
+  /// rule in `Database+Connections`), and by `Database.seeded`, which composes
+  /// the cache tables' `static` query bodies into one in-package transaction.
+  /// Every cache-table accessor uses ``wrappingAsync(_:_:)``.
   func wrapping<T>(_ operation: String, _ body: () throws -> T) throws(DatabaseError) -> T {
     do {
       return try body()
     } catch let error as DatabaseError {
       throw error
+    } catch {
+      Logger.persistence.error(
+        "Database operation '\(operation, privacy: .public)' failed: \(error)")
+      throw DatabaseError.operationFailed(operation: operation, underlying: error)
+    }
+  }
+
+  /// ``wrapping(_:_:)`` for the cache-table accessors — same re-wrapping, with
+  /// one deliberate hole: `CancellationError` passes through untouched.
+  ///
+  /// GRDB's `async` `read` / `write` throw `CancellationError` when the
+  /// surrounding task is cancelled, and callers discriminate on exactly that
+  /// (`catch is CancellationError`) to tell *"we were told to stop"* from
+  /// *"the write failed"* — a cancelled library fill must not be recorded as a
+  /// per-view sync error. Rewrapping it as ``DatabaseError/operationFailed``
+  /// would erase that distinction, and `throws(DatabaseError)` cannot express
+  /// "or a cancellation", which is why the cache tables' accessors are
+  /// untyped-`throws` while the `server` table's keep the typed signature.
+  func wrappingAsync<T>(
+    _ operation: String, _ body: () async throws -> T
+  ) async throws -> T {
+    do {
+      return try await body()
+    } catch let error as DatabaseError {
+      throw error
+    } catch is CancellationError {
+      throw CancellationError()
     } catch {
       Logger.persistence.error(
         "Database operation '\(operation, privacy: .public)' failed: \(error)")

--- a/Persistence/Tests/PersistenceTests/AtomicCacheUpdateTests.swift
+++ b/Persistence/Tests/PersistenceTests/AtomicCacheUpdateTests.swift
@@ -1,0 +1,259 @@
+import DataModel
+import Foundation
+import GRDB
+import Testing
+
+@testable import Persistence
+
+/// Covers the two accessors that exist purely to be *one* transaction.
+///
+/// Both replaced a read-or-write pair in `CachingRepository` that was atomic
+/// only because the main actor happened to run the two calls back to back. The
+/// `async` accessors suspend, so anything else can now commit in between, and
+/// the fix is to push the whole sequence into a single `writer.write`.
+///
+/// The seam these tests can reach is an in-memory `DatabaseQueue`, which
+/// serializes every access — so a genuinely concurrent writer cannot be staged
+/// here, and "one transaction" is asserted directly instead, by counting
+/// commits through a GRDB `TransactionObserver`. That is the property that
+/// closes the window: with one commit there is no point at which another writer
+/// could observe or overwrite a half-applied update.
+@Suite("AtomicCacheUpdate")
+struct AtomicCacheUpdateTests {
+  // MARK: - Helpers
+
+  /// Counts committed transactions on a connection, so a test can assert that
+  /// an accessor takes exactly one.
+  private final class CommitCounter: TransactionObserver, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _commits = 0
+
+    var commits: Int {
+      lock.lock()
+      defer { lock.unlock() }
+      return _commits
+    }
+
+    func reset() {
+      lock.lock()
+      _commits = 0
+      lock.unlock()
+    }
+
+    func observes(eventsOfKind _: DatabaseEventKind) -> Bool { true }
+    func databaseDidChange(with _: DatabaseEvent) {}
+    func databaseDidRollback(_: GRDB.Database) {}
+
+    func databaseDidCommit(_: GRDB.Database) {
+      lock.lock()
+      _commits += 1
+      lock.unlock()
+    }
+  }
+
+  /// A one-shot flag a `@Sendable` transform can set.
+  private final class Ran: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+
+    var value: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return flag
+    }
+
+    func mark() {
+      lock.lock()
+      flag = true
+      lock.unlock()
+    }
+  }
+
+  private func date(_ t: TimeInterval) -> Date { Date(timeIntervalSince1970: t) }
+
+  private func database(_ server: UUID) throws -> Persistence.Database {
+    try Database.seeded(serverID: server)
+  }
+
+  /// Attach a commit counter and hand it back zeroed, so the caller measures
+  /// only what it does next.
+  private func countingCommits(on database: Persistence.Database) throws -> CommitCounter {
+    let counter = CommitCounter()
+    try database.writer.write { db in
+      db.add(transactionObserver: counter, extent: .databaseLifetime)
+    }
+    counter.reset()
+    return counter
+  }
+
+  private func doc(_ id: UInt, title: String = "Doc", notesCount: Int = 1) -> Document {
+    Document(
+      id: id, title: title, created: date(1000), tags: [], owner: .user(1),
+      notes: NotesPayload(count: notesCount))
+  }
+
+  private func note(_ id: UInt, _ text: String) -> DocumentNote {
+    DocumentNote(id: id, note: text, created: date(1000), user: nil)
+  }
+
+  private func uiSettings(user: String, appTitle: String?) -> UISettings {
+    UISettings(
+      user: User(id: 1, isSuperUser: false, username: user, groups: []),
+      settings: UISettingsSettings(appTitle: appTitle),
+      permissions: UserPermissions.empty(with: { $0.set(.view, to: true, for: .document) }))
+  }
+
+  // MARK: - upsertDocumentsInvalidatingNotes
+
+  @Test("upsertDocumentsInvalidatingNotes refreshes the rows and drops their notes")
+  func combinedUpsertAndInvalidate() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try await database.upsertDocuments([doc(1), doc(2)], serverID: server)
+    try await database.setNotes([note(1, "one")], serverID: server, documentID: 1)
+    try await database.setNotes([note(2, "two")], serverID: server, documentID: 2)
+
+    try await database.upsertDocumentsInvalidatingNotes(
+      [doc(1, title: "Renamed")], serverID: server)
+
+    #expect(try await database.document(serverID: server, id: 1)?.title == "Renamed")
+    #expect(try await database.notes(serverID: server, documentID: 1) == nil)
+    // A document outside the batch keeps both its row and its notes.
+    #expect(try await database.notes(serverID: server, documentID: 2)?.count == 1)
+  }
+
+  @Test("upsertDocumentsInvalidatingNotes takes exactly one transaction")
+  func combinedUpsertIsOneTransaction() async throws {
+    let server = UUID()
+    let database = try database(server)
+    try await database.upsertDocuments([doc(1)], serverID: server)
+    try await database.setNotes([note(1, "one")], serverID: server, documentID: 1)
+
+    let counter = try countingCommits(on: database)
+    try await database.upsertDocumentsInvalidatingNotes([doc(1)], serverID: server)
+
+    // The regression this guards: as two accessors it was two commits, and a
+    // `createNote` write-through committing between them was deleted by the
+    // invalidation that followed it — invisible under *Recently browsed* until
+    // the document was fetched online again.
+    #expect(counter.commits == 1)
+  }
+
+  @Test("upsertDocumentsInvalidatingNotes writes nothing for an empty batch")
+  func combinedUpsertEmptyBatch() async throws {
+    let server = UUID()
+    let database = try database(server)
+    try await database.upsertDocuments([doc(1)], serverID: server)
+    try await database.setNotes([note(1, "one")], serverID: server, documentID: 1)
+
+    let counter = try countingCommits(on: database)
+    try await database.upsertDocumentsInvalidatingNotes([], serverID: server)
+
+    #expect(counter.commits == 0)
+    #expect(try await database.notes(serverID: server, documentID: 1)?.count == 1)
+  }
+
+  @Test("upsertDocumentsInvalidatingNotes is scoped to one server")
+  func combinedUpsertServerScoping() async throws {
+    let serverA = UUID()
+    let serverB = UUID()
+    let database = try database(serverA)
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverB,
+        url: URL(string: "https://other.example.com/api/")!,
+        user: .init(id: 1, isSuperUser: true, username: "bob")))
+
+    try await database.upsertDocuments([doc(1)], serverID: serverA)
+    try await database.upsertDocuments([doc(1)], serverID: serverB)
+    try await database.setNotes([note(1, "a")], serverID: serverA, documentID: 1)
+    try await database.setNotes([note(1, "b")], serverID: serverB, documentID: 1)
+
+    try await database.upsertDocumentsInvalidatingNotes([doc(1)], serverID: serverA)
+
+    #expect(try await database.notes(serverID: serverA, documentID: 1) == nil)
+    #expect(try await database.notes(serverID: serverB, documentID: 1)?.count == 1)
+  }
+
+  // MARK: - updateUISettings
+
+  @Test("updateUISettings merges against the row as it stands inside the transaction")
+  func updateUISettingsReadsInsideTheTransaction() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    try await database.setUISettings(uiSettings(user: "alice", appTitle: "old"), serverID: server)
+    // Stands in for an element sync landing a freshly-fetched row. The bug this
+    // guards was a read *outside* the write transaction: the merge was built on
+    // the row as it looked before this write and put "alice" back.
+    try await database.setUISettings(uiSettings(user: "bob", appTitle: "old"), serverID: server)
+
+    let replacement = UISettingsSettings(appTitle: "new")
+    let updated = try await database.updateUISettings(serverID: server) { current in
+      UISettings(user: current.user, settings: replacement, permissions: current.permissions)
+    }
+
+    #expect(updated)
+    let stored = try #require(try await database.uiSettings(serverID: server))
+    #expect(stored.settings.appTitle == "new")
+    #expect(stored.user.username == "bob")
+    #expect(stored.permissions.test(.view, for: .document))
+  }
+
+  @Test("updateUISettings takes exactly one transaction")
+  func updateUISettingsIsOneTransaction() async throws {
+    let server = UUID()
+    let database = try database(server)
+    try await database.setUISettings(uiSettings(user: "alice", appTitle: "old"), serverID: server)
+
+    let counter = try countingCommits(on: database)
+    try await database.updateUISettings(serverID: server) { current in
+      UISettings(
+        user: current.user, settings: UISettingsSettings(appTitle: "new"),
+        permissions: current.permissions)
+    }
+
+    #expect(counter.commits == 1)
+  }
+
+  @Test("updateUISettings reports a missing row and writes nothing")
+  func updateUISettingsWithoutARow() async throws {
+    let server = UUID()
+    let database = try database(server)
+
+    let transformRan = Ran()
+    let updated = try await database.updateUISettings(serverID: server) { current in
+      transformRan.mark()
+      return current
+    }
+
+    #expect(!updated)
+    #expect(!transformRan.value)
+    #expect(try await database.uiSettings(serverID: server) == nil)
+  }
+
+  @Test("updateUISettings touches only the named server's row")
+  func updateUISettingsServerScoping() async throws {
+    let serverA = UUID()
+    let serverB = UUID()
+    let database = try database(serverA)
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: serverB,
+        url: URL(string: "https://other.example.com/api/")!,
+        user: .init(id: 1, isSuperUser: true, username: "bob")))
+
+    try await database.setUISettings(uiSettings(user: "alice", appTitle: "a"), serverID: serverA)
+    try await database.setUISettings(uiSettings(user: "bob", appTitle: "b"), serverID: serverB)
+
+    try await database.updateUISettings(serverID: serverA) { current in
+      UISettings(
+        user: current.user, settings: UISettingsSettings(appTitle: "changed"),
+        permissions: current.permissions)
+    }
+
+    #expect(try await database.uiSettings(serverID: serverA)?.settings.appTitle == "changed")
+    #expect(try await database.uiSettings(serverID: serverB)?.settings.appTitle == "b")
+  }
+}

--- a/Persistence/Tests/PersistenceTests/DetailFillTests.swift
+++ b/Persistence/Tests/PersistenceTests/DetailFillTests.swift
@@ -41,63 +41,64 @@ struct DetailFillTests {
   // MARK: - Zero-note seed
 
   @Test("seed writes an empty notes row only for zero-note docs without one")
-  func seedZeroNoteDocs() throws {
+  func seedZeroNoteDocs() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [
         doc(1, notesCount: 0),  // seeded
         doc(2, notesCount: 0),  // already has a row → skipped
         doc(3, notesCount: 2),  // has notes → not seeded
       ], serverID: server)
     // Doc 2 already cached (non-empty here, could be anything) — must not be touched.
-    try database.setNotes(
+    try await database.setNotes(
       [.init(id: 9, note: "x", created: date(1))], serverID: server, documentID: 2)
 
-    let seeded = try database.seedEmptyNotesForZeroCountDocuments(serverID: server)
+    let seeded = try await database.seedEmptyNotesForZeroCountDocuments(serverID: server)
     #expect(seeded == 1)
 
-    #expect(try database.notes(serverID: server, documentID: 1) == [])
+    #expect(try await database.notes(serverID: server, documentID: 1) == [])
     // Doc 2's existing row is untouched (still one note), not overwritten with [].
-    #expect(try database.notes(serverID: server, documentID: 2)?.count == 1)
+    #expect(try await database.notes(serverID: server, documentID: 2)?.count == 1)
     // Doc 3 (has notes) is left for the network fetch — no row yet.
-    #expect(try database.notes(serverID: server, documentID: 3) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 3) == nil)
   }
 
   @Test("seed is idempotent — a second pass seeds nothing")
-  func seedIdempotent() throws {
+  func seedIdempotent() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments([doc(1, notesCount: 0), doc(2, notesCount: 0)], serverID: server)
+    try await database.upsertDocuments(
+      [doc(1, notesCount: 0), doc(2, notesCount: 0)], serverID: server)
 
-    #expect(try database.seedEmptyNotesForZeroCountDocuments(serverID: server) == 2)
-    #expect(try database.seedEmptyNotesForZeroCountDocuments(serverID: server) == 0)
+    #expect(try await database.seedEmptyNotesForZeroCountDocuments(serverID: server) == 2)
+    #expect(try await database.seedEmptyNotesForZeroCountDocuments(serverID: server) == 0)
   }
 
   // MARK: - Needs-fetch sets
 
   @Test("documentIDsNeedingNotesFetch = notesCount>0 docs without a cached row")
-  func needsNotesFetch() throws {
+  func needsNotesFetch() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [
         doc(1, notesCount: 0),  // no notes → free seed, never fetched
         doc(2, notesCount: 3),  // needs fetch
         doc(3, notesCount: 1),  // already cached → excluded
       ], serverID: server)
-    try database.setNotes(
+    try await database.setNotes(
       [.init(id: 9, note: "x", created: date(1))], serverID: server, documentID: 3)
 
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: server) == [2])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: server) == [2])
 
     // Seeding zero-note docs does not add them to the fetch set.
-    try database.seedEmptyNotesForZeroCountDocuments(serverID: server)
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: server) == [2])
+    try await database.seedEmptyNotesForZeroCountDocuments(serverID: server)
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: server) == [2])
   }
 
   @Test("documentIDsMissingFileMetadata keys on the current version, not any version")
-  func missingFileMetadata() throws {
+  func missingFileMetadata() async throws {
     let server = UUID()
     let database = try database(server)
     let multiVersion = doc(
@@ -106,48 +107,48 @@ struct DetailFillTests {
         DocumentVersion(id: 1, added: date(1000), isRoot: true),
         DocumentVersion(id: 9, added: date(5000), isRoot: false),  // current
       ])
-    try database.upsertDocuments([multiVersion, doc(2)], serverID: server)
+    try await database.upsertDocuments([multiVersion, doc(2)], serverID: server)
 
     // Nothing cached → both missing.
-    #expect(try Set(database.documentIDsMissingFileMetadata(serverID: server)) == [1, 2])
+    #expect(try await Set(database.documentIDsMissingFileMetadata(serverID: server)) == [1, 2])
 
     // Caching an *old* version (1) does not satisfy doc 1 — current is 9.
-    try database.setFileMetadata(metadata("old"), serverID: server, versionID: 1)
-    #expect(try Set(database.documentIDsMissingFileMetadata(serverID: server)) == [1, 2])
+    try await database.setFileMetadata(metadata("old"), serverID: server, versionID: 1)
+    #expect(try await Set(database.documentIDsMissingFileMetadata(serverID: server)) == [1, 2])
 
     // Caching the current version (9) clears doc 1. Doc 2's current version is
     // its own id (no versions) → cache under id 2.
-    try database.setFileMetadata(metadata("current"), serverID: server, versionID: 9)
-    try database.setFileMetadata(metadata("doc2"), serverID: server, versionID: 2)
-    #expect(try database.documentIDsMissingFileMetadata(serverID: server).isEmpty)
+    try await database.setFileMetadata(metadata("current"), serverID: server, versionID: 9)
+    try await database.setFileMetadata(metadata("doc2"), serverID: server, versionID: 2)
+    #expect(try await database.documentIDsMissingFileMetadata(serverID: server).isEmpty)
   }
 
   // MARK: - Invalidation
 
   @Test("invalidateNotes drops only the named docs' rows")
-  func invalidate() throws {
+  func invalidate() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(1, notesCount: 1), doc(2, notesCount: 1), doc(3, notesCount: 1)], serverID: server)
     for id in [UInt(1), 2, 3] {
-      try database.setNotes(
+      try await database.setNotes(
         [.init(id: id, note: "n", created: date(1))], serverID: server, documentID: id)
     }
 
-    try database.invalidateNotes(serverID: server, documentIDs: [1, 3])
+    try await database.invalidateNotes(serverID: server, documentIDs: [1, 3])
 
-    #expect(try database.notes(serverID: server, documentID: 1) == nil)
-    #expect(try database.notes(serverID: server, documentID: 2)?.count == 1)
-    #expect(try database.notes(serverID: server, documentID: 3) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 1) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 2)?.count == 1)
+    #expect(try await database.notes(serverID: server, documentID: 3) == nil)
     // The invalidated docs (which have notes) resurface in the fetch set.
-    #expect(try Set(database.documentIDsNeedingNotesFetch(serverID: server)) == [1, 3])
+    #expect(try await Set(database.documentIDsNeedingNotesFetch(serverID: server)) == [1, 3])
   }
 
   // MARK: - Server scoping
 
   @Test("all detail-fill queries are scoped to one server")
-  func serverScoping() throws {
+  func serverScoping() async throws {
     let serverA = UUID()
     let serverB = UUID()
     let database = try database(serverA)
@@ -157,48 +158,50 @@ struct DetailFillTests {
         url: URL(string: "https://other.example.com/api/")!,
         user: .init(id: 1, isSuperUser: true, username: "bob")))
 
-    try database.upsertDocuments([doc(1, notesCount: 0), doc(2, notesCount: 2)], serverID: serverA)
-    try database.upsertDocuments([doc(1, notesCount: 0), doc(2, notesCount: 2)], serverID: serverB)
+    try await database.upsertDocuments(
+      [doc(1, notesCount: 0), doc(2, notesCount: 2)], serverID: serverA)
+    try await database.upsertDocuments(
+      [doc(1, notesCount: 0), doc(2, notesCount: 2)], serverID: serverB)
 
     // Seeding A must not touch B.
-    #expect(try database.seedEmptyNotesForZeroCountDocuments(serverID: serverA) == 1)
-    #expect(try database.notes(serverID: serverB, documentID: 1) == nil)
+    #expect(try await database.seedEmptyNotesForZeroCountDocuments(serverID: serverA) == 1)
+    #expect(try await database.notes(serverID: serverB, documentID: 1) == nil)
 
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: serverA) == [2])
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: serverB) == [2])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: serverA) == [2])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: serverB) == [2])
 
-    try database.setNotes([], serverID: serverA, documentID: 2)
-    try database.invalidateNotes(serverID: serverA, documentIDs: [2])
+    try await database.setNotes([], serverID: serverA, documentID: 2)
+    try await database.invalidateNotes(serverID: serverA, documentIDs: [2])
     // B's doc 2 is untouched.
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: serverB) == [2])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: serverB) == [2])
   }
   @Test("excluding drops known-bad ids from both detail-fill queries")
-  func excludingSkipsFailedIDs() throws {
+  func excludingSkipsFailedIDs() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(1, notesCount: 1), doc(2, notesCount: 1), doc(3, notesCount: 1)], serverID: server)
 
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: server) == [1, 2, 3])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: server) == [1, 2, 3])
     #expect(
-      try database.documentIDsNeedingNotesFetch(serverID: server, excluding: [2]) == [1, 3])
+      try await database.documentIDsNeedingNotesFetch(serverID: server, excluding: [2]) == [1, 3])
     #expect(
-      try database.documentIDsMissingFileMetadata(serverID: server, excluding: [1, 3]) == [2])
+      try await database.documentIDsMissingFileMetadata(serverID: server, excluding: [1, 3]) == [2])
   }
 
   @Test("detail-fill queries return ids in a stable order")
-  func detailQueriesAreOrdered() throws {
+  func detailQueriesAreOrdered() async throws {
     let server = UUID()
     let database = try database(server)
 
     // Inserted out of order: the caller resumes by taking what is still
     // missing, which only works if the order doesn't wander between passes.
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(30, notesCount: 1), doc(10, notesCount: 1), doc(20, notesCount: 1)], serverID: server)
 
-    #expect(try database.documentIDsNeedingNotesFetch(serverID: server) == [10, 20, 30])
-    #expect(try database.documentIDsMissingFileMetadata(serverID: server) == [10, 20, 30])
+    #expect(try await database.documentIDsNeedingNotesFetch(serverID: server) == [10, 20, 30])
+    #expect(try await database.documentIDsMissingFileMetadata(serverID: server) == [10, 20, 30])
   }
 
 }

--- a/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentCacheTests.swift
@@ -52,8 +52,8 @@ struct DocumentCacheTests {
     // which also sets setPermissions via didSet) so equality holds round-trip.
     input.permissions = Permissions { $0.view = .init(users: [1, 2]) }
 
-    try database.upsertDocument(input, serverID: server)
-    let output = try database.document(serverID: server, id: 1)
+    try await database.upsertDocument(input, serverID: server)
+    let output = try await database.document(serverID: server, id: 1)
 
     #expect(output == input)
     #expect(output?.currentVersionID == 9)  // newest by `added`
@@ -64,12 +64,12 @@ struct DocumentCacheTests {
   func resolvesByAsn() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(1, "A", asn: 100), doc(2, "B", asn: 200)],
       serverID: server)
 
-    #expect(try database.document(serverID: server, asn: 200)?.id == 2)
-    #expect(try database.document(serverID: server, asn: 999) == nil)
+    #expect(try await database.document(serverID: server, asn: 200)?.id == 2)
+    #expect(try await database.document(serverID: server, asn: 999) == nil)
   }
 
   // MARK: - query_order replay
@@ -81,12 +81,12 @@ struct DocumentCacheTests {
     let key = QueryKey(sentinel: "test")
 
     // Written out of natural id order.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server,
       documents: [doc(3, "C"), doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 3, replaceAll: true)
 
-    let replayed = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    let replayed = try await database.queryDocuments(queryKey: key, serverID: server, limit: 10)
     #expect(replayed.map(\.id) == [3, 1, 2])
   }
 
@@ -96,16 +96,16 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "test")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 4, replaceAll: true)
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
       startPosition: 2, totalCount: 4, replaceAll: false)
 
-    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    let all = try await database.queryDocuments(queryKey: key, serverID: server, limit: 10)
     #expect(all.map(\.id) == [1, 2, 3, 4])
-    #expect(try database.queryStatus(queryKey: key, serverID: server).totalCount == 4)
+    #expect(try await database.queryStatus(queryKey: key, serverID: server).totalCount == 4)
   }
 
   @Test("a document repeated across a page boundary is placed only once")
@@ -114,18 +114,18 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "test")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B"), doc(3, "C")],
       startPosition: 0, totalCount: 4, replaceAll: true)
     // Page 2 re-delivers doc 3, as it does when the page offsets shift.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
       startPosition: 3, totalCount: 4, replaceAll: false)
 
-    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    let all = try await database.queryDocuments(queryKey: key, serverID: server, limit: 10)
     #expect(all.map(\.id) == [1, 2, 3, 4])
     // A duplicate would inflate `localCount` as well as duplicating the row.
-    #expect(try database.queryStatus(queryKey: key, serverID: server).localCount == 4)
+    #expect(try await database.queryStatus(queryKey: key, serverID: server).localCount == 4)
   }
 
   @Test("a second writer on the same position overwrites instead of throwing")
@@ -134,16 +134,16 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "test")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 2, replaceAll: true)
     // A concurrent fill lands on the same positions with different documents.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(3, "C"), doc(4, "D")],
       startPosition: 0, totalCount: 2, replaceAll: false)
 
     // The later write wins, as it did when this used `upsert`.
-    let all = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    let all = try await database.queryDocuments(queryKey: key, serverID: server, limit: 10)
     #expect(all.map(\.id) == [3, 4])
   }
 
@@ -154,15 +154,17 @@ struct DocumentCacheTests {
     let a = QueryKey(sentinel: "a")
     let b = QueryKey(sentinel: "b")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: a, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: b, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
 
-    #expect(try database.queryDocuments(queryKey: a, serverID: server, limit: 10).map(\.id) == [1])
-    #expect(try database.queryDocuments(queryKey: b, serverID: server, limit: 10).map(\.id) == [1])
+    #expect(
+      try await database.queryDocuments(queryKey: a, serverID: server, limit: 10).map(\.id) == [1])
+    #expect(
+      try await database.queryDocuments(queryKey: b, serverID: server, limit: 10).map(\.id) == [1])
   }
 
   // MARK: - Windowing + deletion gaps
@@ -173,22 +175,23 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "test")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server,
       documents: (10...14).map { doc($0, "d\($0)") },
       startPosition: 0, totalCount: 5, replaceAll: true)
 
     // Delete the doc at position 2 — its query_order row cascades away.
-    try database.deleteDocuments(serverID: server, removedIDs: [12])
+    try await database.deleteDocuments(serverID: server, removedIDs: [12])
 
-    let window = try database.queryDocuments(queryKey: key, serverID: server, limit: 5)
+    let window = try await database.queryDocuments(queryKey: key, serverID: server, limit: 5)
     #expect(window.map(\.id) == [10, 11, 13, 14])  // gap at position 2 is invisible
 
     // Offset windows step by ordered row, not by raw position.
-    let tail = try database.queryDocuments(queryKey: key, serverID: server, limit: 2, offset: 2)
+    let tail = try await database.queryDocuments(
+      queryKey: key, serverID: server, limit: 2, offset: 2)
     #expect(tail.map(\.id) == [13, 14])
 
-    let status = try database.queryStatus(queryKey: key, serverID: server)
+    let status = try await database.queryStatus(queryKey: key, serverID: server)
     #expect(status.localCount == 4)  // one row gone locally
     #expect(status.totalCount == 5)  // server extent unchanged
   }
@@ -200,19 +203,23 @@ struct DocumentCacheTests {
     let keyA = QueryKey(sentinel: "A")
     let keyB = QueryKey(sentinel: "B")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: keyA, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 2, replaceAll: true)
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: keyB, serverID: server, documents: [doc(2, "B"), doc(3, "C")],
       startPosition: 0, totalCount: 2, replaceAll: true)
 
-    try database.deleteDocuments(serverID: server, removedIDs: [2])
+    try await database.deleteDocuments(serverID: server, removedIDs: [2])
 
     #expect(
-      try database.queryDocuments(queryKey: keyA, serverID: server, limit: 10).map(\.id) == [1])
+      try await database.queryDocuments(queryKey: keyA, serverID: server, limit: 10).map(\.id) == [
+        1
+      ])
     #expect(
-      try database.queryDocuments(queryKey: keyB, serverID: server, limit: 10).map(\.id) == [3])
+      try await database.queryDocuments(queryKey: keyB, serverID: server, limit: 10).map(\.id) == [
+        3
+      ])
   }
 
   // MARK: - Upsert
@@ -227,11 +234,11 @@ struct DocumentCacheTests {
 
     var first = doc(1, "Doc")
     first.permissions = Permissions { $0.view = .init(users: [9]) }
-    try database.upsertDocument(first, serverID: server)
+    try await database.upsertDocument(first, serverID: server)
 
     var second = doc(1, "Doc")
     second.permissions = Permissions { $0.view = .init(users: [42]) }
-    try database.upsertDocument(second, serverID: server)
+    try await database.upsertDocument(second, serverID: server)
 
     #expect(try record(database, server, 1)?.payload.permissions?.view.users == [42])
   }
@@ -248,16 +255,16 @@ struct DocumentCacheTests {
     let key = QueryKey(sentinel: "view")
 
     // Only docs 1 and 3 are cached; 2 is reported by the server but absent.
-    try database.upsertDocuments([doc(1, "A"), doc(3, "C")], serverID: server)
+    try await database.upsertDocuments([doc(1, "A"), doc(3, "C")], serverID: server)
 
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2, 3])
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2, 3])
 
-    let replayed = try database.queryDocuments(queryKey: key, serverID: server, limit: 10)
+    let replayed = try await database.queryDocuments(queryKey: key, serverID: server, limit: 10)
     #expect(replayed.map(\.id) == [1, 2, 3])  // all ids, order preserved
     #expect(replayed[0].document != nil)  // loaded
     #expect(replayed[1].document == nil)  // id 2 is a skeleton
     #expect(replayed[2].document != nil)  // loaded
-    let status = try database.queryStatus(queryKey: key, serverID: server)
+    let status = try await database.queryStatus(queryKey: key, serverID: server)
     #expect(status.totalCount == 3)
   }
 
@@ -266,17 +273,19 @@ struct DocumentCacheTests {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "view")
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(1, "A"), doc(2, "B"), doc(3, "C")], serverID: server)
 
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [3, 1])
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [3, 1])
     #expect(
-      try database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [3, 1])
+      try await database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
+        3, 1,
+      ])
 
     // A subsequent sweep with a different membership/order fully replaces it.
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [2, 3, 1])
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [2, 3, 1])
     #expect(
-      try database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
+      try await database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
         2, 3, 1,
       ])
   }
@@ -291,26 +300,26 @@ struct DocumentCacheTests {
 
     // Page 1 truncated the key's order down to what it just wrote, so the key
     // is incomplete no matter what it was before.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 4, replaceAll: true)
-    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+    #expect(try await database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
 
     // An appended page is still not a completed fill — this is the case that
     // used to be indistinguishable from one.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(2, "B")],
       startPosition: 1, totalCount: 4, replaceAll: false)
-    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+    #expect(try await database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
 
-    try database.markQueryFillComplete(queryKey: key, serverID: server)
-    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) != nil)
+    try await database.markQueryFillComplete(queryKey: key, serverID: server)
+    #expect(try await database.queryFillCompletedAt(queryKey: key, serverID: server) != nil)
 
     // A new fill's page 1 wipes the order, so the completion goes with it.
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(3, "C")],
       startPosition: 0, totalCount: 9, replaceAll: true)
-    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
+    #expect(try await database.queryFillCompletedAt(queryKey: key, serverID: server) == nil)
   }
 
   @Test("marking a fill complete keeps the recorded total and stale flag")
@@ -319,13 +328,13 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "fill")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 7, replaceAll: true)
-    try database.markQueriesOrderStale(containing: 1, serverID: server)
-    try database.markQueryFillComplete(queryKey: key, serverID: server)
+    try await database.markQueriesOrderStale(containing: 1, serverID: server)
+    try await database.markQueryFillComplete(queryKey: key, serverID: server)
 
-    let status = try database.queryStatus(queryKey: key, serverID: server)
+    let status = try await database.queryStatus(queryKey: key, serverID: server)
     #expect(status.totalCount == 7)
     #expect(status.orderStale)
   }
@@ -335,18 +344,19 @@ struct DocumentCacheTests {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "view")
-    try database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
+    try await database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
-    try database.markQueryFillComplete(queryKey: key, serverID: server)
-    let stamped = try #require(try database.queryFillCompletedAt(queryKey: key, serverID: server))
+    try await database.markQueryFillComplete(queryKey: key, serverID: server)
+    let stamped = try #require(
+      try await database.queryFillCompletedAt(queryKey: key, serverID: server))
 
     // The sweep writes a complete ordering of its own, so it neither claims nor
     // revokes the fill's completion.
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [2, 1])
-    #expect(try database.queryFillCompletedAt(queryKey: key, serverID: server) == stamped)
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [2, 1])
+    #expect(try await database.queryFillCompletedAt(queryKey: key, serverID: server) == stamped)
   }
 
   // MARK: - Order staleness
@@ -358,19 +368,19 @@ struct DocumentCacheTests {
     let keyA = QueryKey(sentinel: "A")
     let keyB = QueryKey(sentinel: "B")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: keyA, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: keyB, serverID: server, documents: [doc(2, "B")],
       startPosition: 0, totalCount: 1, replaceAll: true)
 
-    #expect(try database.queryStatus(queryKey: keyA, serverID: server).orderStale == false)
+    #expect(try await database.queryStatus(queryKey: keyA, serverID: server).orderStale == false)
 
-    try database.markQueriesOrderStale(containing: 1, serverID: server)
+    try await database.markQueriesOrderStale(containing: 1, serverID: server)
 
-    #expect(try database.queryStatus(queryKey: keyA, serverID: server).orderStale == true)
-    #expect(try database.queryStatus(queryKey: keyB, serverID: server).orderStale == false)
+    #expect(try await database.queryStatus(queryKey: keyA, serverID: server).orderStale == true)
+    #expect(try await database.queryStatus(queryKey: keyB, serverID: server).orderStale == false)
   }
 
   @Test("a fresh fill clears the order-stale flag")
@@ -379,16 +389,16 @@ struct DocumentCacheTests {
     let database = try database(server)
     let key = QueryKey(sentinel: "A")
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
-    try database.markQueriesOrderStale(containing: 1, serverID: server)
-    #expect(try database.queryStatus(queryKey: key, serverID: server).orderStale == true)
+    try await database.markQueriesOrderStale(containing: 1, serverID: server)
+    #expect(try await database.queryStatus(queryKey: key, serverID: server).orderStale == true)
 
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
-    #expect(try database.queryStatus(queryKey: key, serverID: server).orderStale == false)
+    #expect(try await database.queryStatus(queryKey: key, serverID: server).orderStale == false)
   }
 
   // MARK: - Reconcile support
@@ -397,13 +407,13 @@ struct DocumentCacheTests {
   func allDocumentIDs() async throws {
     let server = UUID()
     let database = try database(server)
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [doc(1, "A"), doc(2, "B"), doc(3, "C")], serverID: server)
 
-    #expect(try database.allDocumentIDs(serverID: server) == [1, 2, 3])
+    #expect(try await database.allDocumentIDs(serverID: server) == [1, 2, 3])
     // The reconcile diff: local − server.
     let serverIDs: Set<UInt> = [2, 3, 4]
-    let removed = try database.allDocumentIDs(serverID: server).subtracting(serverIDs)
+    let removed = try await database.allDocumentIDs(serverID: server).subtracting(serverIDs)
     #expect(removed == [1])
   }
 
@@ -414,13 +424,13 @@ struct DocumentCacheTests {
     let server = UUID()
     let database = try database(server)
 
-    #expect(try database.documentCount(serverID: server) == 0)
+    #expect(try await database.documentCount(serverID: server) == 0)
 
-    try database.upsertDocuments([doc(1, "A"), doc(2, "B"), doc(3, "C")], serverID: server)
-    #expect(try database.documentCount(serverID: server) == 3)
+    try await database.upsertDocuments([doc(1, "A"), doc(2, "B"), doc(3, "C")], serverID: server)
+    #expect(try await database.documentCount(serverID: server) == 3)
 
-    try database.deleteDocuments(serverID: server, removedIDs: [2])
-    #expect(try database.documentCount(serverID: server) == 2)
+    try await database.deleteDocuments(serverID: server, removedIDs: [2])
+    #expect(try await database.documentCount(serverID: server) == 2)
   }
 
   // MARK: - Cache wipe (keeps connections)
@@ -430,11 +440,11 @@ struct DocumentCacheTests {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "A")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 2, replaceAll: true)
 
-    try database.clearCache()
+    try await database.clearCache()
 
     let counts = try await database.writer.read { db in
       (
@@ -455,7 +465,7 @@ struct DocumentCacheTests {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "A")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 1, replaceAll: true)
 

--- a/Persistence/Tests/PersistenceTests/DocumentColumnPromotionTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentColumnPromotionTests.swift
@@ -56,8 +56,8 @@ struct DocumentColumnPromotionTests {
     try migrator.migrate(queue)
   }
 
-  private func columns(_ queue: DatabaseQueue, id: Int) throws -> (notes: Int, version: Int) {
-    try queue.read { db in
+  private func columns(_ reader: any DatabaseReader, id: Int) throws -> (notes: Int, version: Int) {
+    try reader.read { db in
       let row = try Row.fetchOne(
         db, sql: "SELECT notes_count, current_version_id FROM document WHERE id = ?",
         arguments: [id])!
@@ -95,7 +95,7 @@ struct DocumentColumnPromotionTests {
   }
 
   @Test("the promoted columns match what a freshly written record stores")
-  func backfillMatchesRecordWrite() throws {
+  func backfillMatchesRecordWrite() async throws {
     // The backfill reproduces `Document.currentVersionID` in SQL, so the two
     // paths have to agree — otherwise an upgraded install and a fresh one
     // disagree about which documents still need a metadata fetch.
@@ -112,13 +112,13 @@ struct DocumentColumnPromotionTests {
         DocumentVersion(
           id: $0, added: Date(timeIntervalSince1970: 0), label: nil, checksum: nil, isRoot: false)
       })
-    try database.upsertDocuments([document], serverID: server)
-    let written = try database.writer.read { db in
-      try Row.fetchOne(
-        db, sql: "SELECT notes_count, current_version_id FROM document WHERE id = 30")!
-    }
+    try await database.upsertDocuments([document], serverID: server)
+    // Through the synchronous helper on purpose: inside an `async` test, a bare
+    // `writer.read` resolves to a different GRDB overload on Swift 6.2 than on
+    // 6.3, so one toolchain demands `await` and the other warns about it.
+    let written = try columns(database.writer, id: 30)
 
-    #expect(backfilled.version == written["current_version_id"])
+    #expect(backfilled.version == written.version)
     #expect(backfilled.version == 99)
   }
 }

--- a/Persistence/Tests/PersistenceTests/DocumentDetailCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentDetailCacheTests.swift
@@ -40,7 +40,7 @@ struct DocumentDetailCacheTests {
   // MARK: - Notes round-trip
 
   @Test("notes round-trip through set + read, preserving user")
-  func notesRoundTrip() throws {
+  func notesRoundTrip() async throws {
     let server = UUID()
     let database = try database(server)
 
@@ -48,44 +48,44 @@ struct DocumentDetailCacheTests {
       note(1, "First", user: .init(id: 7, username: "alice")),
       note(2, "Second"),
     ]
-    try database.setNotes(notes, serverID: server, documentID: 42)
+    try await database.setNotes(notes, serverID: server, documentID: 42)
 
-    #expect(try database.notes(serverID: server, documentID: 42) == notes)
+    #expect(try await database.notes(serverID: server, documentID: 42) == notes)
   }
 
   @Test("absent notes read as nil, distinct from a cached empty list")
-  func notesAbsentVsEmpty() throws {
+  func notesAbsentVsEmpty() async throws {
     let server = UUID()
     let database = try database(server)
 
-    #expect(try database.notes(serverID: server, documentID: 42) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 42) == nil)
 
-    try database.setNotes([], serverID: server, documentID: 42)
-    #expect(try database.notes(serverID: server, documentID: 42) == [])
+    try await database.setNotes([], serverID: server, documentID: 42)
+    #expect(try await database.notes(serverID: server, documentID: 42) == [])
   }
 
   @Test("set replaces the whole notes list, never merges")
-  func notesReplace() throws {
+  func notesReplace() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.setNotes([note(1, "a"), note(2, "b")], serverID: server, documentID: 42)
-    try database.setNotes([note(3, "c")], serverID: server, documentID: 42)
+    try await database.setNotes([note(1, "a"), note(2, "b")], serverID: server, documentID: 42)
+    try await database.setNotes([note(3, "c")], serverID: server, documentID: 42)
 
-    #expect(try database.notes(serverID: server, documentID: 42) == [note(3, "c")])
+    #expect(try await database.notes(serverID: server, documentID: 42) == [note(3, "c")])
   }
 
   // MARK: - File-metadata round-trip
 
   @Test("file-metadata round-trips, including the archive fields and item lists")
-  func metadataRoundTrip() throws {
+  func metadataRoundTrip() async throws {
     let server = UUID()
     let database = try database(server)
 
     let input = metadata("abc123", archive: true)
-    try database.setFileMetadata(input, serverID: server, versionID: 9)
+    try await database.setFileMetadata(input, serverID: server, versionID: 9)
 
-    let output = try #require(try database.fileMetadata(serverID: server, versionID: 9))
+    let output = try #require(try await database.fileMetadata(serverID: server, versionID: 9))
     #expect(output.originalChecksum == input.originalChecksum)
     #expect(output.hasArchiveVersion == input.hasArchiveVersion)
     #expect(output.archiveChecksum == input.archiveChecksum)
@@ -96,28 +96,30 @@ struct DocumentDetailCacheTests {
   }
 
   @Test("absent file-metadata reads as nil")
-  func metadataAbsent() throws {
+  func metadataAbsent() async throws {
     let server = UUID()
     let database = try database(server)
-    #expect(try database.fileMetadata(serverID: server, versionID: 9) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 9) == nil)
   }
 
   @Test("file-metadata is keyed per version")
-  func metadataVersionKeyed() throws {
+  func metadataVersionKeyed() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.setFileMetadata(metadata("v1sum"), serverID: server, versionID: 1)
-    try database.setFileMetadata(metadata("v2sum"), serverID: server, versionID: 2)
+    try await database.setFileMetadata(metadata("v1sum"), serverID: server, versionID: 1)
+    try await database.setFileMetadata(metadata("v2sum"), serverID: server, versionID: 2)
 
-    #expect(try database.fileMetadata(serverID: server, versionID: 1)?.originalChecksum == "v1sum")
-    #expect(try database.fileMetadata(serverID: server, versionID: 2)?.originalChecksum == "v2sum")
+    #expect(
+      try await database.fileMetadata(serverID: server, versionID: 1)?.originalChecksum == "v1sum")
+    #expect(
+      try await database.fileMetadata(serverID: server, versionID: 2)?.originalChecksum == "v2sum")
   }
 
   // MARK: - Server isolation
 
   @Test("notes and file-metadata are isolated per server")
-  func serverIsolation() throws {
+  func serverIsolation() async throws {
     let serverA = UUID()
     let serverB = UUID()
     let database = try database(serverA)
@@ -128,46 +130,46 @@ struct DocumentDetailCacheTests {
         url: URL(string: "https://other.example.com/api/")!,
         user: .init(id: 1, isSuperUser: true, username: "bob")))
 
-    try database.setNotes([note(1, "a-note")], serverID: serverA, documentID: 42)
-    try database.setFileMetadata(metadata("a-sum"), serverID: serverA, versionID: 9)
+    try await database.setNotes([note(1, "a-note")], serverID: serverA, documentID: 42)
+    try await database.setFileMetadata(metadata("a-sum"), serverID: serverA, versionID: 9)
 
-    #expect(try database.notes(serverID: serverB, documentID: 42) == nil)
-    #expect(try database.fileMetadata(serverID: serverB, versionID: 9) == nil)
-    #expect(try database.notes(serverID: serverA, documentID: 42) == [note(1, "a-note")])
+    #expect(try await database.notes(serverID: serverB, documentID: 42) == nil)
+    #expect(try await database.fileMetadata(serverID: serverB, versionID: 9) == nil)
+    #expect(try await database.notes(serverID: serverA, documentID: 42) == [note(1, "a-note")])
   }
 
   // MARK: - Ordinary delete path (R2 reconcile)
 
   @Test("deleteDocuments also removes the deleted document's notes and file-metadata")
-  func deleteDocumentsDropsDetailCache() throws {
+  func deleteDocumentsDropsDetailCache() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.upsertDocument(
+    try await database.upsertDocument(
       Document(id: 42, title: "A", created: date(1000), tags: [], owner: .user(1)),
       serverID: server)
-    try database.setNotes([note(1, "a-note")], serverID: server, documentID: 42)
-    try database.setFileMetadata(metadata("sum"), serverID: server, versionID: 42)
+    try await database.setNotes([note(1, "a-note")], serverID: server, documentID: 42)
+    try await database.setFileMetadata(metadata("sum"), serverID: server, versionID: 42)
 
-    try database.deleteDocuments(serverID: server, removedIDs: [42])
+    try await database.deleteDocuments(serverID: server, removedIDs: [42])
 
-    #expect(try database.notes(serverID: server, documentID: 42) == nil)
-    #expect(try database.fileMetadata(serverID: server, versionID: 42) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 42) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 42) == nil)
   }
 
   // MARK: - Cascade
 
   @Test("clearCache drops cached notes and file-metadata")
-  func clearCacheSweeps() throws {
+  func clearCacheSweeps() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.setNotes([note(1, "a")], serverID: server, documentID: 42)
-    try database.setFileMetadata(metadata("sum"), serverID: server, versionID: 9)
+    try await database.setNotes([note(1, "a")], serverID: server, documentID: 42)
+    try await database.setFileMetadata(metadata("sum"), serverID: server, versionID: 9)
 
-    try database.clearCache()
+    try await database.clearCache()
 
-    #expect(try database.notes(serverID: server, documentID: 42) == nil)
-    #expect(try database.fileMetadata(serverID: server, versionID: 9) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 42) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 9) == nil)
   }
 }

--- a/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
@@ -102,7 +102,7 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(3, "C"), doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 3, replaceAll: true)
 
@@ -116,7 +116,7 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: (1...5).map { doc($0, "d\($0)") },
       startPosition: 0, totalCount: 5, replaceAll: true)
 
@@ -130,14 +130,14 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 4, replaceAll: true)
 
     let grown = try await value(
       from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
     ) {
-      try database.writeQueryPage(
+      try await database.writeQueryPage(
         queryKey: key, serverID: server, documents: [self.doc(3, "C"), self.doc(4, "D")],
         startPosition: 2, totalCount: 4, replaceAll: false)
     }
@@ -149,14 +149,14 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 2, replaceAll: true)
 
     let updated = try await value(
       from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
     ) {
-      try database.upsertDocument(
+      try await database.upsertDocument(
         self.doc(1, "A-edited"), serverID: server)
     }
     #expect(updated.first(where: { $0.id == 1 })?.document?.title == "A-edited")
@@ -167,14 +167,14 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B"), doc(3, "C")],
       startPosition: 0, totalCount: 3, replaceAll: true)
 
     let remaining = try await value(
       from: database.observeDocumentPrefix(queryKey: key, serverID: server, limit: 10)
     ) {
-      try database.deleteDocuments(serverID: server, removedIDs: [2])
+      try await database.deleteDocuments(serverID: server, removedIDs: [2])
     }
     #expect(remaining.map(\.id) == [1, 3])
   }
@@ -186,7 +186,7 @@ struct DocumentObservationTests {
     let server = UUID()
     let database = try Database.seeded(serverID: server)
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: server, documents: [doc(1, "A"), doc(2, "B")],
       startPosition: 0, totalCount: 5, replaceAll: true)
 
@@ -197,7 +197,7 @@ struct DocumentObservationTests {
     let stale = try await value(
       from: database.observeQueryStatus(queryKey: key, serverID: server)
     ) {
-      try database.markQueriesOrderStale(containing: 1, serverID: server)
+      try await database.markQueriesOrderStale(containing: 1, serverID: server)
     }
     #expect(stale.orderStale == true)
   }
@@ -213,12 +213,12 @@ struct DocumentObservationTests {
     #expect(cold == nil)
 
     let appeared = try await value(from: database.observeDocument(serverID: server, id: 1)) {
-      try database.upsertDocument(self.doc(1, "A"), serverID: server)
+      try await database.upsertDocument(self.doc(1, "A"), serverID: server)
     }
     #expect(appeared?.title == "A")
 
     let edited = try await value(from: database.observeDocument(serverID: server, id: 1)) {
-      try database.upsertDocument(
+      try await database.upsertDocument(
         self.doc(1, "A-edited"), serverID: server)
     }
     #expect(edited?.title == "A-edited")
@@ -237,14 +237,14 @@ struct DocumentObservationTests {
     let afterUpsert = try await value(
       from: database.observeDocumentCount(serverID: server)
     ) {
-      try database.upsertDocuments([self.doc(1, "A"), self.doc(2, "B")], serverID: server)
+      try await database.upsertDocuments([self.doc(1, "A"), self.doc(2, "B")], serverID: server)
     }
     #expect(afterUpsert == 2)
 
     let afterDelete = try await value(
       from: database.observeDocumentCount(serverID: server)
     ) {
-      try database.deleteDocuments(serverID: server, removedIDs: [1])
+      try await database.deleteDocuments(serverID: server, removedIDs: [1])
     }
     #expect(afterDelete == 1)
   }
@@ -257,7 +257,7 @@ struct DocumentObservationTests {
     let database = try Database.seeded(serverID: serverA)
     let serverB = try addServer(to: database, host: "b")
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: serverA, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 2, replaceAll: true)
 
@@ -265,12 +265,12 @@ struct DocumentObservationTests {
       from: database.observeDocumentPrefix(queryKey: key, serverID: serverA, limit: 10),
       foreignWrite: {
         // Same query key, other server — the sweep's shape exactly.
-        try database.writeQueryPage(
+        try await database.writeQueryPage(
           queryKey: key, serverID: serverB, documents: [self.doc(1, "B-1"), self.doc(2, "B-2")],
           startPosition: 0, totalCount: 2, replaceAll: true)
       },
       ownWrite: {
-        try database.writeQueryPage(
+        try await database.writeQueryPage(
           queryKey: key, serverID: serverA, documents: [self.doc(2, "B")],
           startPosition: 1, totalCount: 2, replaceAll: false)
       })
@@ -283,19 +283,19 @@ struct DocumentObservationTests {
     let database = try Database.seeded(serverID: serverA)
     let serverB = try addServer(to: database, host: "b")
     let key = QueryKey(sentinel: "q")
-    try database.writeQueryPage(
+    try await database.writeQueryPage(
       queryKey: key, serverID: serverA, documents: [doc(1, "A")],
       startPosition: 0, totalCount: 2, replaceAll: true)
 
     let next = try await valueSkippingForeignWrite(
       from: database.observeQueryStatus(queryKey: key, serverID: serverA),
       foreignWrite: {
-        try database.writeQueryPage(
+        try await database.writeQueryPage(
           queryKey: key, serverID: serverB, documents: [self.doc(9, "B-9")],
           startPosition: 0, totalCount: 9, replaceAll: true)
       },
       ownWrite: {
-        try database.writeQueryPage(
+        try await database.writeQueryPage(
           queryKey: key, serverID: serverA, documents: [self.doc(2, "B")],
           startPosition: 1, totalCount: 2, replaceAll: false)
       })
@@ -310,8 +310,8 @@ struct DocumentObservationTests {
 
     let next = try await valueSkippingForeignWrite(
       from: database.observeDocument(serverID: serverA, id: 1),
-      foreignWrite: { try database.upsertDocument(self.doc(1, "B-1"), serverID: serverB) },
-      ownWrite: { try database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
+      foreignWrite: { try await database.upsertDocument(self.doc(1, "B-1"), serverID: serverB) },
+      ownWrite: { try await database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
     #expect(next?.title == "A-edited")
   }
 
@@ -323,8 +323,8 @@ struct DocumentObservationTests {
     let next = try await valueSkippingForeignWrite(
       from: database.observeDocument(serverID: serverA, id: 1),
       // Same object, written again: a fresh transaction, an identical row.
-      foreignWrite: { try database.upsertDocument(self.doc(1, "A"), serverID: serverA) },
-      ownWrite: { try database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
+      foreignWrite: { try await database.upsertDocument(self.doc(1, "A"), serverID: serverA) },
+      ownWrite: { try await database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
     #expect(next?.title == "A-edited")
   }
 
@@ -337,10 +337,10 @@ struct DocumentObservationTests {
     let next = try await valueSkippingForeignWrite(
       from: database.observeDocumentCount(serverID: serverA),
       foreignWrite: {
-        try database.upsertDocuments(
+        try await database.upsertDocuments(
           [self.doc(1, "B-1"), self.doc(2, "B-2")], serverID: serverB)
       },
-      ownWrite: { try database.upsertDocument(self.doc(2, "B"), serverID: serverA) })
+      ownWrite: { try await database.upsertDocument(self.doc(2, "B"), serverID: serverA) })
     #expect(next == 2)
   }
 }

--- a/Persistence/Tests/PersistenceTests/DowngradeGCTests.swift
+++ b/Persistence/Tests/PersistenceTests/DowngradeGCTests.swift
@@ -35,55 +35,55 @@ struct DowngradeGCTests {
   // MARK: - Orphan reclaim
 
   @Test("deletes a document referenced by no query_order row")
-  func deletesUnreferencedDocument() throws {
+  func deletesUnreferencedDocument() async throws {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "A")
 
-    try database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
+    try await database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
     // Only doc 1 is tracked by any query.
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1])
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1])
 
-    let removed = try database.pruneUnreferencedDocuments(serverID: server)
+    let removed = try await database.pruneUnreferencedDocuments(serverID: server)
 
     #expect(removed == 1)
-    #expect(try database.document(serverID: server, id: 1) != nil)
-    #expect(try database.document(serverID: server, id: 2) == nil)
+    #expect(try await database.document(serverID: server, id: 1) != nil)
+    #expect(try await database.document(serverID: server, id: 2) == nil)
   }
 
   @Test("preserves a document referenced by at least one query, even if others dropped it")
-  func preservesDocumentStillReferencedElsewhere() throws {
+  func preservesDocumentStillReferencedElsewhere() async throws {
     let server = UUID()
     let database = try database(server)
     let keyA = QueryKey(sentinel: "A")
     let keyB = QueryKey(sentinel: "B")
 
-    try database.upsertDocuments([doc(1, "A")], serverID: server)
-    try database.replaceQueryOrder(queryKey: keyA, serverID: server, orderedIDs: [1])
-    try database.replaceQueryOrder(queryKey: keyB, serverID: server, orderedIDs: [])
+    try await database.upsertDocuments([doc(1, "A")], serverID: server)
+    try await database.replaceQueryOrder(queryKey: keyA, serverID: server, orderedIDs: [1])
+    try await database.replaceQueryOrder(queryKey: keyB, serverID: server, orderedIDs: [])
 
-    let removed = try database.pruneUnreferencedDocuments(serverID: server)
+    let removed = try await database.pruneUnreferencedDocuments(serverID: server)
 
     #expect(removed == 0)
-    #expect(try database.document(serverID: server, id: 1) != nil)
+    #expect(try await database.document(serverID: server, id: 1) != nil)
   }
 
   @Test("is a no-op when every cached document is still referenced")
-  func noOpWhenFullyReferenced() throws {
+  func noOpWhenFullyReferenced() async throws {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "A")
 
-    try database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2])
+    try await database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
+    try await database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2])
 
-    #expect(try database.pruneUnreferencedDocuments(serverID: server) == 0)
-    #expect(try database.document(serverID: server, id: 1) != nil)
-    #expect(try database.document(serverID: server, id: 2) != nil)
+    #expect(try await database.pruneUnreferencedDocuments(serverID: server) == 0)
+    #expect(try await database.document(serverID: server, id: 1) != nil)
+    #expect(try await database.document(serverID: server, id: 2) != nil)
   }
 
   @Test("is scoped to one server")
-  func scopedToOneServer() throws {
+  func scopedToOneServer() async throws {
     let serverA = UUID()
     let serverB = UUID()
     let database = try database(serverA)
@@ -94,40 +94,40 @@ struct DowngradeGCTests {
         user: .init(id: 1, isSuperUser: true, username: "bob")))
 
     // Neither server's document is referenced by any query.
-    try database.upsertDocuments([doc(1, "A")], serverID: serverA)
-    try database.upsertDocuments([doc(1, "A")], serverID: serverB)
+    try await database.upsertDocuments([doc(1, "A")], serverID: serverA)
+    try await database.upsertDocuments([doc(1, "A")], serverID: serverB)
 
-    let removed = try database.pruneUnreferencedDocuments(serverID: serverA)
+    let removed = try await database.pruneUnreferencedDocuments(serverID: serverA)
 
     #expect(removed == 1)
-    #expect(try database.document(serverID: serverA, id: 1) == nil)
-    #expect(try database.document(serverID: serverB, id: 1) != nil)
+    #expect(try await database.document(serverID: serverA, id: 1) == nil)
+    #expect(try await database.document(serverID: serverB, id: 1) != nil)
   }
 
   // MARK: - Detail-cache cleanup
 
   @Test("also drops the orphaned document's notes and file-metadata")
-  func dropsDetailCacheForOrphan() throws {
+  func dropsDetailCacheForOrphan() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.upsertDocuments([doc(1, "A")], serverID: server)
-    try database.setNotes([note(1)], serverID: server, documentID: 1)
-    try database.setFileMetadata(metadata("sum"), serverID: server, versionID: 1)
+    try await database.upsertDocuments([doc(1, "A")], serverID: server)
+    try await database.setNotes([note(1)], serverID: server, documentID: 1)
+    try await database.setFileMetadata(metadata("sum"), serverID: server, versionID: 1)
     // Not referenced by any query.
 
-    _ = try database.pruneUnreferencedDocuments(serverID: server)
+    _ = try await database.pruneUnreferencedDocuments(serverID: server)
 
-    #expect(try database.notes(serverID: server, documentID: 1) == nil)
-    #expect(try database.fileMetadata(serverID: server, versionID: 1) == nil)
+    #expect(try await database.notes(serverID: server, documentID: 1) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 1) == nil)
   }
 
   @Test("cleans up file-metadata for every recorded version, not just the current one")
-  func dropsFileMetadataForEveryVersion() throws {
+  func dropsFileMetadataForEveryVersion() async throws {
     let server = UUID()
     let database = try database(server)
 
-    try database.upsertDocuments(
+    try await database.upsertDocuments(
       [
         doc(
           1, "A",
@@ -136,81 +136,83 @@ struct DowngradeGCTests {
             DocumentVersion(id: 9, added: date(5000), isRoot: false),
           ])
       ], serverID: server)
-    try database.setFileMetadata(metadata("root"), serverID: server, versionID: 1)
-    try database.setFileMetadata(metadata("v9"), serverID: server, versionID: 9)
+    try await database.setFileMetadata(metadata("root"), serverID: server, versionID: 1)
+    try await database.setFileMetadata(metadata("v9"), serverID: server, versionID: 9)
     // Not referenced by any query.
 
-    _ = try database.pruneUnreferencedDocuments(serverID: server)
+    _ = try await database.pruneUnreferencedDocuments(serverID: server)
 
-    #expect(try database.fileMetadata(serverID: server, versionID: 1) == nil)
-    #expect(try database.fileMetadata(serverID: server, versionID: 9) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 1) == nil)
+    #expect(try await database.fileMetadata(serverID: server, versionID: 9) == nil)
   }
 
   // MARK: - dropQueryOrder
 
   @Test("dropQueryOrder removes every other query's order/meta/sync-error, keeps the given one")
-  func dropQueryOrderKeepsOnlyGivenKey() throws {
+  func dropQueryOrderKeepsOnlyGivenKey() async throws {
     let server = UUID()
     let database = try database(server)
     let keep = QueryKey(sentinel: "default")
     let drop = QueryKey(sentinel: "saved-view")
 
-    try database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
-    try database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1, 2])
-    try database.replaceQueryOrder(queryKey: drop, serverID: server, orderedIDs: [1, 2])
-    try database.recordQuerySyncError(
+    try await database.upsertDocuments([doc(1, "A"), doc(2, "B")], serverID: server)
+    try await database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1, 2])
+    try await database.replaceQueryOrder(queryKey: drop, serverID: server, orderedIDs: [1, 2])
+    try await database.recordQuerySyncError(
       serverID: server, queryKey: drop.rawValue, savedViewName: "Saved", message: "boom")
 
-    try database.dropQueryOrder(serverID: server, exceptQueryKey: keep)
+    try await database.dropQueryOrder(serverID: server, exceptQueryKey: keep)
 
     #expect(
-      try database.queryDocuments(queryKey: keep, serverID: server, limit: 10).map(\.id) == [
+      try await database.queryDocuments(queryKey: keep, serverID: server, limit: 10).map(\.id) == [
         1, 2,
       ])
-    #expect(try database.queryDocuments(queryKey: drop, serverID: server, limit: 10).isEmpty)
+    #expect(try await database.queryDocuments(queryKey: drop, serverID: server, limit: 10).isEmpty)
     // query_meta gone too: totalCount reads nil, not just localCount == 0.
-    #expect(try database.queryStatus(queryKey: drop, serverID: server).totalCount == nil)
-    #expect(try database.queryStatus(queryKey: keep, serverID: server).totalCount == 2)
+    #expect(try await database.queryStatus(queryKey: drop, serverID: server).totalCount == nil)
+    #expect(try await database.queryStatus(queryKey: keep, serverID: server).totalCount == 2)
   }
 
   // MARK: - truncateQueryOrder
 
   @Test("truncateQueryOrder keeps only the first N positions")
-  func truncateKeepsPrefix() throws {
+  func truncateKeepsPrefix() async throws {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "default")
 
-    try database.upsertDocuments((1...5).map { doc($0, "d\($0)") }, serverID: server)
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2, 3, 4, 5])
+    try await database.upsertDocuments((1...5).map { doc($0, "d\($0)") }, serverID: server)
+    try await database.replaceQueryOrder(
+      queryKey: key, serverID: server, orderedIDs: [1, 2, 3, 4, 5])
 
-    try database.truncateQueryOrder(serverID: server, queryKey: key, keepingFirst: 3)
+    try await database.truncateQueryOrder(serverID: server, queryKey: key, keepingFirst: 3)
 
     #expect(
-      try database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
+      try await database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
         1, 2, 3,
       ])
     // The server's true total is untouched by the local cap.
-    #expect(try database.queryStatus(queryKey: key, serverID: server).totalCount == 5)
+    #expect(try await database.queryStatus(queryKey: key, serverID: server).totalCount == 5)
   }
 
   @Test("truncateQueryOrder counts rows, not position values, when positions are gappy")
-  func truncateCountsRowsNotPositions() throws {
+  func truncateCountsRowsNotPositions() async throws {
     let server = UUID()
     let database = try database(server)
     let key = QueryKey(sentinel: "default")
 
-    try database.upsertDocuments((1...5).map { doc($0, "d\($0)") }, serverID: server)
-    try database.replaceQueryOrder(queryKey: key, serverID: server, orderedIDs: [1, 2, 3, 4, 5])
+    try await database.upsertDocuments((1...5).map { doc($0, "d\($0)") }, serverID: server)
+    try await database.replaceQueryOrder(
+      queryKey: key, serverID: server, orderedIDs: [1, 2, 3, 4, 5])
     // Punch a hole the way a page-boundary repeat or a remote delete does: the
     // surviving rows now sit at positions 0, 2, 3, 4 rather than 0...3.
-    try database.deleteDocuments(serverID: server, removedIDs: [2])
+    try await database.deleteDocuments(serverID: server, removedIDs: [2])
 
-    try database.truncateQueryOrder(serverID: server, queryKey: key, keepingFirst: 3)
+    try await database.truncateQueryOrder(serverID: server, queryKey: key, keepingFirst: 3)
 
     // Three rows kept. A `position < 3` test would have kept only two (0 and 2).
     #expect(
-      try database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
+      try await database.queryDocuments(queryKey: key, serverID: server, limit: 10).map(\.id) == [
         1, 3, 4,
       ])
   }
@@ -218,70 +220,72 @@ struct DowngradeGCTests {
   // MARK: - reclaimAfterDowngrade
 
   @Test("reclaimAfterDowngrade drops, truncates and prunes in one call")
-  func reclaimDoesTheWholeSequence() throws {
+  func reclaimDoesTheWholeSequence() async throws {
     let server = UUID()
     let database = try database(server)
     let keep = QueryKey(sentinel: "default")
     let drop = QueryKey(sentinel: "saved-view")
 
-    try database.upsertDocuments((1...6).map { doc($0, "d\($0)") }, serverID: server)
-    try database.replaceQueryOrder(
+    try await database.upsertDocuments((1...6).map { doc($0, "d\($0)") }, serverID: server)
+    try await database.replaceQueryOrder(
       queryKey: keep, serverID: server, orderedIDs: [1, 2, 3, 4])
     // 5 and 6 are only reachable through the saved view.
-    try database.replaceQueryOrder(queryKey: drop, serverID: server, orderedIDs: [5, 6])
+    try await database.replaceQueryOrder(queryKey: drop, serverID: server, orderedIDs: [5, 6])
 
-    let removed = try database.reclaimAfterDowngrade(
+    let removed = try await database.reclaimAfterDowngrade(
       serverID: server, defaultQueryKey: keep, keepingFirst: 2)
 
     // 5 and 6 lost their only reference; 3 and 4 fell off the truncated prefix.
     #expect(removed == 4)
     #expect(
-      try database.queryDocuments(queryKey: keep, serverID: server, limit: 10).map(\.id) == [1, 2])
-    #expect(try database.queryDocuments(queryKey: drop, serverID: server, limit: 10).isEmpty)
-    #expect(try database.document(serverID: server, id: 5) == nil)
+      try await database.queryDocuments(queryKey: keep, serverID: server, limit: 10).map(\.id) == [
+        1, 2,
+      ])
+    #expect(try await database.queryDocuments(queryKey: drop, serverID: server, limit: 10).isEmpty)
+    #expect(try await database.document(serverID: server, id: 5) == nil)
   }
 
   @Test("reclaimAfterDowngrade clears the library-coverage marker")
-  func reclaimClearsCoverageMarker() throws {
+  func reclaimClearsCoverageMarker() async throws {
     let server = UUID()
     let database = try database(server)
     let keep = QueryKey(sentinel: "default")
 
-    try database.upsertDocuments([doc(1, "A")], serverID: server)
-    try database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1])
-    try database.setLibraryCoverageAt(date(5000), serverID: server)
+    try await database.upsertDocuments([doc(1, "A")], serverID: server)
+    try await database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1])
+    try await database.setLibraryCoverageAt(date(5000), serverID: server)
 
-    try database.reclaimAfterDowngrade(
+    try await database.reclaimAfterDowngrade(
       serverID: server, defaultQueryKey: keep, keepingFirst: 200)
 
     // The cache no longer matches what the marker claimed, so a later
     // re-upgrade has to re-fill instead of reading a fresh stamp.
-    #expect(try database.libraryCoverageAt(serverID: server) == nil)
+    #expect(try await database.libraryCoverageAt(serverID: server) == nil)
   }
 
   @Test("reclaimAfterDowngrade leaves the delta watermark alone")
-  func reclaimKeepsDeltaWatermark() throws {
+  func reclaimKeepsDeltaWatermark() async throws {
     let server = UUID()
     let database = try database(server)
     let keep = QueryKey(sentinel: "default")
 
-    try database.upsertDocuments([doc(1, "A")], serverID: server)
-    try database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1])
-    try database.setDeltaWatermark(date(7000), serverID: server)
-    try database.setLibraryCoverageAt(date(5000), serverID: server)
+    try await database.upsertDocuments([doc(1, "A")], serverID: server)
+    try await database.replaceQueryOrder(queryKey: keep, serverID: server, orderedIDs: [1])
+    try await database.setDeltaWatermark(date(7000), serverID: server)
+    try await database.setLibraryCoverageAt(date(5000), serverID: server)
 
-    try database.reclaimAfterDowngrade(
+    try await database.reclaimAfterDowngrade(
       serverID: server, defaultQueryKey: keep, keepingFirst: 200)
 
     // Documents that survive the reclaim still want their changes applied, so
     // the delta must not re-baseline over them.
-    #expect(try database.deltaWatermark(serverID: server) == date(7000))
+    #expect(try await database.deltaWatermark(serverID: server) == date(7000))
   }
 
   // MARK: - End-to-end downgrade sequence
 
   @Test("drop-non-default + truncate-default + prune actually shrinks the cache")
-  func downgradeSequenceShrinksCache() throws {
+  func downgradeSequenceShrinksCache() async throws {
     // Reproduces the reported gap: after an entire-library-style fill, both
     // the default list and a saved view reference every document, so
     // pruneUnreferencedDocuments alone finds nothing to reclaim.
@@ -291,26 +295,27 @@ struct DowngradeGCTests {
     let savedViewKey = QueryKey(sentinel: "saved-view")
 
     let allDocs = (1...10).map { doc($0, "d\($0)") }
-    try database.upsertDocuments(allDocs, serverID: server)
-    try database.replaceQueryOrder(
+    try await database.upsertDocuments(allDocs, serverID: server)
+    try await database.replaceQueryOrder(
       queryKey: defaultKey, serverID: server, orderedIDs: allDocs.map(\.id))
-    try database.replaceQueryOrder(
+    try await database.replaceQueryOrder(
       queryKey: savedViewKey, serverID: server, orderedIDs: allDocs.map(\.id))
 
-    #expect(try database.pruneUnreferencedDocuments(serverID: server) == 0)
-    #expect(try database.documentCount(serverID: server) == 10)
+    #expect(try await database.pruneUnreferencedDocuments(serverID: server) == 0)
+    #expect(try await database.documentCount(serverID: server) == 10)
 
     // The actual downgrade sequence (mirrors ConnectionManager.runDowngradeGC).
-    try database.dropQueryOrder(serverID: server, exceptQueryKey: defaultKey)
-    try database.truncateQueryOrder(serverID: server, queryKey: defaultKey, keepingFirst: 3)
-    let removed = try database.pruneUnreferencedDocuments(serverID: server)
+    try await database.dropQueryOrder(serverID: server, exceptQueryKey: defaultKey)
+    try await database.truncateQueryOrder(serverID: server, queryKey: defaultKey, keepingFirst: 3)
+    let removed = try await database.pruneUnreferencedDocuments(serverID: server)
 
     #expect(removed == 7)
-    #expect(try database.documentCount(serverID: server) == 3)
+    #expect(try await database.documentCount(serverID: server) == 3)
     #expect(
-      try database.queryDocuments(queryKey: defaultKey, serverID: server, limit: 10).map(\.id)
+      try await database.queryDocuments(queryKey: defaultKey, serverID: server, limit: 10).map(\.id)
         == [1, 2, 3])
     #expect(
-      try database.queryDocuments(queryKey: savedViewKey, serverID: server, limit: 10).isEmpty)
+      try await database.queryDocuments(queryKey: savedViewKey, serverID: server, limit: 10).isEmpty
+    )
   }
 }

--- a/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementCacheTests.swift
@@ -45,13 +45,13 @@ struct ElementCacheTests {
   }
 
   @Test("the name-ordered collection read sorts via the index, not a temp b-tree")
-  func orderedReadUsesTheIndex() throws {
+  func orderedReadUsesTheIndex() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
-    try database.replaceElements(
+    try await database.replaceElements(
       [tag(1, "B"), tag(2, "A")], of: TagRecord.self, serverID: server)
 
-    let plan = try database.writer.read { db in
+    let plan = try await database.writer.read { db in
       try String.fetchAll(
         db,
         sql: """
@@ -74,19 +74,19 @@ struct ElementCacheTests {
   // MARK: - Round-trip
 
   @Test("multi-row records round-trip through replace + read")
-  func multiRowRoundtrip() throws {
+  func multiRowRoundtrip() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
     let tags = [tag(1, "Alpha"), tag(2, "Beta")]
-    try database.replaceElements(tags, of: TagRecord.self, serverID: server)
+    try await database.replaceElements(tags, of: TagRecord.self, serverID: server)
 
     let correspondents = [
       Correspondent(
         id: 5, documentCount: 3, lastCorrespondence: nil, name: "ACME",
         slug: "acme", matchingAlgorithm: .literal, match: "x", isInsensitive: false)
     ]
-    try database.replaceElements(
+    try await database.replaceElements(
       correspondents, of: CorrespondentRecord.self, serverID: server)
 
     let customFields = [
@@ -96,27 +96,27 @@ struct ElementCacheTests {
           selectOptions: [.init(id: "a", label: "High")], defaultCurrency: "EUR"),
         documentCount: 2)
     ]
-    try database.replaceElements(
+    try await database.replaceElements(
       customFields, of: CustomFieldRecord.self, serverID: server)
 
     // Tag holds a SwiftUI.Color whose == is provider-identity based, and
     // AppKit's Color→hex conversion drifts ±1 per round-trip on the host — both
     // unrelated to storage. Compare the stable fields; the JSON-column path is
     // proven by the other record types below.
-    let fetchedTags = try database.elements(TagRecord.self, serverID: server)
+    let fetchedTags = try await database.elements(TagRecord.self, serverID: server)
     #expect(fetchedTags.map(\.id) == tags.map(\.id))
     #expect(fetchedTags.map(\.name) == tags.map(\.name))
     #expect(fetchedTags.map(\.slug) == tags.map(\.slug))
     #expect(fetchedTags.map(\.matchingAlgorithm) == tags.map(\.matchingAlgorithm))
 
     #expect(
-      try database.elements(CorrespondentRecord.self, serverID: server) == correspondents)
+      try await database.elements(CorrespondentRecord.self, serverID: server) == correspondents)
     #expect(
-      try database.elements(CustomFieldRecord.self, serverID: server) == customFields)
+      try await database.elements(CustomFieldRecord.self, serverID: server) == customFields)
   }
 
   @Test("saved view round-trips its filter rules and permissions")
-  func savedViewRoundtrip() throws {
+  func savedViewRoundtrip() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
@@ -125,31 +125,31 @@ struct ElementCacheTests {
       sortField: .created, sortOrder: .descending,
       filterRules: [FilterRule(ruleType: .title, value: .string(value: "invoice"))!],
       owner: .user(1))
-    try database.replaceElements([view], of: SavedViewRecord.self, serverID: server)
+    try await database.replaceElements([view], of: SavedViewRecord.self, serverID: server)
 
-    let fetched = try database.elements(SavedViewRecord.self, serverID: server)
+    let fetched = try await database.elements(SavedViewRecord.self, serverID: server)
     #expect(fetched == [view])
   }
 
   // MARK: - Reconcile
 
   @Test("replaceElements drops rows absent from the new set")
-  func replaceDropsMissing() throws {
+  func replaceDropsMissing() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
-    try database.replaceElements(
+    try await database.replaceElements(
       [tag(1, "A"), tag(2, "B"), tag(3, "C")], of: TagRecord.self, serverID: server)
-    try database.replaceElements(
+    try await database.replaceElements(
       [tag(1, "A"), tag(3, "C-renamed")], of: TagRecord.self, serverID: server)
 
-    let fetched = try database.elements(TagRecord.self, serverID: server)
+    let fetched = try await database.elements(TagRecord.self, serverID: server)
     #expect(fetched.map(\.id) == [1, 3])
     #expect(fetched.first { $0.id == 3 }?.name == "C-renamed")
   }
 
   @Test("replaceElements tolerates the same element twice in one batch")
-  func replaceTolerScopesDuplicates() throws {
+  func replaceTolerScopesDuplicates() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
@@ -158,29 +158,29 @@ struct ElementCacheTests {
     // `insert` raised a primary-key violation there and rolled the whole
     // reconcile back, losing every other element in the batch.
     let duplicated = [tag(1, "A"), tag(2, "B"), tag(2, "B"), tag(3, "C")]
-    try database.replaceElements(duplicated, of: TagRecord.self, serverID: server)
+    try await database.replaceElements(duplicated, of: TagRecord.self, serverID: server)
 
-    let fetched = try database.elements(TagRecord.self, serverID: server)
+    let fetched = try await database.elements(TagRecord.self, serverID: server)
     #expect(fetched.map(\.id) == [1, 2, 3])
   }
 
   @Test("upsert and delete single element")
-  func upsertAndDelete() throws {
+  func upsertAndDelete() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
-    try database.upsertElement(tag(1, "One"), of: TagRecord.self, serverID: server)
-    try database.upsertElement(tag(1, "One-edit"), of: TagRecord.self, serverID: server)
-    #expect(try database.elements(TagRecord.self, serverID: server).first?.name == "One-edit")
+    try await database.upsertElement(tag(1, "One"), of: TagRecord.self, serverID: server)
+    try await database.upsertElement(tag(1, "One-edit"), of: TagRecord.self, serverID: server)
+    #expect(try await database.elements(TagRecord.self, serverID: server).first?.name == "One-edit")
 
-    try database.deleteElement(TagRecord.self, serverID: server, id: 1)
-    #expect(try database.elements(TagRecord.self, serverID: server).isEmpty)
+    try await database.deleteElement(TagRecord.self, serverID: server, id: 1)
+    #expect(try await database.elements(TagRecord.self, serverID: server).isEmpty)
   }
 
   // MARK: - Scoping & cascade
 
   @Test("elements are scoped per server")
-  func perServerScoping() throws {
+  func perServerScoping() async throws {
     let serverA = UUID()
     let database = try makeDatabase(server: serverA)
     let serverB = UUID()
@@ -189,43 +189,43 @@ struct ElementCacheTests {
         id: serverB, url: URL(string: "https://b.example.com/")!,
         user: .init(id: 1, isSuperUser: false, username: "bob")))
 
-    try database.replaceElements([tag(1, "A")], of: TagRecord.self, serverID: serverA)
-    try database.replaceElements([tag(2, "B")], of: TagRecord.self, serverID: serverB)
+    try await database.replaceElements([tag(1, "A")], of: TagRecord.self, serverID: serverA)
+    try await database.replaceElements([tag(2, "B")], of: TagRecord.self, serverID: serverB)
 
-    #expect(try database.elements(TagRecord.self, serverID: serverA).map(\.id) == [1])
-    #expect(try database.elements(TagRecord.self, serverID: serverB).map(\.id) == [2])
+    #expect(try await database.elements(TagRecord.self, serverID: serverA).map(\.id) == [1])
+    #expect(try await database.elements(TagRecord.self, serverID: serverB).map(\.id) == [2])
   }
 
   @Test("deleting a server cascades to its element rows")
-  func cascadeOnServerDelete() throws {
+  func cascadeOnServerDelete() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
-    try database.replaceElements(
+    try await database.replaceElements(
       [tag(1, "A"), tag(2, "B")], of: TagRecord.self, serverID: server)
 
     try database.deleteConnection(id: server)
 
-    #expect(try database.elements(TagRecord.self, serverID: server).isEmpty)
+    #expect(try await database.elements(TagRecord.self, serverID: server).isEmpty)
   }
 
   // MARK: - Singletons
 
   @Test("server configuration singleton round-trips")
-  func serverConfigurationRoundtrip() throws {
+  func serverConfigurationRoundtrip() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
-    #expect(try database.serverConfiguration(serverID: server) == nil)
+    #expect(try await database.serverConfiguration(serverID: server) == nil)
     let config = ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN")
-    try database.setServerConfiguration(config, serverID: server)
+    try await database.setServerConfiguration(config, serverID: server)
 
-    let fetched = try #require(try database.serverConfiguration(serverID: server))
+    let fetched = try #require(try await database.serverConfiguration(serverID: server))
     #expect(fetched.id == 1)
     #expect(fetched.barcodeAsnPrefix == "ASN")
   }
 
   @Test("ui settings singleton round-trips user, settings and permissions")
-  func uiSettingsRoundtrip() throws {
+  func uiSettingsRoundtrip() async throws {
     let server = UUID()
     let database = try makeDatabase(server: server)
 
@@ -244,8 +244,8 @@ struct ElementCacheTests {
       settings: settings,
       permissions: permissions)
 
-    try database.setUISettings(uiSettings, serverID: server)
-    let fetched = try #require(try database.uiSettings(serverID: server))
+    try await database.setUISettings(uiSettings, serverID: server)
+    let fetched = try #require(try await database.uiSettings(serverID: server))
 
     #expect(fetched.user == uiSettings.user)
     #expect(fetched.settings == settings)

--- a/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
@@ -129,7 +129,7 @@ struct ElementObservationTests {
     let updated = try await value(
       from: database.observeElements(CorrespondentRecord.self, serverID: server)
     ) {
-      try database.upsertElement(
+      try await database.upsertElement(
         self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: server)
     }
     #expect(updated.map(\.id) == [1, 2])
@@ -144,7 +144,7 @@ struct ElementObservationTests {
     let remaining = try await value(
       from: database.observeElements(CorrespondentRecord.self, serverID: server)
     ) {
-      try database.deleteElement(CorrespondentRecord.self, serverID: server, id: 1)
+      try await database.deleteElement(CorrespondentRecord.self, serverID: server, id: 1)
     }
     #expect(remaining.map(\.id) == [2])
   }
@@ -162,7 +162,7 @@ struct ElementObservationTests {
       settings: UISettingsSettings(),
       permissions: .empty)
     let resolved = try await value(from: database.observeUISettings(serverID: server)) {
-      try database.setUISettings(settings, serverID: server)
+      try await database.setUISettings(settings, serverID: server)
     }
     #expect(resolved?.user.id == 7)
     #expect(resolved?.user.username == "alice")
@@ -179,7 +179,7 @@ struct ElementObservationTests {
     let resolved = try await value(
       from: database.observeServerConfiguration(serverID: server)
     ) {
-      try database.setServerConfiguration(
+      try await database.setServerConfiguration(
         ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN"), serverID: server)
     }
     #expect(resolved?.barcodeAsnPrefix == "ASN")
@@ -190,7 +190,7 @@ struct ElementObservationTests {
     let serverA = UUID()
     let database = try Database.seeded(serverID: serverA, correspondents: [correspondent(1, "A")])
     let serverB = try addServer(to: database, host: "b")
-    try database.replaceElements(
+    try await database.replaceElements(
       [correspondent(2, "B")], of: CorrespondentRecord.self, serverID: serverB)
 
     let aOnly = try await firstValue(
@@ -209,12 +209,12 @@ struct ElementObservationTests {
     let next = try await valueSkippingForeignWrite(
       from: database.observeElements(CorrespondentRecord.self, serverID: serverA),
       foreignWrite: {
-        try database.replaceElements(
+        try await database.replaceElements(
           [self.correspondent(50, "Foreign")], of: CorrespondentRecord.self, serverID: serverB)
-        try database.deleteElement(CorrespondentRecord.self, serverID: serverB, id: 50)
+        try await database.deleteElement(CorrespondentRecord.self, serverID: serverB, id: 50)
       },
       ownWrite: {
-        try database.upsertElement(
+        try await database.upsertElement(
           self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: serverA)
       })
     #expect(next.map(\.id) == [1, 2])
@@ -229,11 +229,11 @@ struct ElementObservationTests {
       from: database.observeElements(CorrespondentRecord.self, serverID: serverA),
       foreignWrite: {
         // Same rows, written again: a fresh transaction, an identical result.
-        try database.replaceElements(
+        try await database.replaceElements(
           [self.correspondent(1, "A")], of: CorrespondentRecord.self, serverID: serverA)
       },
       ownWrite: {
-        try database.upsertElement(
+        try await database.upsertElement(
           self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: serverA)
       })
     #expect(next.map(\.id) == [1, 2])
@@ -247,8 +247,11 @@ struct ElementObservationTests {
 
     let next = try await valueSkippingForeignWrite(
       from: database.observeUISettings(serverID: serverA),
-      foreignWrite: { try database.setUISettings(self.uiSettings(9, "bob"), serverID: serverB) },
-      ownWrite: { try database.setUISettings(self.uiSettings(7, "alice"), serverID: serverA) })
+      foreignWrite: {
+        try await database.setUISettings(self.uiSettings(9, "bob"), serverID: serverB)
+      },
+      ownWrite: { try await database.setUISettings(self.uiSettings(7, "alice"), serverID: serverA) }
+    )
     #expect(next?.user.username == "alice")
   }
 
@@ -261,11 +264,11 @@ struct ElementObservationTests {
     let next = try await valueSkippingForeignWrite(
       from: database.observeServerConfiguration(serverID: serverA),
       foreignWrite: {
-        try database.setServerConfiguration(
+        try await database.setServerConfiguration(
           ServerConfiguration(id: 1, barcodeAsnPrefix: "FOREIGN"), serverID: serverB)
       },
       ownWrite: {
-        try database.setServerConfiguration(
+        try await database.setServerConfiguration(
           ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN"), serverID: serverA)
       })
     #expect(next?.barcodeAsnPrefix == "ASN")

--- a/current_changelog.txt
+++ b/current_changelog.txt
@@ -32,3 +32,4 @@
 - On iPad you can now refresh an open document from the toolbar, picking up a new version or changed details without closing and reopening it
 - Saving, editing or deleting something while offline now tells you the change was not saved, instead of failing silently and leaving your edit looking like it was queued. If the connection dropped mid-request, so the change may or may not have gone through, it says that instead of guessing.
 - Pulling to refresh while offline now shows the offline indicator instead of doing nothing at all
+- The app no longer freezes briefly while it reads or writes its offline cache; this was most noticeable when opening the app with a large library, or while the share extension was saving a document at the same time

--- a/swift-paperless/Views/Settings/DebugMenuView.swift
+++ b/swift-paperless/Views/Settings/DebugMenuView.swift
@@ -46,9 +46,9 @@ struct DebugMenuView: View {
     }
   }
 
-  private func clearCache() {
+  private func clearCache() async {
     do {
-      try store.wipeLocalCache()
+      try await store.wipeLocalCache()
       showCacheClearedConfirmation = true
     } catch {
       Logger.shared.error("Failed to clear local cache: \(error)")
@@ -129,7 +129,7 @@ struct DebugMenuView: View {
           titleVisibility: .visible
         ) {
           Button(role: .destructive) {
-            clearCache()
+            Task { await clearCache() }
           } label: {
             Text(.settings(.clearCache))
           }


### PR DESCRIPTION
Closes #660. Resolves #656 item 2 and settles item 11.

## Decision

`CachingRepository` stays `@MainActor`; the cache-table accessors in `Persistence` become `async`. Making the repository non-isolated is not available at a proportionate cost because `Networking.Repository` is itself a `@MainActor` protocol, so every conformer, store and view would have to change with it. The actual defect is not *where* the code runs but that a main-actor task **blocks** inside SQLite. GRDB 7's async `read`/`write` dispatch to GRDB's queues and suspend, so a `busy_timeout` wait becomes a suspension instead of a stall, and with the production `DatabasePool` in WAL mode async reads run concurrently instead of queueing behind writes.

## The rule

> Blocking database access is allowed for the `server` table and nothing else.

- **Cache tables are async-only.** `Database+Elements`, `+Documents`, `+DocumentDetail`, `+QuerySyncError`, `+SyncState`, `+Maintenance`: every public accessor is a single `async throws` function. No blocking form survives, so there is no choice for a caller to get wrong. That includes accessors that previously had no main-actor caller (`queryDocuments`, `documentCount`, `queryStatus`, `pruneUnreferencedDocuments`, `dropQueryOrder`, `truncateQueryOrder`, `clearCache`).
- **`Database+Connections` is unchanged from `main`** apart from a header stating the rule and why `server` is exempt: a handful of rows, single-row writes from Login/Settings flows, and `ConnectionManager.init` has to hydrate it synchronously for SwiftUI's first frame. The twelve blocking call sites left in AppShared are all on that table.
- The async family is untyped-`throws` because GRDB throws `CancellationError` and callers discriminate on it (a cancelled fill must not be recorded as a sync error); `wrappingAsync` re-wraps everything except cancellation.
- `Database.seeded` composes the in-package static query bodies directly, so previews need no public blocking accessor.

## Also in this PR

- **Second commit:** the membership sweep's `isFilling` guards were sufficient only because `replaceQueryOrder` was a blocking main-actor call. With a suspending write the window is real, so the sweep now claims its key in `activeFills` for the write's duration and a concurrent `fillQuery` drains instead of interleaving.
- `SyncEngine` needed no change: it has no database call sites.
- **Item 11:** `CachingRepositoryError.cacheMiss` is *not* unreachable (cold cache before the first element sync; `DocumentStore.fillDocumentQuery`'s "no caching backend" path). Kept, with reachability documented on the case.
- Ripple outside Persistence: `DocumentStore.wipeLocalCache` and `ElementStore.refreshUISettings` are now `async`; the debug menu's clear-cache button wraps in a `Task`; one `await` in `ConnectionManager.runDowngradeGC`.
- 40 test functions became `async`; no test logic or expectations changed.

## Cancellation (third commit, from the Codex review)

The async accessors are cancellation-aware: GRDB throws `CancellationError` if the task is already cancelled and interrupts the statement if it is cancelled mid-flight. The blocking calls they replaced always completed. That is kept as is for reads and for sweep writes, so a server switch or backgrounding still stops a sweep promptly, and shielded only where completion matters:

- **Every cache write that follows a successful remote mutation** now runs through `commitCache`, a private helper that executes the write in a fresh unstructured task (inherits actor isolation, not cancellation) and awaits it. The remote change is already committed at that point, so the cache write must land or the two diverge; for deletes the cached document would otherwise keep appearing and be served offline. Twenty sites: element create/update/delete (tags, correspondents, document types, storage paths, saved views), document update (row plus order-stale marking, as one unit) and delete, note create/delete, and the settings read-modify-write. Write-through after a plain GET is deliberately not shielded: nothing was mutated, so an abandoned write only leaves the cache cold.
- **`fillDocumentDetails`** checks cancellation right after its two discovery reads. Those are `try? await`, so a cancelled read became an empty list, both loops and their own checks were skipped, and the pass returned normally and was recorded as complete.
- The remaining `try? await database.` sites were audited one by one (the audit is in the commit message's context); all fail safe under cancellation. One accepted loss is commented at the site: a cancellation between a document upsert and its notes invalidation leaves those notes stale until the next reconcile.

## Atomicity (fourth commit, from the Codex re-review)

Second-order effect of the same change: multi-step database sequences that were atomic only because the main actor serialized them can now interleave at every `await`. Every such sequence in the repository was audited; three needed a fix, the rest are harmless or self-healing and carry a one-line comment saying why.

- **Membership sweep**: the owned query-order write runs in an unstructured task, which hides the sweep's own cancellation, so a cancelled pass could report success. A cancellation check now follows the write, outside the drain `catch`.
- **Delta reconcile**: document upsert and notes invalidation were two transactions, so a note saved in between was wiped. New `upsertDocumentsInvalidatingNotes` does both in one.
- **Settings save**: the read-modify-write of the `ui_settings` row could overwrite a row an element sync refreshed in between. New `updateUISettings(serverID:_:)` applies the merge inside one write transaction.

Eight Persistence tests cover the two accessors. An in-memory queue serializes every access, so the tests assert the property that closes the window, exactly one commit per call via a transaction observer, plus a direct regression for the merge (a row rewritten before the update survives it).

## Cancelled sweeps never read as success (fifth commit, from the third Codex pass)

Two more `try?`-on-the-last-await windows, closed locally, plus one chokepoint so the family stops surfacing one await at a time:

- Membership sweep: a cancellation check at the end of each view's loop body, after both the success and the failure branch.
- `setDeltaWatermark` rethrows cancellation instead of swallowing it with ordinary persistence failures; the cursor is never reported committed when it wasn't.
- `ServerSession`: a cancellation check in the `sweep` helper between the awaited pass and the success count, before `lastSuccessfulSync` is stamped in `runSync`, and before the library and detail fills return `true`. Any swallowed cancellation on a pass's last await now lands as cancelled, not clean. This also covers the coalesced `syncElements` task, which does not inherit its caller's cancellation.

## Verified

All four package suites pass; `just generate` + simulator clean build succeeded with 0 warnings; `just lint` clean. Not measured at runtime: the no-stall claim is reasoned from GRDB's async semantics.

## Rebased on main after #700, #702, #703, #704

The branch is rebased onto current `main`. The observation tests from #700 carry the `await`s this change requires, and the async `refreshUISettings` now lives on `ServerProjection` from #702, which reads its own immutable server id, so the cross-server window Codex flagged on the pre-#702 code no longer exists.

## Manual test checklist

- [ ] Foreground the app on a server with a large library: the UI stays responsive while the element sync runs (no hitch on foreground).
- [ ] Switch servers: the switch is immediate, and Offline & Sync shows the new server's numbers.
- [ ] Online: delete a document and immediately background the app; on return the document is gone from the list.
- [ ] Edit a document's tags: the list reflects the change without a pull-to-refresh.
- [ ] Toggle a UI setting that writes through (e.g. saved-view visibility), then foreground the app again: the change is still there after the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9