### PR TITLE
perf(persistence): stop another server's writes from re-emitting observations

### DIFF
--- a/Persistence/Sources/Persistence/Database+Observe.swift
+++ b/Persistence/Sources/Persistence/Database+Observe.swift
@@ -15,29 +15,59 @@ import GRDB
 /// assigns it directly and never re-reads the database to find out what
 /// changed.
 ///
-/// Scope: the observation tracks the whole table region, so a write to
-/// *another* server's rows re-fires this stream with an identical array. That
-/// is harmless while one server is active and not worth narrowing.
+/// ## Scope: why these streams stay quiet for other servers
+///
+/// A GRDB observation tracks a *database region*, and a region is only
+/// `(table, columns, rowIDs)`. The rowID set is narrowed solely when the
+/// request filters on the rowid itself (`SQLQueryGenerator.optimizedSelectedRegion`
+/// → `SQLExpression.identifyingRowIDs`), and none of these tables is keyed by
+/// rowid — they are keyed `(server_id, …)`. A `server_id` predicate is
+/// therefore *not expressible* as a region, and there is no region narrowing to
+/// be had: a write for another server still wakes every observation on that
+/// table and re-runs its fetch. That matters now that the inactive-server
+/// sweep keeps every configured server's cache warm, not just the active one.
+///
+/// What such a write no longer does is reach the consumer. Every observation
+/// below fetches **records**, applies `removeDuplicates()`, and only then maps
+/// to domain values, so for a server whose rows did not change the fetched
+/// records compare equal, the stream stays silent, and neither the
+/// record → domain mapping nor the consumer's re-publish (main-actor hop,
+/// SwiftUI invalidation, store re-derivation) runs. The residual cost of a
+/// foreign write is one SQL fetch per live observation — the floor GRDB's
+/// region granularity allows.
+///
+/// `removeDuplicates()` never suppresses the initial value: the first emission
+/// is always delivered, so the "initial hydrate + live updates" contract holds.
 extension Database {
   /// Live, name-ordered list of one element collection for a server.
-  public func observeElements<R: ElementRecord>(
+  ///
+  /// `R` is `Equatable` so the fetched rows can be de-duplicated *before* the
+  /// domain mapping — see the type-level note on scope.
+  public func observeElements<R: ElementRecord & Equatable>(
     _ type: R.Type, serverID: UUID
   ) -> AsyncThrowingStream<[R.Domain], Error> {
-    let observation = ValueObservation.tracking { db in
-      try R
-        .filter(Column("server_id") == serverID)
-        .order(Column("name"))
-        .fetchAll(db)
-        .map(\.domain)
-    }
+    let observation =
+      ValueObservation
+      .tracking { db in
+        try R
+          .filter(Column("server_id") == serverID)
+          .order(Column("name"))
+          .fetchAll(db)
+      }
+      .removeDuplicates()
+      .map { records in records.map(\.domain) }
     return stream(observation)
   }
 
   /// Live per-server `UISettings` singleton (`nil` until first cached/synced).
   public func observeUISettings(serverID: UUID) -> AsyncThrowingStream<UISettings?, Error> {
-    let observation = ValueObservation.tracking { db in
-      try UISettingsRecord.fetchOne(db, key: serverID)?.domain
-    }
+    let observation =
+      ValueObservation
+      .tracking { db in
+        try UISettingsRecord.fetchOne(db, key: serverID)
+      }
+      .removeDuplicates()
+      .map { record in record?.domain }
     return stream(observation)
   }
 
@@ -45,9 +75,13 @@ extension Database {
   public func observeServerConfiguration(
     serverID: UUID
   ) -> AsyncThrowingStream<ServerConfiguration?, Error> {
-    let observation = ValueObservation.tracking { db in
-      try ServerConfigurationRecord.fetchOne(db, key: serverID)?.domain
-    }
+    let observation =
+      ValueObservation
+      .tracking { db in
+        try ServerConfigurationRecord.fetchOne(db, key: serverID)
+      }
+      .removeDuplicates()
+      .map { record in record?.domain }
     return stream(observation)
   }
 
@@ -61,13 +95,20 @@ extension Database {
   /// to), not the whole filled set — the win over observing the entire array
   /// during the eager background fill. Re-fires automatically as the fill appends
   /// rows and as mutations write the joined `document` rows.
+  ///
+  /// The join re-runs for any write to `query_order`/`document`, another
+  /// server's included (see the type-level scope note); de-duplication is what
+  /// keeps an unchanged prefix from reaching the list.
   public func observeDocumentPrefix(
     queryKey: QueryKey, serverID: UUID, limit: Int
   ) -> AsyncThrowingStream<[DocumentEntry], Error> {
     let key = queryKey.rawValue
-    let observation = ValueObservation.tracking { db -> [DocumentEntry] in
-      try Self.fetchEntries(db, serverID: serverID, queryKey: key, limit: limit, offset: 0)
-    }
+    let observation =
+      ValueObservation
+      .tracking { db -> [DocumentEntry] in
+        try Self.fetchEntries(db, serverID: serverID, queryKey: key, limit: limit, offset: 0)
+      }
+      .removeDuplicates()
     return stream(observation)
   }
 
@@ -78,9 +119,12 @@ extension Database {
   public func observeQueryStatus(
     queryKey: QueryKey, serverID: UUID
   ) -> AsyncThrowingStream<QueryStatus, Error> {
-    let observation = ValueObservation.tracking { db -> QueryStatus in
-      try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
-    }
+    let observation =
+      ValueObservation
+      .tracking { db -> QueryStatus in
+        try Self.fetchQueryStatus(db, queryKey: queryKey, serverID: serverID)
+      }
+      .removeDuplicates()
     return stream(observation)
   }
 
@@ -90,12 +134,15 @@ extension Database {
   public func observeDocument(
     serverID: UUID, id: UInt
   ) -> AsyncThrowingStream<Document?, Error> {
-    let observation = ValueObservation.tracking { db -> Document? in
-      try DocumentRecord
-        .filter(Column("server_id") == serverID && Column("id") == id)
-        .fetchOne(db)?
-        .domain
-    }
+    let observation =
+      ValueObservation
+      .tracking { db -> DocumentRecord? in
+        try DocumentRecord
+          .filter(Column("server_id") == serverID && Column("id") == id)
+          .fetchOne(db)
+      }
+      .removeDuplicates()
+      .map { record in record?.domain }
     return stream(observation)
   }
 
@@ -103,18 +150,25 @@ extension Database {
   /// (the Offline & Sync screen) so the proactive fill and the downgrade GC's
   /// effect are visible without a debugger.
   public func observeDocumentCount(serverID: UUID) -> AsyncThrowingStream<Int, Error> {
-    let observation = ValueObservation.tracking { db in
-      try DocumentRecord.filter(Column("server_id") == serverID).fetchCount(db)
-    }
+    let observation =
+      ValueObservation
+      .tracking { db in
+        try DocumentRecord.filter(Column("server_id") == serverID).fetchCount(db)
+      }
+      .removeDuplicates()
     return stream(observation)
   }
 
   /// Shared adapter: drive a `ValueObservation` into an `AsyncThrowingStream`,
   /// mirroring ``observeConnections()``. Cancelling the consuming task tears
   /// down the underlying observation.
-  private func stream<Value: Sendable>(
-    _ observation: ValueObservation<ValueReducers.Fetch<Value>>
-  ) -> AsyncThrowingStream<Value, Error> {
+  ///
+  /// Generic over the reducer rather than over `ValueReducers.Fetch` so the
+  /// `removeDuplicates()`/`map` chains above — each of which wraps the reducer
+  /// in another one — all go through this same adapter.
+  private func stream<Reducer: ValueReducer>(
+    _ observation: ValueObservation<Reducer>
+  ) -> AsyncThrowingStream<Reducer.Value, Error> {
     let writer = writer
     return AsyncThrowingStream { continuation in
       let task = Task {

--- a/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
+++ b/Persistence/Sources/Persistence/Models/UISettingsRecord.swift
@@ -17,23 +17,23 @@ import GRDB
 /// flag as `false`. Inserting one in the middle shifts every raw value and
 /// makes already-cached rows decode as the wrong permissions, which fails
 /// silently. Such a change needs a migration that clears `ui_settings`.
-public struct UISettingsRecord: Codable, Sendable {
+public struct UISettingsRecord: Codable, Sendable, Equatable {
   public var serverId: UUID
   public var payload: Payload
 
-  public struct Payload: Codable, Sendable {
+  public struct Payload: Codable, Sendable, Equatable {
     public var user: UserData
     public var settings: SettingsData
     public var permissions: [String: [Bool]]
 
-    public struct UserData: Codable, Sendable {
+    public struct UserData: Codable, Sendable, Equatable {
       public var id: UInt
       public var isSuperUser: Bool
       public var username: String
       public var groups: [UInt]
     }
 
-    public struct SettingsData: Codable, Sendable {
+    public struct SettingsData: Codable, Sendable, Equatable {
       public var removeInboxTags: Bool
       public var defaultOwner: UInt?
       public var defaultViewUsers: [UInt]

--- a/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/DocumentObservationTests.swift
@@ -35,6 +35,35 @@ struct DocumentObservationTests {
     }
   }
 
+  /// Per-server narrowing probe: subscribe, run `foreignWrite` (a write for
+  /// *another* server, which the observation's table region cannot exclude),
+  /// give the observation time to process it, then run `ownWrite` and return
+  /// the next emission.
+  ///
+  /// If the foreign write leaked an emission, that stale value — not the one
+  /// `ownWrite` produced — is what comes back, so the caller's expectation on
+  /// the returned value is the assertion. Sequencing the own write behind the
+  /// foreign one also proves the stream is still live, i.e. the silence was
+  /// narrowing and not a dead subscription.
+  private func valueSkippingForeignWrite<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>,
+    foreignWrite: @escaping @Sendable () async throws -> Void,
+    ownWrite: @escaping @Sendable () async throws -> Void
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      _ = try await iterator.next()
+      try await foreignWrite()
+      // Long enough for the observation to have fetched and (had it not been
+      // de-duplicated) emitted before the own write lands, so the two writes
+      // cannot be coalesced into one notification.
+      try await Task.sleep(for: .milliseconds(250))
+      try await ownWrite()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
   private func withTimeout<T: Sendable>(
     seconds: Double = 3,
     _ operation: @escaping @Sendable () async throws -> T
@@ -49,6 +78,16 @@ struct DocumentObservationTests {
       group.cancelAll()
       return result
     }
+  }
+
+  /// Registers a second server so its rows satisfy the `server_id` foreign key.
+  private func addServer(to database: Database, host: String) throws -> UUID {
+    let id = UUID()
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: id, url: URL(string: "https://\(host).example.com/")!,
+        user: .init(id: 1, isSuperUser: false, username: host)))
+    return id
   }
 
   private func doc(_ id: UInt, _ title: String) -> Document {
@@ -208,5 +247,100 @@ struct DocumentObservationTests {
       try database.deleteDocuments(serverID: server, removedIDs: [1])
     }
     #expect(afterDelete == 1)
+  }
+
+  // MARK: - Per-server narrowing (#696)
+
+  @Test("observeDocumentPrefix does not emit for another server's write")
+  func prefixIgnoresForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA)
+    let serverB = try addServer(to: database, host: "b")
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: serverA, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeDocumentPrefix(queryKey: key, serverID: serverA, limit: 10),
+      foreignWrite: {
+        // Same query key, other server — the sweep's shape exactly.
+        try database.writeQueryPage(
+          queryKey: key, serverID: serverB, documents: [self.doc(1, "B-1"), self.doc(2, "B-2")],
+          startPosition: 0, totalCount: 2, replaceAll: true)
+      },
+      ownWrite: {
+        try database.writeQueryPage(
+          queryKey: key, serverID: serverA, documents: [self.doc(2, "B")],
+          startPosition: 1, totalCount: 2, replaceAll: false)
+      })
+    #expect(next.map(\.id) == [1, 2])
+  }
+
+  @Test("observeQueryStatus does not emit for another server's write")
+  func queryStatusIgnoresForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA)
+    let serverB = try addServer(to: database, host: "b")
+    let key = QueryKey(sentinel: "q")
+    try database.writeQueryPage(
+      queryKey: key, serverID: serverA, documents: [doc(1, "A")],
+      startPosition: 0, totalCount: 2, replaceAll: true)
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeQueryStatus(queryKey: key, serverID: serverA),
+      foreignWrite: {
+        try database.writeQueryPage(
+          queryKey: key, serverID: serverB, documents: [self.doc(9, "B-9")],
+          startPosition: 0, totalCount: 9, replaceAll: true)
+      },
+      ownWrite: {
+        try database.writeQueryPage(
+          queryKey: key, serverID: serverA, documents: [self.doc(2, "B")],
+          startPosition: 1, totalCount: 2, replaceAll: false)
+      })
+    #expect(next == QueryStatus(totalCount: 2, localCount: 2, orderStale: false))
+  }
+
+  @Test("observeDocument does not emit for another server's write of the same id")
+  func documentIgnoresForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, documents: [doc(1, "A")])
+    let serverB = try addServer(to: database, host: "b")
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeDocument(serverID: serverA, id: 1),
+      foreignWrite: { try database.upsertDocument(self.doc(1, "B-1"), serverID: serverB) },
+      ownWrite: { try database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
+    #expect(next?.title == "A-edited")
+  }
+
+  @Test("observeDocument does not re-emit an identical own-server write")
+  func documentIgnoresIdenticalWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, documents: [doc(1, "A")])
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeDocument(serverID: serverA, id: 1),
+      // Same object, written again: a fresh transaction, an identical row.
+      foreignWrite: { try database.upsertDocument(self.doc(1, "A"), serverID: serverA) },
+      ownWrite: { try database.upsertDocument(self.doc(1, "A-edited"), serverID: serverA) })
+    #expect(next?.title == "A-edited")
+  }
+
+  @Test("observeDocumentCount does not emit for another server's write")
+  func documentCountIgnoresForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, documents: [doc(1, "A")])
+    let serverB = try addServer(to: database, host: "b")
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeDocumentCount(serverID: serverA),
+      foreignWrite: {
+        try database.upsertDocuments(
+          [self.doc(1, "B-1"), self.doc(2, "B-2")], serverID: serverB)
+      },
+      ownWrite: { try database.upsertDocument(self.doc(2, "B"), serverID: serverA) })
+    #expect(next == 2)
   }
 }

--- a/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
+++ b/Persistence/Tests/PersistenceTests/ElementObservationTests.swift
@@ -38,6 +38,35 @@ struct ElementObservationTests {
     }
   }
 
+  /// Per-server narrowing probe: subscribe, run `foreignWrite` (a write for
+  /// *another* server, which the observation's table region cannot exclude),
+  /// give the observation time to process it, then run `ownWrite` and return
+  /// the next emission.
+  ///
+  /// If the foreign write leaked an emission, that stale value — not the one
+  /// `ownWrite` produced — is what comes back, so the caller's expectation on
+  /// the returned value is the assertion. Sequencing the own write behind the
+  /// foreign one also proves the stream is still live, i.e. the silence was
+  /// narrowing and not a dead subscription.
+  private func valueSkippingForeignWrite<T: Sendable>(
+    from stream: AsyncThrowingStream<T, Error>,
+    foreignWrite: @escaping @Sendable () async throws -> Void,
+    ownWrite: @escaping @Sendable () async throws -> Void
+  ) async throws -> T {
+    try await withTimeout {
+      var iterator = stream.makeAsyncIterator()
+      _ = try await iterator.next()
+      try await foreignWrite()
+      // Long enough for the observation to have fetched and (had it not been
+      // de-duplicated) emitted before the own write lands, so the two writes
+      // cannot be coalesced into one notification.
+      try await Task.sleep(for: .milliseconds(250))
+      try await ownWrite()
+      guard let value = try await iterator.next() else { throw TimeoutError() }
+      return value
+    }
+  }
+
   private func withTimeout<T: Sendable>(
     seconds: Double = 3,
     _ operation: @escaping @Sendable () async throws -> T
@@ -52,6 +81,24 @@ struct ElementObservationTests {
       group.cancelAll()
       return result
     }
+  }
+
+  /// Registers a second server so its rows satisfy the `server_id` foreign key.
+  @discardableResult
+  private func addServer(to database: Database, host: String) throws -> UUID {
+    let id = UUID()
+    try database.upsertConnection(
+      ConnectionRecord(
+        id: id, url: URL(string: "https://\(host).example.com/")!,
+        user: .init(id: 1, isSuperUser: false, username: host)))
+    return id
+  }
+
+  private func uiSettings(_ id: UInt, _ username: String) -> UISettings {
+    UISettings(
+      user: User(id: id, isSuperUser: false, username: username, groups: []),
+      settings: UISettingsSettings(),
+      permissions: .empty)
   }
 
   private func correspondent(_ id: UInt, _ name: String) -> Correspondent {
@@ -142,16 +189,85 @@ struct ElementObservationTests {
   func scopedPerServer() async throws {
     let serverA = UUID()
     let database = try Database.seeded(serverID: serverA, correspondents: [correspondent(1, "A")])
-    let serverB = UUID()
-    try database.upsertConnection(
-      ConnectionRecord(
-        id: serverB, url: URL(string: "https://b.example.com/")!,
-        user: .init(id: 1, isSuperUser: false, username: "bob")))
+    let serverB = try addServer(to: database, host: "b")
     try database.replaceElements(
       [correspondent(2, "B")], of: CorrespondentRecord.self, serverID: serverB)
 
     let aOnly = try await firstValue(
       from: database.observeElements(CorrespondentRecord.self, serverID: serverA))
     #expect(aOnly.map(\.id) == [1])
+  }
+
+  // MARK: - Per-server narrowing (#696)
+
+  @Test("observeElements does not emit for another server's write")
+  func elementsIgnoreForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, correspondents: [correspondent(1, "A")])
+    let serverB = try addServer(to: database, host: "b")
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeElements(CorrespondentRecord.self, serverID: serverA),
+      foreignWrite: {
+        try database.replaceElements(
+          [self.correspondent(50, "Foreign")], of: CorrespondentRecord.self, serverID: serverB)
+        try database.deleteElement(CorrespondentRecord.self, serverID: serverB, id: 50)
+      },
+      ownWrite: {
+        try database.upsertElement(
+          self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: serverA)
+      })
+    #expect(next.map(\.id) == [1, 2])
+  }
+
+  @Test("observeElements does not re-emit an identical own-server write")
+  func elementsIgnoreIdenticalWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA, correspondents: [correspondent(1, "A")])
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeElements(CorrespondentRecord.self, serverID: serverA),
+      foreignWrite: {
+        // Same rows, written again: a fresh transaction, an identical result.
+        try database.replaceElements(
+          [self.correspondent(1, "A")], of: CorrespondentRecord.self, serverID: serverA)
+      },
+      ownWrite: {
+        try database.upsertElement(
+          self.correspondent(2, "Beta"), of: CorrespondentRecord.self, serverID: serverA)
+      })
+    #expect(next.map(\.id) == [1, 2])
+  }
+
+  @Test("observeUISettings does not emit for another server's write")
+  func uiSettingsIgnoreForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA)
+    let serverB = try addServer(to: database, host: "b")
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeUISettings(serverID: serverA),
+      foreignWrite: { try database.setUISettings(self.uiSettings(9, "bob"), serverID: serverB) },
+      ownWrite: { try database.setUISettings(self.uiSettings(7, "alice"), serverID: serverA) })
+    #expect(next?.user.username == "alice")
+  }
+
+  @Test("observeServerConfiguration does not emit for another server's write")
+  func serverConfigurationIgnoresForeignServerWrite() async throws {
+    let serverA = UUID()
+    let database = try Database.seeded(serverID: serverA)
+    let serverB = try addServer(to: database, host: "b")
+
+    let next = try await valueSkippingForeignWrite(
+      from: database.observeServerConfiguration(serverID: serverA),
+      foreignWrite: {
+        try database.setServerConfiguration(
+          ServerConfiguration(id: 1, barcodeAsnPrefix: "FOREIGN"), serverID: serverB)
+      },
+      ownWrite: {
+        try database.setServerConfiguration(
+          ServerConfiguration(id: 1, barcodeAsnPrefix: "ASN"), serverID: serverA)
+      })
+    #expect(next?.barcodeAsnPrefix == "ASN")
   }
 }


### PR DESCRIPTION
Closes #696. Part of #656 item 9.

## Why not region narrowing

Checked against GRDB 7.11.1's source rather than assumed: a `DatabaseRegion` is `(table, columns, rowIDs)`, and the rowID set is narrowed only when the filter is on the rowid column itself (`SQLQueryGenerator.optimizedSelectedRegion` → `identifyingRowIDs`). These tables are keyed `(server_id, …)` with an implicit rowid, so a `server_id` predicate is not expressible as a region. A hand-built "rowids of server A" region would also be resolved once at observation start and go stale on the next insert, trading wasted work for stale UI. This applies equally to all seven observations; the join in `observeDocumentPrefix` is not specially worse.

## What changed

All seven observations fetch records, `removeDuplicates()`, and only then map to domain values. A foreign write still costs one SQL fetch (GRDB's floor) but no longer reaches the consumer, and for five of the seven the record→domain mapping is skipped as well. `removeDuplicates()` never suppresses the first value, so the "initial hydrate + live updates" contract is unchanged.

- `observeElements` gains `R: ElementRecord & Equatable` (every conformer already was).
- `UISettingsRecord` and its payload structs gain `Equatable`.
- The "not worth narrowing" header note is replaced with the explanation above, naming the GRDB symbols so it can be re-verified.

## Tests

Nine cases: subscribe for server A, write for server B, then write for A and assert the next emission is A's. All nine fail against the pre-change implementation (negative control run). The helper sleeps 250 ms between the foreign and sentinel writes so GRDB cannot coalesce them into one notification; if that ever flakes on CI, raising it is the fix, not removing it.

## Verified

Persistence 143 tests pass; other three package suites pass; simulator build succeeded (the `observeElements` signature changed); swift-format clean.

## Merge order

Touches the same test files as #660's branch; whichever lands second needs a trivial `try` → `try await` rebase.

## Manual test checklist

- [x] Two servers configured. While viewing server A's document list, trigger a sync of server B (switch to B and back, or wait for the inactive sweep): A's list does not flicker or lose scroll position.
- [x] On the active server, create a tag: it appears in the tag list without a refresh (live updates still work).
- [x] Switch filters and saved views: the list still repaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9