### PR TITLE
fix: one server projection per server, so a stale observation can't overwrite the current one

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore+Preview.swift
@@ -14,8 +14,8 @@ import Persistence
 
 extension DocumentStore {
   /// A store backed by an in-memory seeded DB, wrapping `wrapped` in a
-  /// `CachingRepository` so the live `ElementStore` projection and the
-  /// write-through mutations behave exactly as in production.
+  /// `CachingRepository` so the live `ServerProjection` and the write-through
+  /// mutations behave exactly as in production.
   ///
   /// The wrapped repository's element data is copied into the DB by a one-shot
   /// `sync()` (previews are live, so it lands a beat after first render);
@@ -52,7 +52,7 @@ extension DocumentStore {
     // ownership path production does, and there is no `init(repository:)` for
     // production code to reach for.
     let store = DocumentStore(session: ServerSession(serverID: serverID, repository: caching))
-    store.elementStore.refreshUISettings(from: database, serverID: serverID)
+    store.projection?.refreshUISettings()
     Task { try? await store.sync() }
     return store
   }

--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -22,28 +22,34 @@ public final class DocumentStore: Sendable {
 
   public private(set) var tasks: [PaperlessTask] = []
 
-  /// The live element projection (DB → typed `ValueObservation`). The store owns
-  /// it and re-exposes its collections through the computed delegates below, so
-  /// `store.tags` etc. keep working and stay reactive (a view reading
-  /// `store.tags` tracks `ElementStore.tags` through the getter). The reference
-  /// is stable across its lifetime — only its contents change — so it is
-  /// `@ObservationIgnored`; the inner `@Observable` does the tracking.
-  @ObservationIgnored
-  public let elementStore = ElementStore()
+  /// The live projection of the *active* server (DB → typed `ValueObservation`),
+  /// or `nil` when there is no server to project (before login, or a repository
+  /// that fronts no DB). The store owns it and re-exposes it through the
+  /// read-only computed delegates below, so `store.tags` etc. keep working.
+  ///
+  /// Deliberately a tracked stored property, and deliberately *replaced* rather
+  /// than re-pointed on a connection switch. Both hops a delegate walks —
+  /// `projection`, then the value on it — are observation-tracked, so views
+  /// repaint when the instance is swapped as well as when its contents change.
+  /// Replacing it is also what makes a superseded server's late emission
+  /// harmless: that server's loops hold the object they were born with, and
+  /// once it is no longer this property nothing reads what they write into it.
+  public private(set) var projection: ServerProjection?
 
   // Element collections and singletons — read-only projections of the DB,
-  // observed via `elementStore`. Writes go through the repository (which
-  // write-throughs to the DB); the observation repaints these.
-  public var correspondents: [UInt: Correspondent] { elementStore.correspondents }
-  public var documentTypes: [UInt: DocumentType] { elementStore.documentTypes }
-  public var tags: [UInt: Tag] { elementStore.tags }
-  public var savedViews: [UInt: SavedView] { elementStore.savedViews }
-  public var storagePaths: [UInt: StoragePath] { elementStore.storagePaths }
-  public var users: [UInt: User] { elementStore.users }
-  public var groups: [UInt: UserGroup] { elementStore.groups }
-  public var customFields: [UInt: CustomField] { elementStore.customFields }
-  public var currentUser: User? { elementStore.currentUser }
-  public var serverConfiguration: ServerConfiguration? { elementStore.serverConfiguration }
+  // observed via `projection`. Writes go through the repository (which
+  // write-throughs to the DB); the observation repaints these. The fallbacks are
+  // the serverless state: the same empties a fresh projection is born with.
+  public var correspondents: [UInt: Correspondent] { projection?.correspondents ?? [:] }
+  public var documentTypes: [UInt: DocumentType] { projection?.documentTypes ?? [:] }
+  public var tags: [UInt: Tag] { projection?.tags ?? [:] }
+  public var savedViews: [UInt: SavedView] { projection?.savedViews ?? [:] }
+  public var storagePaths: [UInt: StoragePath] { projection?.storagePaths ?? [:] }
+  public var users: [UInt: User] { projection?.users ?? [:] }
+  public var groups: [UInt: UserGroup] { projection?.groups ?? [:] }
+  public var customFields: [UInt: CustomField] { projection?.customFields ?? [:] }
+  public var currentUser: User? { projection?.currentUser }
+  public var serverConfiguration: ServerConfiguration? { projection?.serverConfiguration }
   /// The permission matrix to *gate on* — and, until `ui_settings` has landed
   /// for the active server, a deliberate optimistic lie.
   ///
@@ -59,16 +65,17 @@ public final class DocumentStore: Sendable {
   /// ``permissionsKnown`` first — otherwise it reports access the server never
   /// granted. `PermissionsView` does.
   public var permissions: UserPermissions {
-    permissionsKnown ? elementStore.permissions : .full
+    guard let projection, projection.isHydrated else { return .full }
+    return projection.permissions
   }
 
-  public var settings: UISettingsSettings { elementStore.settings }
+  public var settings: UISettingsSettings { projection?.settings ?? UISettingsSettings() }
 
   /// Whether ``permissions`` reflects the server's answer yet, or is the
   /// optimistic `.full` stand-in. Gates don't need this; anything that shows the
   /// matrix, or that would otherwise assert *why* something is unavailable,
   /// does.
-  public var permissionsKnown: Bool { elementStore.isHydrated }
+  public var permissionsKnown: Bool { projection?.isHydrated ?? false }
 
   /// The last automatic (non-user-initiated) sync failure, kept so the UI can
   /// surface a degraded state without tearing down the cached display.
@@ -98,23 +105,26 @@ public final class DocumentStore: Sendable {
   /// the store used never to hear about.
   public var lastReconcileAt: Date? { session?.lastReconcileSuccess }
 
-  /// When the active server's library was last fully filled (`nil` if never).
-  /// A stored, observed mirror of `server_sync_state.library_coverage_at` —
-  /// refreshed when the repository changes and after each fill — so the
-  /// Offline & Sync screen repaints instead of staying on "Never". A bare DB
-  /// read wouldn't be tracked by the observation.
-  public private(set) var libraryCoverageAt: Date?
+  /// When the active server's library was last fully filled (`nil` if never),
+  /// observed from `server_sync_state.library_coverage_at` so the Offline & Sync
+  /// screen tracks fills *and* a cache wipe (which clears it) instead of staying
+  /// on "Never".
+  ///
+  /// The one that made this bug visible: it may not emit again for hours, so a
+  /// value the previous server's observation slipped in after a switch used to
+  /// stay on screen until the next fill.
+  public var libraryCoverageAt: Date? { projection?.libraryCoverageAt }
 
   /// Views (saved or default) whose proactive offline fill the server most
   /// recently rejected — observed from `query_sync_error` for the active server
   /// so the Offline & Sync screen can warn that they aren't fully cached.
-  public private(set) var syncErrors: [QuerySyncError] = []
+  public var syncErrors: [QuerySyncError] { projection?.syncErrors ?? [] }
 
   /// Live count of `document` rows cached for the active server — lets the
   /// Offline & Sync screen show the effect of the proactive fill and the
   /// downgrade GC (switching *Entire library* → *Recently browsed*) without a
   /// debugger.
-  public private(set) var cachedDocumentCount: Int = 0
+  public var cachedDocumentCount: Int { projection?.cachedDocumentCount ?? 0 }
 
   public var activeTasks: [PaperlessTask] {
     tasks.filter(\.isActive)
@@ -166,19 +176,6 @@ public final class DocumentStore: Sendable {
   @ObservationIgnored
   private var taskUpdateTask: Task<Void, Never>?
 
-  // Observes the active server's `library_coverage_at` into `libraryCoverageAt`.
-  // Re-pointed alongside the element projection whenever the repository changes.
-  @ObservationIgnored
-  private var coverageObservationTask: Task<Void, Never>?
-
-  // Observes the active server's recorded per-view sync failures into `syncErrors`.
-  @ObservationIgnored
-  private var syncErrorObservationTask: Task<Void, Never>?
-
-  // Observes the active server's cached document count into `cachedDocumentCount`.
-  @ObservationIgnored
-  private var documentCountObservationTask: Task<Void, Never>?
-
   // MARK: Methods
 
   /// The production store: it activates onto servers by asking `registry` for
@@ -199,58 +196,32 @@ public final class DocumentStore: Sendable {
     self.registry = registry
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session?.repository?.delegate)
-    wireElementStore()
+    rebuildProjection()
   }
 
   deinit {
     taskUpdateTask?.cancel()
-    coverageObservationTask?.cancel()
-    syncErrorObservationTask?.cancel()
-    documentCountObservationTask?.cancel()
   }
 
-  /// Point the element projection at the active repository's DB. Under the
-  /// source-of-truth model every production/preview repository fronts a DB
-  /// (`CachingBackend`); a repository that doesn't (e.g. `NullRepository` before
-  /// login) detaches the projection.
-  private func wireElementStore() {
-    coverageObservationTask?.cancel()
-    syncErrorObservationTask?.cancel()
-    documentCountObservationTask?.cancel()
-    if let backend = session?.backend {
-      elementStore.repoint(database: backend.database, serverID: backend.serverID)
-      // Source-of-truth: observe the coverage timestamp rather than reading it
-      // imperatively, so it tracks fills *and* a cache wipe (which clears it).
-      let stream = backend.database.observeLibraryCoverageAt(serverID: backend.serverID)
-      coverageObservationTask = Task { [weak self] in
-        do {
-          for try await date in stream { self?.libraryCoverageAt = date }
-        } catch {
-          Logger.shared.debug("Coverage observation ended: \(error)")
-        }
-      }
-      let errors = backend.database.observeQuerySyncErrors(serverID: backend.serverID)
-      syncErrorObservationTask = Task { [weak self] in
-        do {
-          for try await errors in errors { self?.syncErrors = errors }
-        } catch {
-          Logger.shared.debug("Sync-error observation ended: \(error)")
-        }
-      }
-      let counts = backend.database.observeDocumentCount(serverID: backend.serverID)
-      documentCountObservationTask = Task { [weak self] in
-        do {
-          for try await count in counts { self?.cachedDocumentCount = count }
-        } catch {
-          Logger.shared.debug("Document-count observation ended: \(error)")
-        }
-      }
-    } else {
-      elementStore.reset()
-      libraryCoverageAt = nil
-      syncErrors = []
-      cachedDocumentCount = 0
+  /// Build a projection for the active server, replacing whatever was there.
+  ///
+  /// Under the source-of-truth model every production/preview repository fronts
+  /// a DB (`CachingBackend`); a repository that doesn't (e.g. `NullRepository`
+  /// before login) leaves the store serverless and the delegates on their empty
+  /// defaults.
+  ///
+  /// Replacement, not re-pointing, is the whole design: the outgoing server's
+  /// observation loops die with the object they wrote into (they hold it weakly,
+  /// so dropping it here runs its `deinit` and cancels them), and a value one of
+  /// them had already produced can no longer reach the store — cancellation is
+  /// cooperative, so it *would* still be delivered, it just lands somewhere
+  /// nothing reads.
+  private func rebuildProjection() {
+    guard let backend = session?.backend else {
+      projection = nil
+      return
     }
+    projection = ServerProjection(database: backend.database, serverID: backend.serverID)
   }
 
   @Sendable
@@ -297,8 +268,8 @@ public final class DocumentStore: Sendable {
   /// Drop the per-server state this store still holds in memory, on a repository
   /// swap. That is only the task list and the last sync error now: documents
   /// aren't held in memory under source-of-truth (the list observes the DB
-  /// directly), and the element projection is owned by `elementStore` and
-  /// re-pointed by `wireElementStore()`. `private` because `install(session:)` is
+  /// directly), and the element projection is owned by `projection` and
+  /// rebuilt by `rebuildProjection()`. `private` because `install(session:)` is
   /// the one caller — a swap is the only moment this is the right thing to do.
   private func clear() {
     tasks = []
@@ -350,7 +321,7 @@ public final class DocumentStore: Sendable {
     // the Offline & Sync screen shows.
     self.session = session
     imagePipeline = Self.makeImagePipeline(delegate: session.repository?.delegate)
-    wireElementStore()
+    rebuildProjection()
     if reload {
       events.emit(.repositoryChanged)
       clear()
@@ -460,7 +431,16 @@ public final class DocumentStore: Sendable {
     guard (try? checkPermission(.view, for: .paperlessTask)) != nil else {
       return
     }
+    // The poller is not restarted on a connection switch, and the fetch below is
+    // a suspension point, so the session has to be re-checked: the outgoing
+    // server's task list must not land in the store after `install` cleared it
+    // for the incoming one.
+    let session = session
     guard let tasks = try? await repository.tasks(limit: Self.taskPollLimit) else {
+      return
+    }
+    guard self.session === session else {
+      Logger.shared.debug("Dropping task list from a superseded server")
       return
     }
     self.tasks = tasks
@@ -479,9 +459,9 @@ public final class DocumentStore: Sendable {
   /// permissions (offline-first) instead of aborting the launch load.
   public func fetchUISettings() async throws {
     try await sync()
-    if let backend = session?.backend {
-      elementStore.refreshUISettings(from: backend.database, serverID: backend.serverID)
-    }
+    // Re-read after the await: a switch during the sync means the projection to
+    // refresh is the new server's, and it reads its own database and serverID.
+    projection?.refreshUISettings()
   }
 
   /// Network → DB via the caching backend; the live element observation repaints
@@ -502,7 +482,10 @@ public final class DocumentStore: Sendable {
     guard let session else { return }
     do {
       try await session.syncElements()
-      lastSyncError = nil
+      // `lastSyncError` describes the server this call synced, so an outcome
+      // that arrives after a switch must not be shown for — or cleared on — the
+      // server now on screen.
+      if self.session === session { lastSyncError = nil }
       Logger.sync.info("Sync store complete")
       // Kick the reconcile alongside the element sync (throttled,
       // non-blocking). Not just remote deletes, despite the name it used to
@@ -524,7 +507,7 @@ public final class DocumentStore: Sendable {
       // Only presentable failures are recorded. A non-displayable one (a GRDB
       // `DatabaseError`, a raw `URLError`) leaves any degraded state already
       // on screen intact rather than clearing it.
-      if let displayable = error as? any DisplayableError {
+      if let displayable = error as? any DisplayableError, self.session === session {
         lastSyncError = displayable
       }
       Logger.sync.error("Background sync failed (suppressed): \(error)")

--- a/AppShared/Sources/AppShared/Document/ServerProjection.swift
+++ b/AppShared/Sources/AppShared/Document/ServerProjection.swift
@@ -1,10 +1,11 @@
 //
-//  ElementStore.swift
+//  ServerProjection.swift
 //  AppShared
 //
-//  The source-of-truth read projection for the element collections. Owned by
-//  `DocumentStore`, which re-exposes these through read-only computed delegates
-//  (`store.tags { elementStore.tags }`) so existing call sites keep working.
+//  The source-of-truth read projection for one server. Owned by
+//  `DocumentStore`, which re-exposes it through read-only computed delegates
+//  (`store.tags { projection?.tags ?? [:] }`) so existing call sites keep
+//  working.
 //
 //  The DB is the only authoritative copy. Each collection/singleton is kept
 //  live by a GRDB `ValueObservation` (vended as a typed `observe…` stream from
@@ -13,6 +14,13 @@
 //  coarse `CacheChange` signal. The first emission is the current cached state
 //  (offline-first instant paint), then live updates as `sync`/mutations write
 //  the DB.
+//
+//  One instance belongs to one server for its whole life: it is created with
+//  the `(database, serverID)` it observes, starts its loops in `init`, and
+//  cancels them in `deinit`. Switching servers *replaces* the instance rather
+//  than re-pointing it, which is what makes a stale emission harmless — the
+//  loop that produced it can only write into the object it was born with, and
+//  nothing reads that object any more.
 //
 
 import Common
@@ -24,7 +32,7 @@ import os
 
 @MainActor
 @Observable
-public final class ElementStore {
+public final class ServerProjection {
   // MARK: Observed projection (read-only; written only by the observation loops)
 
   public private(set) var tags: [UInt: Tag] = [:]
@@ -43,10 +51,35 @@ public final class ElementStore {
 
   public private(set) var serverConfiguration: ServerConfiguration?
 
-  /// True once the `ui_settings` singleton has produced a non-nil value for the
-  /// active server — i.e. `permissions`/`settings` reflect real data rather than
-  /// the cold-cache default. Lets the UI distinguish "loading" from "denied".
+  /// True once the `ui_settings` singleton has produced a non-nil value for this
+  /// server — i.e. `permissions`/`settings` reflect real data rather than the
+  /// cold-cache default. Lets the UI distinguish "loading" from "denied".
   public private(set) var isHydrated = false
+
+  /// When this server's library was last fully filled (`nil` if never): an
+  /// observed mirror of `server_sync_state.library_coverage_at`, so the Offline
+  /// & Sync screen tracks fills *and* a cache wipe (which clears it) instead of
+  /// staying on "Never". A bare DB read wouldn't be tracked by the observation.
+  public private(set) var libraryCoverageAt: Date?
+
+  /// Views (saved or default) whose proactive offline fill the server most
+  /// recently rejected, from `query_sync_error`, so the Offline & Sync screen
+  /// can warn that they aren't fully cached.
+  public private(set) var syncErrors: [QuerySyncError] = []
+
+  /// Live count of cached `document` rows — lets the Offline & Sync screen show
+  /// the effect of the proactive fill and the downgrade GC (switching *Entire
+  /// library* → *Recently browsed*) without a debugger.
+  public private(set) var cachedDocumentCount: Int = 0
+
+  // MARK: Members
+
+  @ObservationIgnored
+  private let database: Database
+
+  /// The server this projection is pinned to for its whole life.
+  @ObservationIgnored
+  public let serverID: UUID
 
   /// The live observation loops, held in a locked box rather than a stored
   /// property because `deinit` is nonisolated and cannot read main-actor state.
@@ -55,29 +88,45 @@ public final class ElementStore {
   @ObservationIgnored
   private let observationTasks = TaskBox()
 
-  public init() {}
+  // MARK: Lifecycle
+
+  /// Start observing `serverID`'s cached data. A fresh instance is born empty,
+  /// which is what a caller switching servers wants: the previous server's data
+  /// is gone the moment the instance is replaced, without a separate clearing
+  /// step to keep in sync with the loops.
+  public init(database: Database, serverID: UUID) {
+    self.database = database
+    self.serverID = serverID
+    observationTasks.replace(with: [
+      observe(database.observeElements(TagRecord.self, serverID: serverID), into: \.tags),
+      observe(
+        database.observeElements(CorrespondentRecord.self, serverID: serverID),
+        into: \.correspondents),
+      observe(
+        database.observeElements(DocumentTypeRecord.self, serverID: serverID),
+        into: \.documentTypes),
+      observe(
+        database.observeElements(StoragePathRecord.self, serverID: serverID),
+        into: \.storagePaths),
+      observe(
+        database.observeElements(SavedViewRecord.self, serverID: serverID), into: \.savedViews),
+      observe(database.observeElements(UserRecord.self, serverID: serverID), into: \.users),
+      observe(database.observeElements(UserGroupRecord.self, serverID: serverID), into: \.groups),
+      observe(
+        database.observeElements(CustomFieldRecord.self, serverID: serverID),
+        into: \.customFields),
+      observeUISettings(database.observeUISettings(serverID: serverID)),
+      observeValue(
+        database.observeServerConfiguration(serverID: serverID), into: \.serverConfiguration),
+      observeValue(
+        database.observeLibraryCoverageAt(serverID: serverID), into: \.libraryCoverageAt),
+      observeValue(database.observeQuerySyncErrors(serverID: serverID), into: \.syncErrors),
+      observeValue(database.observeDocumentCount(serverID: serverID), into: \.cachedDocumentCount),
+    ])
+  }
 
   deinit {
     observationTasks.cancelAll()
-  }
-
-  // MARK: Lifecycle
-
-  /// Point the projection at a server's cached data and keep it live. Cancels
-  /// any prior observation, clears the dicts synchronously (so the previous
-  /// server's data isn't shown during the gap before the first emission lands),
-  /// then subscribes. Mirror of `set(repository:)`'s connection-switch hook.
-  public func repoint(database: Database, serverID: UUID) {
-    cancelObservation()
-    clearProjection()
-    start(database: database, serverID: serverID)
-  }
-
-  /// Detach from any server (logout / a non-caching repository that fronts no
-  /// DB): stop the loops and clear the projection.
-  public func reset() {
-    cancelObservation()
-    clearProjection()
   }
 
   /// Synchronously pull the `ui_settings` singleton from the DB into the
@@ -85,44 +134,18 @@ public final class ElementStore {
   /// `permissions` immediately after a refresh and cannot wait for the
   /// observation's runloop hop. The observation will re-emit the same values
   /// harmlessly.
-  func refreshUISettings(from database: Database, serverID: UUID) {
+  func refreshUISettings() {
     guard let uiSettings = try? database.uiSettings(serverID: serverID) else { return }
     apply(uiSettings)
   }
 
   // MARK: Observation
 
-  private func start(database: Database, serverID: UUID) {
-    observationTasks.replace(with: [
-      observeCollection(
-        database.observeElements(TagRecord.self, serverID: serverID), into: \.tags),
-      observeCollection(
-        database.observeElements(CorrespondentRecord.self, serverID: serverID),
-        into: \.correspondents),
-      observeCollection(
-        database.observeElements(DocumentTypeRecord.self, serverID: serverID),
-        into: \.documentTypes),
-      observeCollection(
-        database.observeElements(StoragePathRecord.self, serverID: serverID),
-        into: \.storagePaths),
-      observeCollection(
-        database.observeElements(SavedViewRecord.self, serverID: serverID), into: \.savedViews),
-      observeCollection(
-        database.observeElements(UserRecord.self, serverID: serverID), into: \.users),
-      observeCollection(
-        database.observeElements(UserGroupRecord.self, serverID: serverID), into: \.groups),
-      observeCollection(
-        database.observeElements(CustomFieldRecord.self, serverID: serverID),
-        into: \.customFields),
-      observeUISettings(database.observeUISettings(serverID: serverID)),
-      observeSingleton(
-        database.observeServerConfiguration(serverID: serverID), into: \.serverConfiguration),
-    ])
-  }
-
-  private func observeCollection<E: Identifiable & Sendable>(
+  /// A collection observation, keyed by element id for the dictionary shape the
+  /// call sites read.
+  private func observe<E: Identifiable & Sendable>(
     _ stream: AsyncThrowingStream<[E], Error>,
-    into keyPath: ReferenceWritableKeyPath<ElementStore, [UInt: E]>
+    into keyPath: ReferenceWritableKeyPath<ServerProjection, [UInt: E]>
   ) -> Task<Void, Never> where E.ID == UInt {
     Task { @MainActor [weak self] in
       do {
@@ -139,9 +162,11 @@ public final class ElementStore {
     }
   }
 
-  private func observeSingleton<V: Sendable>(
-    _ stream: AsyncThrowingStream<V?, Error>,
-    into keyPath: ReferenceWritableKeyPath<ElementStore, V?>
+  /// Whatever the stream carries, assigned as it arrives: a singleton, a
+  /// timestamp, a count, a list that isn't keyed by id.
+  private func observeValue<V: Sendable>(
+    _ stream: AsyncThrowingStream<V, Error>,
+    into keyPath: ReferenceWritableKeyPath<ServerProjection, V>
   ) -> Task<Void, Never> {
     Task { @MainActor [weak self] in
       do {
@@ -151,7 +176,7 @@ public final class ElementStore {
         }
       } catch is CancellationError {
       } catch {
-        Logger.shared.error("Singleton observation terminated: \(error)")
+        Logger.shared.error("\(V.self) observation terminated: \(error)")
       }
     }
   }
@@ -180,27 +205,5 @@ public final class ElementStore {
     permissions = uiSettings.permissions
     settings = uiSettings.settings
     isHydrated = true
-  }
-
-  // MARK: Helpers
-
-  private func cancelObservation() {
-    observationTasks.cancelAll()
-  }
-
-  private func clearProjection() {
-    tags = [:]
-    correspondents = [:]
-    documentTypes = [:]
-    storagePaths = [:]
-    savedViews = [:]
-    users = [:]
-    groups = [:]
-    customFields = [:]
-    currentUser = nil
-    permissions = .empty
-    settings = UISettingsSettings()
-    serverConfiguration = nil
-    isHydrated = false
   }
 }

--- a/Networking/Tests/NetworkingTests/PageCursorTest.swift
+++ b/Networking/Tests/NetworkingTests/PageCursorTest.swift
@@ -143,4 +143,51 @@ private let initial = URL(string: "https://example.com/api/items/?page=1")!
     _ = try await cursor.collectAll()
     #expect(await recorder.urls == [initial, expectedFixed])
   }
+
+  // A 403 from the server is rewritten into `ResourceForbidden<Element>`, which
+  // deliberately is *not* a `RequestError`: callers that want to skip a
+  // forbidden resource must match on `ResourceForbiddenError`, not on
+  // `RequestError`. Regression guard for
+  // https://github.com/paulgessinger/swift-paperless/issues/661.
+  @Test(.bug("https://github.com/paulgessinger/swift-paperless/issues/661", id: 661))
+  func forbiddenIsRewrittenToResourceForbidden() async throws {
+    let cursor = PageCursor<Int>(
+      initialURL: initial,
+      fetch: { _ in
+        throw RequestError.forbidden(detail: "Insufficient permissions")
+      })
+
+    do {
+      _ = try await cursor.nextPage()
+      Issue.record("nextPage() must throw for a forbidden response")
+    } catch let error {
+      // The rewrite target, carrying the server detail through.
+      let forbidden = try #require(error as? ResourceForbidden<Int>)
+      #expect(forbidden.response == "Insufficient permissions")
+      // Recognisable without knowing the element type.
+      #expect(error is any ResourceForbiddenError)
+      // The whole point of the rewrite: it is no longer a `RequestError`, so
+      // `catch let error as RequestError` never sees it.
+      #expect(!(error is RequestError))
+    }
+  }
+
+  // The rewrite also applies on later pages, i.e. it is not tied to the first
+  // request, and `collectAll` propagates it rather than ending the sequence.
+  @Test(.bug("https://github.com/paulgessinger/swift-paperless/issues/661", id: 661))
+  func forbiddenOnLaterPagePropagatesThroughCollectAll() async throws {
+    let second = URL(string: "https://example.com/api/items/?page=2")!
+    let cursor = PageCursor<Int>(
+      initialURL: initial,
+      fetch: { url in
+        if url == initial {
+          return ListResponse(count: 4, next: second, previous: nil, results: [1, 2])
+        }
+        throw RequestError.forbidden(detail: nil)
+      })
+
+    await #expect(throws: ResourceForbidden<Int>.self) {
+      _ = try await cursor.collectAll()
+    }
+  }
 }


### PR DESCRIPTION
Closes #691 and closes #661. Part of #656 (items 34 and 4).

## #661: `PageCursor` forbidden → `ResourceForbidden` test

Two tests in `PageCursorTest`, tagged `.bug(id: 661)`: a fetch throwing `RequestError.forbidden` makes `nextPage()` throw `ResourceForbidden<Int>` (asserting the concrete type, the `ResourceForbiddenError` existential, that the server detail survives, and that it is **not** a `RequestError`, the property that made the old `catch let error as RequestError` never match); and that the rewrite on a later page propagates through `collectAll()`. `isSkippable` lives in AppShared and stays uncovered.

## #691: one projection object per server

The race: every observation loop suspends in `for try await`, then hops back to the main actor to assign. A switch cancels the old loops and starts new ones, but an old loop that already has a value in hand resumes *after* the switch and assigns the previous server's value. `libraryCoverageAt` made it visible because it may not update again for a long time.

Rather than guarding every assignment, the server-scoped projection is now an object with one server for its whole life, replaced wholesale on a switch. A stale value from an old loop can only land in an old object that nothing displays, so the bug class is gone rather than checked for.

- `ElementStore` → **`ServerProjection`** (`git mv`). `init(database:serverID:)` starts all thirteen loops; `deinit` cancels them. `repoint`, `reset`, `clearProjection` and the replace-tasks dance are deleted; a fresh instance is born empty, which is what the old synchronous clear was for.
- It now also owns the three server-scoped values that used to be observed on `DocumentStore` itself and restarted on every switch: `libraryCoverageAt`, `syncErrors`, `cachedDocumentCount`.
- `DocumentStore.projection` is a tracked `public private(set) var ServerProjection?`; every delegate (`store.tags` etc.) reads through it with empty fallbacks for the logged-out case. Both hops are observation-tracked, so views repaint on the swap. Nothing outside `DocumentStore` held the old instance (one preview helper, updated).
- The two sites that are not observations and never restart, `fetchTasks()` and the `lastSyncError` writes in `sync()`, pin the session before their await and compare identity after it. No helper type.

Net −14 lines. The wiring stays untested: AppShared has no test target and the store needs a registry plus a GRDB stack to construct; nothing was faked to cover it.

## Behaviour notes

- On a switch, coverage timestamp, sync errors and document count now blank until the new server's first emission, the same as the element collections already did. Visible on the Offline & Sync screen for one runloop hop.
- Re-activating the *same* connection (e.g. after editing extra headers) rebuilds the projection, equivalent to the old `repoint`, which also cleared.
- Comment-only mentions of "ElementStore" remain in `CachingRepository`, `ConnectionsView` and `ShareView`; worth a follow-up sweep.

## Verified

All four package suites pass; `just generate` + simulator build succeeded; `just lint` clean.

## Merge order

`refreshUISettings` becomes `async` under #699 (it reads a cache table). Whichever of #699 and this lands second needs that two-line rebase; the integrated tree of both has been built locally.

## Manual test checklist

- [x] Switch between two servers: tags, correspondents and saved views change immediately with nothing left over from the previous server.
- [x] After switching servers, Offline & Sync's document count and "last full fill" belong to the new server.
- [x] Remove the active connection: lists clear and nothing stale reappears.
- [x] Edit extra headers on the active connection and save: elements are still present afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9