### PR TITLE
fix: friendly-name Subscription and stale Stage N comments

### DIFF
--- a/AppShared/Sources/AppShared/Document/DocumentStore.swift
+++ b/AppShared/Sources/AppShared/Document/DocumentStore.swift
@@ -762,7 +762,7 @@ public final class DocumentStore: Sendable {
   }
 }
 
-// MARK: - Document cache surface (Stage 8)
+// MARK: - Document cache surface
 
 /// The GRDB-free surface the document list and detail views reach for. Each
 /// method resolves the active `CachingBackend` (the production/preview stack) and

--- a/AppShared/Sources/AppShared/Model/OfflineBrowsingMode.swift
+++ b/AppShared/Sources/AppShared/Model/OfflineBrowsingMode.swift
@@ -9,7 +9,7 @@ import Foundation
 /// How aggressively the offline cache fills a given server's documents.
 ///
 /// - `recentlyBrowsed`: only queries the user actually opens are cached
-///   (Stage 8 on-open fill).
+///   (the on-open eager fill).
 /// - `entireLibrary`: a proactive fill caches every saved view and the default
 ///   list, so the whole library browses offline even if never opened.
 ///

--- a/AppShared/Sources/AppShared/Networking/CachingRepository.swift
+++ b/AppShared/Sources/AppShared/Networking/CachingRepository.swift
@@ -61,7 +61,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// resource the user lacks permission for is skipped, not fatal.
   func syncElements(progress: SyncProgressReporter?) async throws
 
-  /// Eager full-fill of a document list (Stage 8 v1): await page 1 (so the first
+  /// Eager full-fill of a document list: await page 1 (so the first
   /// window + an exact count land synchronously), write it as the query's order,
   /// then background-page the rest of the query to the cache. The returned
   /// ``QueryFillHandle`` carries the `QueryKey` the list observes and a cancel
@@ -75,7 +75,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// cap; until users ask for it, every opened view eager-fills in full.
   func fillQuery(filter: FilterState) async throws -> QueryFillHandle
 
-  /// Proactive one-time coverage fill (Stage 9, *Entire library*): page the
+  /// Proactive one-time coverage fill (*Entire library*): page the
   /// default list and every saved view, stamping rows `.full`, so the whole
   /// active-server library browses offline even if never opened. Sequential
   /// (one query's background paging completes before the next starts). Guarded by
@@ -86,7 +86,7 @@ public protocol CachingBackend: AnyObject, Sendable {
   /// failed advances nothing, so it retries.
   func fillLibrary(force: Bool, progress: SyncProgressReporter?) async throws
 
-  /// Proactive per-document detail fill (Stage 9, *Entire library*): give every
+  /// Proactive per-document detail fill (*Entire library*): give every
   /// cached document its notes and file-metadata so it's fully renderable
   /// offline even if never opened. Zero-note documents are seeded from the
   /// list payload's notes *count* for free (no request); only documents that

--- a/AppShared/Sources/AppShared/Networking/SyncEngine.swift
+++ b/AppShared/Sources/AppShared/Networking/SyncEngine.swift
@@ -2,7 +2,7 @@
 //  SyncEngine.swift
 //  AppShared
 //
-//  Stage 10 (multi-server sync): keeps every configured server's offline cache
+//  Multi-server sync: keeps every configured server's offline cache
 //  warm. The sweep still *selects* the inactive ones — the active server is
 //  driven by `DocumentStore` on the same lifecycle trigger, so "active-first"
 //  falls out for free — but that is now an ordering choice, not a safety
@@ -14,7 +14,8 @@
 //  active server coalesces onto the session the store is already using.
 //
 //  Scheduling stays on app-lifecycle triggers (launch / foreground /
-//  active-change); true `BGProcessingTask` execution is Stage 11's.
+//  active-change); true `BGProcessingTask` execution is not implemented yet
+//  (see #697).
 //
 //  This type is now purely the *scheduler*: it decides which servers to sync and
 //  in what order, and hands each one to its ``ServerSession``, which owns that

--- a/DataModel/Sources/DataModel/Model/CustomFieldModel.swift
+++ b/DataModel/Sources/DataModel/Model/CustomFieldModel.swift
@@ -77,7 +77,8 @@ public enum CustomFieldDataType: RawRepresentable, Codable, Equatable, Hashable,
 }
 
 // Wire-symmetric leaf value type — round-tripped by ApiCustomFieldExtraData
-// and the (future) storage layer. Stays Codable per the Stage 3 principle.
+// and the (future) storage layer. Stays Codable: wire, storage and domain
+// shapes coincide here.
 public struct CustomFieldSelectOption: Codable, Identifiable, Hashable, Sendable {
   public var id: String
   public var label: String

--- a/DataModel/Sources/DataModel/Model/DocumentModel.swift
+++ b/DataModel/Sources/DataModel/Model/DocumentModel.swift
@@ -40,7 +40,8 @@ public struct DocumentNote: Identifiable, Equatable, Sendable, Hashable {
   }
 
   // Wire-symmetric leaf value type — round-tripped by ApiDocumentNote and
-  // the (future) storage layer. Stays Codable per the Stage 3 principle.
+  // the (future) storage layer. Stays Codable: wire, storage and domain
+  // shapes coincide here.
   public struct User: Codable, Equatable, Sendable, Hashable {
     public var id: UInt
     public var username: String

--- a/DataModel/Sources/DataModel/Model/MetadataModel.swift
+++ b/DataModel/Sources/DataModel/Model/MetadataModel.swift
@@ -13,7 +13,7 @@ public struct Metadata: Sendable {
   public var hasArchiveVersion: Bool
 
   // Wire-symmetric value type — round-tripped by `ApiMetadata` and storage
-  // alike. Stays `Codable` per the Stage 3 principle.
+  // alike. Stays `Codable`: wire, storage and domain shapes coincide here.
   public struct Item: Codable, Sendable, Equatable {
     public var namespace: String
     public var prefix: String

--- a/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
+++ b/DataModel/Sources/DataModel/Model/ShareLinkModel.swift
@@ -2,7 +2,8 @@ import Foundation
 
 public struct ShareLink: Sendable, Equatable {
   // Wire-symmetric leaf enum; round-tripped as-is by the wire type and (future)
-  // storage layer. Stays Codable per the Stage 3 principle.
+  // storage layer. Stays Codable: wire, storage and domain shapes coincide
+  // here.
   public enum FileVersion: String, Codable, Sendable {
     case original
     case archive

--- a/Networking/Sources/Networking/Api/Wire/ApiSavedView.swift
+++ b/Networking/Sources/Networking/Api/Wire/ApiSavedView.swift
@@ -8,9 +8,10 @@ import DataModel
 // MARK: - Wire type for reading saved views
 //
 // `filter_rules: [FilterRule]`, `owner: Owner?`, `permissions: Permissions?`
-// embed leaf wire-symmetric value types straight from DataModel — see the
-// Stage 3 plan for the rule. Each domain type carries its own JSON shape and
-// is round-tripped as-is.
+// embed leaf wire-symmetric value types straight from DataModel — the rule
+// being that a type crosses the boundary as-is only where wire, storage and
+// domain shapes coincide. Each domain type carries its own JSON shape and is
+// round-tripped as-is.
 
 struct ApiSavedView: Codable, Sendable {
   var id: UInt

--- a/Persistence/Sources/Persistence/Database+Connections.swift
+++ b/Persistence/Sources/Persistence/Database+Connections.swift
@@ -7,8 +7,8 @@ import os
 ///
 /// These are the only entry points `ConnectionManager` uses to read or
 /// mutate `server` rows; GRDB stays hidden from AppShared and the rest of
-/// the app. Stage 7 will add analogous APIs for element and document
-/// records under the same principle ("GRDB is sealed inside Persistence").
+/// the app. Element and document records have analogous APIs under the same
+/// principle ("GRDB is sealed inside Persistence").
 extension Database {
   /// Fetch every connection row currently in the table.
   public func allConnections() throws(DatabaseError) -> [ConnectionRecord] {
@@ -76,8 +76,7 @@ extension Database {
   /// The first value is the current state (so callers can use this as both
   /// "initial hydrate" and "subsequent updates" in one loop). Cross-process
   /// changes (e.g. from the Share Extension) are not delivered live —
-  /// foreground re-hydrate covers that, as called out in Stage 5 of the
-  /// offline-cache plan.
+  /// foreground re-hydrate covers that.
   public func observeConnections() -> AsyncThrowingStream<[ConnectionRecord], Error> {
     let observation = ValueObservation.tracking(ConnectionRecord.fetchAll)
     let writer = writer

--- a/Persistence/Sources/Persistence/Database+DocumentDetail.swift
+++ b/Persistence/Sources/Persistence/Database+DocumentDetail.swift
@@ -68,7 +68,7 @@ extension Database {
     }
   }
 
-  // MARK: - Proactive detail fill (Stage 9)
+  // MARK: - Proactive detail fill
 
   /// Seed an empty `document_note` row for every cached document that reports
   /// zero notes and has no cached notes row yet — no network. The list/fill

--- a/Persistence/Sources/Persistence/Database+Documents.swift
+++ b/Persistence/Sources/Persistence/Database+Documents.swift
@@ -175,7 +175,7 @@ extension Database {
   /// list). Called ahead of ``pruneUnreferencedDocuments(serverID:)`` on a
   /// `.entireLibrary` → `.recentlyBrowsed` downgrade: saved views proactively
   /// filled while `.entireLibrary` was active should no longer be tracked at
-  /// all — they eager-fill again from scratch if reopened (Stage 8), matching
+  /// all — they eager-fill again from scratch if reopened, matching
   /// what `.recentlyBrowsed` already does for any other saved view. Returns
   /// the number of `query_order` rows removed.
   @discardableResult

--- a/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V4_CreateDocumentCache.swift
@@ -1,6 +1,6 @@
 import GRDB
 
-/// Document-metadata cache tables (Stage 8).
+/// Document-metadata cache tables.
 ///
 /// Three tables, three jobs:
 ///

--- a/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
+++ b/Persistence/Sources/Persistence/Migrations/V5_CreateDocumentDetailCache.swift
@@ -1,6 +1,6 @@
 import GRDB
 
-/// Per-document detail-cache tables (Stage 8 follow-up) — the two Tier-2
+/// Per-document detail-cache tables — the two Tier-2
 /// sub-resources that don't ride the `document` row's `data` blob because they
 /// have different keys and lifecycles:
 ///

--- a/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentNoteRecord.swift
@@ -9,7 +9,7 @@ import GRDB
 /// always returns the full list, and create/delete return the updated full list,
 /// so a cache write is a row *replace*, never a per-note merge. `DocumentNote`
 /// isn't `Codable`, so the long tail is an explicit storage `NotePayload` mapped
-/// by hand (the Stage 3 principle: storage shape ≠ wire shape ≠ domain shape).
+/// by hand (storage shape ≠ wire shape ≠ domain shape).
 public struct DocumentNoteRecord:
   FetchableRecord, PersistableRecord, TableRecord, Codable, Sendable, Equatable
 {

--- a/Persistence/Sources/Persistence/Models/DocumentRecord.swift
+++ b/Persistence/Sources/Persistence/Models/DocumentRecord.swift
@@ -28,8 +28,8 @@ public enum DocumentEntry: Sendable, Equatable, Identifiable {
 ///
 /// Bespoke rather than an `ElementRecord`: documents are ordered through
 /// `query_order` (never by `name`), and `Document` is not `Codable` — so the long
-/// tail is an explicit storage `Payload`, mapped by hand (the Stage 3 principle:
-/// storage shape ≠ wire shape ≠ domain shape).
+/// tail is an explicit storage `Payload`, mapped by hand (storage shape ≠ wire
+/// shape ≠ domain shape).
 ///
 /// There is no projection/completeness level: the list always requests
 /// `full_perms`, so a stored row is always the complete object. "Loaded-ness" is

--- a/Persistence/Sources/Persistence/Models/QueryKey.swift
+++ b/Persistence/Sources/Persistence/Models/QueryKey.swift
@@ -22,7 +22,7 @@ import Foundation
 ///   independent of dictionary iteration order and of the transient
 ///   `FilterState.modified` flag (which is not a query parameter).
 ///
-/// Virtual / client-defined views (e.g. Stage 14's pinned "Downloaded" list) use
+/// Virtual / client-defined views (e.g. a pinned "Downloaded" list) use
 /// a ``init(sentinel:)`` well-known key instead of a hash, since they have no
 /// server query to replay.
 public struct QueryKey: Hashable, Sendable {

--- a/Persistence/Sources/Persistence/Observation/Broadcaster.swift
+++ b/Persistence/Sources/Persistence/Observation/Broadcaster.swift
@@ -9,8 +9,7 @@ import Foundation
 /// Same shape as Combine's `PassthroughSubject` (drop-on-floor for late
 /// subscribers, no replay), but consumed as an `AsyncSequence`. Used here to
 /// observe GRDB table changes; also backs the discrete-event channels on
-/// `DocumentStore` / `ConnectionManager` (Stage 6) and will back the
-/// `CacheChange` signal in later offline-cache stages.
+/// `DocumentStore` / `ConnectionManager`.
 ///
 /// For SwiftUI consumers, prefer AppShared's `.onEvent(from:perform:)` — or
 /// ``sink(_:)`` directly, holding the returned ``Subscription`` in `@State` —

--- a/Persistence/Tests/PersistenceTests/DetailFillTests.swift
+++ b/Persistence/Tests/PersistenceTests/DetailFillTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @testable import Persistence
 
-/// Covers the proactive notes/file-metadata detail-fill support queries
-/// (Stage 9): the zero-note seed, the "needs a network fetch" sets, and the
-/// R3δ notes invalidation.
+/// Covers the proactive notes/file-metadata detail-fill support queries: the
+/// zero-note seed, the "needs a network fetch" sets, and the R3δ notes
+/// invalidation.
 @Suite("DetailFill")
 struct DetailFillTests {
   // MARK: - Helpers

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -29,7 +29,7 @@ struct MainView: View {
   // source of per-server repositories, not a scheduling detail.
   @State private var sessionRegistry: ServerSessionRegistry
 
-  // Keeps every *inactive* server's offline cache warm (Stage 10). The active
+  // Keeps every *inactive* server's offline cache warm. The active
   // server stays on the DocumentStore path; the engine skips it.
   @State private var syncEngine: SyncEngine
 

--- a/swift-paperless/swift_paperlessApp.swift
+++ b/swift-paperless/swift_paperlessApp.swift
@@ -36,7 +36,7 @@ struct MainView: View {
   // Shared GRDB database, threaded into each connection's CachingRepository.
   private let database: Database
 
-  @State private var friendlyNameTask: Task<Void, Never>?
+  @State private var friendlyNameSubscription: Subscription?
 
   @StateObject private var errorController: ErrorController
 
@@ -264,22 +264,23 @@ struct MainView: View {
     // active connection. The nil-guard drops resets from store.clear() so
     // they don't wipe out a previously stored friendly name. setFriendlyName
     // is already idempotent, so no explicit dedup is needed.
-    friendlyNameTask?.cancel()
-    friendlyNameTask = Task { @MainActor [manager] in
-      while !Task.isCancelled {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
-        withObservationTracking {
-          _ = store.settings.appTitle
-        } onChange: {
-          continuation.yield()
-          continuation.finish()
+    friendlyNameSubscription?.cancel()
+    friendlyNameSubscription = Subscription(
+      Task { @MainActor [manager] in
+        while !Task.isCancelled {
+          let (stream, continuation) = AsyncStream<Void>.makeStream()
+          withObservationTracking {
+            _ = store.settings.appTitle
+          } onChange: {
+            continuation.yield()
+            continuation.finish()
+          }
+          if let title = store.settings.appTitle {
+            manager.setFriendlyName(title)
+          }
+          for await _ in stream { break }
         }
-        if let title = store.settings.appTitle {
-          manager.setFriendlyName(title)
-        }
-        for await _ in stream { break }
-      }
-    }
+      })
   }
 
   private func setupQuickActions() {


### PR DESCRIPTION
Two follow-ups from the offline/persistence stack that were riding on #627 (closed unmerged) and are rewritten here against current `main`.

- **`friendlyNameTask` → `Subscription`** (#656 item 14, the #596 review fix): the friendly-name observer in `swift_paperlessApp` was a bare `Task` held in `@State`; it now uses `Persistence.Subscription`, which cancels on `deinit`, so the observer cannot outlive the view.
- **Drop stale `Stage N` comments** (closes #662): 24 references across the packages rewritten to say what they mean in present tense rather than by stage number. No code change in that commit.

Verified: simulator build clean; Common/DataModel/Networking/Persistence suites pass.

Refs #656.

## Manual test checklist

- [x] Log in to a server whose paperless-ngx has an app title configured: the connection shows that title as its name, and it updates if the title changes on the server and the app is refreshed.
- [x] Open and close the document list a few times: no regression (the observer is now released with the view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9