### PR TITLE
fix: dedupe document-detail load errors by value, not description

### DIFF
--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -49,17 +49,17 @@ enum DocumentDownloadState: Equatable {
 /// Accumulates the errors thrown across one `DocumentDetailModel.load()` pass so
 /// duplicates can be collapsed before they reach the caller's `onError`.
 ///
-/// Repositories normalize transport failures into `RequestError`, which is
-/// `Equatable`: an unreachable server fails every request in the pass with the
-/// same value, so they collapse to one entry. Genuinely different failures (a
-/// permission error on a single endpoint, say) stay distinct and each still show.
+/// An unreachable server fails every request in the pass the same way, so
+/// those should collapse to one entry, while genuinely different failures (a
+/// permission error on a single endpoint, say) stay distinct and each still
+/// show.
 ///
-/// This deliberately compares errors rather than their descriptions. It cannot
-/// be done on what `URLSession` throws directly: a bridged `URLError` carries the
-/// failing URL and a per-request task id in its `NSError.userInfo`, so no two are
-/// ever equal — not even two failures against the same endpoint — and their
-/// descriptions differ for the same reason. Normalizing upstream is what makes
-/// the comparison here meaningful.
+/// Transport failures arrive here raw: `ApiRepository.fetchData` rethrows what
+/// `URLSession` threw, and a bridged `URLError` carries the failing URL and a
+/// per-request task id in its `NSError.userInfo`, so no two are ever equal by
+/// value — not even two failures against the same endpoint. Those are compared
+/// by code. Everything else (`RequestError` and other `Equatable` errors) is
+/// compared by value, which is what keeps distinct failures distinct.
 @MainActor
 private final class LoadErrorCollector {
   private(set) var distinct: [any Error] = []
@@ -70,6 +70,15 @@ private final class LoadErrorCollector {
   }
 
   private static func isDuplicate(_ lhs: any Error, _ rhs: any Error) -> Bool {
+    // Transport failures: same code means the same outage, whatever the URL.
+    if let lhs = lhs as? URLError, let rhs = rhs as? URLError {
+      return lhs.code == rhs.code
+    }
+    let lhsNS = lhs as NSError
+    let rhsNS = rhs as NSError
+    if lhsNS.domain == NSURLErrorDomain, rhsNS.domain == NSURLErrorDomain {
+      return lhsNS.code == rhsNS.code
+    }
     // Via `Any`: casting an `any Error` straight to `any Equatable` draws a
     // spurious "always succeeds" warning, though at runtime it correctly fails
     // for an error type that doesn't conform.

--- a/swift-paperless/ViewModel/DocumentDetailModel.swift
+++ b/swift-paperless/ViewModel/DocumentDetailModel.swift
@@ -47,19 +47,46 @@ enum DocumentDownloadState: Equatable {
 }
 
 /// Accumulates the errors thrown across one `DocumentDetailModel.load()` pass so
-/// duplicates can be collapsed before they reach the caller's `onError`. Keyed on
-/// `String(describing:)`: connectivity failures against the same host produce
-/// equal `RequestError.other` values (identical description), so a server-wide
-/// outage dedupes to a single entry, while distinct failures keep distinct keys.
+/// duplicates can be collapsed before they reach the caller's `onError`.
+///
+/// Repositories normalize transport failures into `RequestError`, which is
+/// `Equatable`: an unreachable server fails every request in the pass with the
+/// same value, so they collapse to one entry. Genuinely different failures (a
+/// permission error on a single endpoint, say) stay distinct and each still show.
+///
+/// This deliberately compares errors rather than their descriptions. It cannot
+/// be done on what `URLSession` throws directly: a bridged `URLError` carries the
+/// failing URL and a per-request task id in its `NSError.userInfo`, so no two are
+/// ever equal — not even two failures against the same endpoint — and their
+/// descriptions differ for the same reason. Normalizing upstream is what makes
+/// the comparison here meaningful.
 @MainActor
 private final class LoadErrorCollector {
-  private var seen: Set<String> = []
   private(set) var distinct: [any Error] = []
 
   func add(_ error: any Error) {
-    if seen.insert(String(describing: error)).inserted {
-      distinct.append(error)
+    guard !distinct.contains(where: { Self.isDuplicate($0, error) }) else { return }
+    distinct.append(error)
+  }
+
+  private static func isDuplicate(_ lhs: any Error, _ rhs: any Error) -> Bool {
+    // Via `Any`: casting an `any Error` straight to `any Equatable` draws a
+    // spurious "always succeeds" warning, though at runtime it correctly fails
+    // for an error type that doesn't conform.
+    guard let lhsEquatable = lhs as Any as? any Equatable,
+      let rhsEquatable = rhs as Any as? any Equatable
+    else {
+      // Nothing better to go on for an error that can't be compared.
+      return String(describing: lhs) == String(describing: rhs)
     }
+    return isEqual(lhsEquatable, rhsEquatable)
+  }
+
+  /// Open the existentials to recover the concrete type and use its `==`.
+  /// Errors of different types are never duplicates.
+  private static func isEqual(_ lhs: any Equatable, _ rhs: any Equatable) -> Bool {
+    func compare<T: Equatable>(_ lhs: T) -> Bool { (rhs as? T) == lhs }
+    return compare(lhs)
   }
 }
 


### PR DESCRIPTION
Follow-up to #620, which merged without this commit.

Document-detail load errors were deduplicated by their description string, so two distinct errors with the same wording collapsed into one and, conversely, the same error rendered slightly differently twice showed as two. They are now deduplicated by value.

Refs #656 (2026-09-05 fact-check notes).



## Follow-up (Codex review)

The original commit assumed repositories normalize transport failures into `RequestError`. They do not: `ApiRepository.fetchData` rethrows the raw `URLError`, whose `==` includes the failing URL and task, so an outage that failed metadata, notes and suggestions still produced three toasts. The second commit compares `URLError`s (and `NSURLErrorDomain` errors) by code before falling back to value equality, and corrects the comment. Simulator build verified.

## Manual test checklist

The dedupe applies to the refresh path only: the on-appear load has no error handler and is silent on `main` too.

- [x] Server unreachable, document open with its details not cached: pull to refresh → one error toast, not one per request.
- [x] Same with a document whose details are cached: pull to refresh → at most one toast, cached content stays.
- [x] Account without notes permission, server reachable: pull to refresh → the permission error still shows on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9