### PR TITLE
fix: retry a stale-version 406 without a second re-probe

### DIFF
--- a/Networking/Sources/Networking/Api/ApiRepository.swift
+++ b/Networking/Sources/Networking/Api/ApiRepository.swift
@@ -253,9 +253,36 @@ public class ApiRepository {
       // Accept header. The retried call goes straight to the static helper, so a
       // second 406 propagates instead of looping.
       Logger.networking.warning(
-        "Request rejected as unsupported API version (sent \(String(describing: sentVersion), privacy: .public)); re-probing backend"
+        "Request rejected as unsupported API version (sent \(String(describing: sentVersion), privacy: .public))"
       )
 
+      // Retries the original request once with `version`, bypassing this
+      // recovery path so a second 406 propagates instead of looping.
+      func retry(withVersion version: UInt) async throws -> (Data, URLResponse) {
+        var retry = request
+        retry.setValue(
+          "application/json; version=\(version)", forHTTPHeaderField: "Accept")
+        return try await Self.fetchData(
+          for: retry, expectedStatus: expectedStatus, progress: progress,
+          cachePolicy: cachePolicy, urlSession: urlSession
+        )
+      }
+
+      // The effective version may have moved on while this request was in
+      // flight: a concurrent request 406'd first, re-probed, and learned the
+      // real version. This request was sent with the stale version, so its 406
+      // says nothing new about the backend — retry with the version we now
+      // hold rather than probing again. Without this, requests that 406 after
+      // a probe has already completed each kick off a redundant probe.
+      if let sentVersion, sentVersion != effectiveApiVersion {
+        let currentVersion = effectiveApiVersion
+        Logger.networking.notice(
+          "API version already moved from \(sentVersion) to \(currentVersion) since the request was sent; retrying without re-probing"
+        )
+        return try await retry(withVersion: currentVersion)
+      }
+
+      Logger.networking.notice("Re-probing backend for its API version")
       guard await reprobeVersion() != nil else {
         Logger.networking.error(
           "Re-probe failed to detect a working API version; propagating unsupportedVersion")
@@ -272,13 +299,7 @@ public class ApiRepository {
 
       Logger.networking.notice(
         "Re-probe selected API version \(retryVersion); retrying request once")
-      var retry = request
-      retry.setValue(
-        "application/json; version=\(retryVersion)", forHTTPHeaderField: "Accept")
-      return try await Self.fetchData(
-        for: retry, expectedStatus: expectedStatus, progress: progress,
-        cachePolicy: cachePolicy, urlSession: urlSession
-      )
+      return try await retry(withVersion: retryVersion)
     }
   }
 
@@ -311,8 +332,16 @@ public class ApiRepository {
       return nil
     }
 
+    // Publish the task before the first suspension point. `reprobeVersion` is
+    // MainActor-isolated and `Task { }` doesn't suspend, so there is no
+    // check-then-act window between the lookup above and this store: a
+    // concurrent caller observes either "no probe yet" or this exact task.
     versionReprobeTask = task
-    defer { versionReprobeTask = nil }
+    defer {
+      if versionReprobeTask == task {
+        versionReprobeTask = nil
+      }
+    }
     return await task.value
   }
 

--- a/Networking/Tests/NetworkingTests/ApiRepositoryVersionReprobeTest.swift
+++ b/Networking/Tests/NetworkingTests/ApiRepositoryVersionReprobeTest.swift
@@ -39,18 +39,23 @@ final class VersionMockURLProtocol: URLProtocol, @unchecked Sendable {
   override class func canInit(with _: URLRequest) -> Bool { true }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+  // Responders in this suite park on gates to pin down request ordering, so
+  // each load runs on its own global-queue thread: a blocked responder must not
+  // hold up the other requests the same test has in flight.
   override func startLoading() {
-    guard let responder = Self.responder else {
-      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
-      return
-    }
-    do {
-      let (response, data) = try responder(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
+    DispatchQueue.global().async { [self] in
+      guard let responder = Self.responder else {
+        client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+        return
+      }
+      do {
+        let (response, data) = try responder(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
     }
   }
 
@@ -65,11 +70,44 @@ struct ApiRepositoryVersionReprobeTest {
     uuidString: "99999999-8888-7777-6666-555555555555")!
 
   // Atomic counter for request-count assertions across concurrent callbacks.
+  // Doubles as a gate: `wait(untilAtLeast:)` lets one mock responder block
+  // until another has run, which is how these tests pin the interleaving
+  // instead of hoping for one.
   final class Counter: @unchecked Sendable {
-    private let lock = NSLock()
+    private let condition = NSCondition()
     private var _value = 0
-    var value: Int { lock.withLock { _value } }
-    func bump() { lock.withLock { _value += 1 } }
+
+    var value: Int {
+      condition.lock()
+      defer { condition.unlock() }
+      return _value
+    }
+
+    func bump() {
+      _ = bumpAndGet()
+    }
+
+    @discardableResult
+    func bumpAndGet() -> Int {
+      condition.lock()
+      defer { condition.unlock() }
+      _value += 1
+      condition.broadcast()
+      return _value
+    }
+
+    // Blocks until the counter reaches `target`. Returns false on timeout, so a
+    // test whose expected ordering never materialises fails instead of hanging.
+    @discardableResult
+    func wait(untilAtLeast target: Int, timeout: TimeInterval = 20) -> Bool {
+      condition.lock()
+      defer { condition.unlock() }
+      let deadline = Date().addingTimeInterval(timeout)
+      while _value < target {
+        if !condition.wait(until: deadline) { return false }
+      }
+      return true
+    }
   }
 
   static func makeRepo(apiVersion: UInt?, backendVersion: Version? = nil) -> ApiRepository {
@@ -139,10 +177,59 @@ struct ApiRepositoryVersionReprobeTest {
 
   // Several requests 406 at once (backend just came back online): they must
   // share a single re-probe rather than each running the version sweep.
+  //
+  // The ordering is forced rather than raced: the probe response is held until
+  // both requests have been rejected, so the second caller provably reaches the
+  // re-probe path while the first probe is still in flight.
   @Test
   func concurrentUnsupportedVersionShareSingleProbe() async throws {
     let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
     let uiSettingsHits = Counter()
+    let rejections = Counter()
+    let orderingHeld = Counter()
+    VersionMockURLProtocol.responder = { req in
+      let accept = req.value(forHTTPHeaderField: "Accept") ?? ""
+      if (req.url?.path ?? "").contains("ui_settings") {
+        // Hold the probe open until both requests have been 406'd.
+        if rejections.wait(untilAtLeast: 2) { orderingHeld.bump() }
+        uiSettingsHits.bump()
+        return (Self.uiSettingsResponse(for: req, apiVersion: "7"), Data("{}".utf8))
+      }
+      if accept.contains("version=7") {
+        return Self.response(for: req, status: 200, body: Data("[\"ok\"]".utf8))
+      }
+      rejections.bump()
+      return Self.response(for: req, status: 406)
+    }
+    defer { VersionMockURLProtocol.reset() }
+
+    let request = repo.request(url: Self.dataURL())
+    async let a = repo.fetchData(for: request, as: [String].self)
+    async let b = repo.fetchData(for: request, as: [String].self)
+    let results = try await [a, b]
+
+    #expect(results[0] == ["ok"])
+    #expect(results[1] == ["ok"])
+    #expect(repo.effectiveApiVersion == 7)
+    #expect(uiSettingsHits.value == 1)
+    // Guards the guard: if the gate had timed out, the assertion above would be
+    // about timing again rather than about coalescing.
+    #expect(orderingHeld.value == 1)
+  }
+
+  // The other half of the concurrent case, and the one that used to make
+  // `concurrentUnsupportedVersionShareSingleProbe` flaky: the second request's
+  // 406 lands *after* the first request's re-probe has already finished and
+  // bumped the effective version. Its rejection is stale news — it was sent
+  // with the old version — so it must retry with the current version instead of
+  // starting a second probe.
+  @Test
+  func unsupportedVersionForStaleVersionRetriesWithoutReprobing() async throws {
+    let repo = Self.makeRepo(apiVersion: ApiRepository.minimumApiVersion)
+    let uiSettingsHits = Counter()
+    let staleRequests = Counter()
+    let acceptedRequests = Counter()
+    let orderingHeld = Counter()
     VersionMockURLProtocol.responder = { req in
       let accept = req.value(forHTTPHeaderField: "Accept") ?? ""
       if (req.url?.path ?? "").contains("ui_settings") {
@@ -150,7 +237,15 @@ struct ApiRepositoryVersionReprobeTest {
         return (Self.uiSettingsResponse(for: req, apiVersion: "7"), Data("{}".utf8))
       }
       if accept.contains("version=7") {
-        return Self.response(for: req, status: 200, body: Data("[\"ok\"]".utf8))
+        let response = Self.response(for: req, status: 200, body: Data("[\"ok\"]".utf8))
+        acceptedRequests.bump()
+        return response
+      }
+      // Second request sent with the stale version: hold its rejection until
+      // the first caller has probed *and* completed its retry, i.e. until the
+      // repository definitely holds version 7 and no probe is in flight.
+      if staleRequests.bumpAndGet() >= 2 {
+        if acceptedRequests.wait(untilAtLeast: 1) { orderingHeld.bump() }
       }
       return Self.response(for: req, status: 406)
     }
@@ -165,6 +260,7 @@ struct ApiRepositoryVersionReprobeTest {
     #expect(results[1] == ["ok"])
     #expect(repo.effectiveApiVersion == 7)
     #expect(uiSettingsHits.value == 1)
+    #expect(orderingHeld.value == 1)
   }
 
   // The backend is still unreachable: re-probe can't find a working version, so


### PR DESCRIPTION
Fixes the intermittent failure of `ApiRepositoryVersionReprobeTest.concurrentUnsupportedVersionShareSingleProbe` (seen on CI on 2026-08-29 and 2026-09-06, on branches that do not touch Networking). Not part of the #656 stack.

## The race

The probe coalescing itself was sound: `ApiRepository` is main-actor and `reprobeVersion()` has no suspension between checking for an in-flight probe and storing one. The hole is one level up. Two requests go out with the locked-in minimum version and both get 406. If the first caller's probe completes and moves `apiVersion` to 7 *before* the second caller's 406 is delivered, the second caller finds no probe in flight and starts another one, although its 406 carried no new information: it was sent with a version the repository had already left.

## Fix

- In the 406 path, if the version the request was sent with is no longer the effective version, retry once with the current version and skip the probe. Retrying is factored into one local used by both paths.
- `reprobeVersion` clears its stored task only if it is still the task that call created.

## Test

- The mock responder can now block on a condition, and runs off the main queue so a parked responder can't starve the other in-flight request.
- `concurrentUnsupportedVersionShareSingleProbe` holds the probe response until both requests have been 406'd, forcing the coalescing order.
- New `unsupportedVersionForStaleVersionRetriesWithoutReprobing` forces the CI order: the second 406 is held until the first caller's probe and retry have completed. It fails on the old code every time with exactly the CI assertion, and passes with the fix.
- Both tests assert the intended ordering actually held, so a broken gate fails loudly instead of degrading back into a timing test.

The original flake could not be reproduced locally by looping (50 idle, 30 under 12-way load); the deterministic test reproduces it instead. After the fix: 30/30 idle, 20/20 under load, full Networking suite green, lint clean.

## Manual test checklist

- [ ] Against a paperless-ngx that rejects the app's minimum API version: the app still recovers on first use (one re-probe, requests succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018agkypG5HAxHiYjnrbDmp9
